### PR TITLE
:hammer: Fixes #49 refactor template specialisation to function overloading

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -82,11 +82,19 @@ class Cell {
   //! Return volume
   double volume() const { return volume_; }
 
-  //! Point in cell
-  bool point_in_cell(const VectorDim& point);
+  //! Point in cell 2D
+  bool point_in_cell(const Eigen::Matrix<double, 2, 1>& point);
 
-  //! Return the local coordinates of a point in a cell
-  VectorDim local_coordinates_point(const VectorDim& point);
+  //! Point in cell 3D
+  bool point_in_cell(const Eigen::Matrix<double, 3, 1>& point);
+
+  //! Return the local coordinates of a point in a 2D cell
+  Eigen::Matrix<double, 2, 1> local_coordinates_point(
+      const Eigen::Matrix<double, 2, 1>& point);
+
+  //! Return the local coordinates of a point in a 3D cell
+  Eigen::Matrix<double, 3, 1> local_coordinates_point(
+      const Eigen::Matrix<double, 3, 1>& point);
 
  protected:
   //! cell id
@@ -108,7 +116,7 @@ class Cell {
 
   //! Shape function
   std::shared_ptr<ShapeFn<Tdim>> shapefn_{nullptr};
-  };  // Cell class
+};  // Cell class
 }  // namespace mpm
 
 #include "cell.tcc"

--- a/include/cell.h
+++ b/include/cell.h
@@ -85,6 +85,9 @@ class Cell {
   //! Point in cell
   bool point_in_cell(const VectorDim& point);
 
+  //! Return the local coordinates of a point in a cell
+  VectorDim local_coordinates_point(const VectorDim& point);
+
  protected:
   //! cell id
   Index id_{std::numeric_limits<Index>::max()};
@@ -105,7 +108,7 @@ class Cell {
 
   //! Shape function
   std::shared_ptr<ShapeFn<Tdim>> shapefn_{nullptr};
-};  // Cell class
+  };  // Cell class
 }  // namespace mpm
 
 #include "cell.tcc"

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -29,15 +29,15 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   std::shared_ptr<mpm::NodeBase<Dim>> node0 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(0, coords);
 
-  coords << 0, 1;
+  coords << 0., 2.;
   std::shared_ptr<mpm::NodeBase<Dim>> node1 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(1, coords);
 
-  coords << 1, 1;
+  coords << 2., 2.;
   std::shared_ptr<mpm::NodeBase<Dim>> node2 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(2, coords);
 
-  coords << 1, 0;
+  coords << 2., 0.;
   std::shared_ptr<mpm::NodeBase<Dim>> node3 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
@@ -76,7 +76,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
       REQUIRE(cell->volume() ==
               Approx(std::numeric_limits<double>::max()).epsilon(Tolerance));
       cell->compute_volume();
-      REQUIRE(cell->volume() == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(cell->volume() == Approx(4.0).epsilon(Tolerance));
 
       SECTION("Check if a point is in a cell") {
         // Check point in cell
@@ -164,31 +164,31 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
   std::shared_ptr<mpm::NodeBase<Dim>> node0 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(0, coords);
 
-  coords << 1, 0, 0;
+  coords << 2, 0, 0;
   std::shared_ptr<mpm::NodeBase<Dim>> node1 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(1, coords);
 
-  coords << 1, 1, 0;
+  coords << 2, 2, 0;
   std::shared_ptr<mpm::NodeBase<Dim>> node2 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(2, coords);
 
-  coords << 0, 1, 0;
+  coords << 0, 2, 0;
   std::shared_ptr<mpm::NodeBase<Dim>> node3 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
-  coords << 0, 0, 1;
+  coords << 0, 0, 2;
   std::shared_ptr<mpm::NodeBase<Dim>> node4 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(4, coords);
 
-  coords << 1, 0, 1;
+  coords << 2, 0, 2;
   std::shared_ptr<mpm::NodeBase<Dim>> node5 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(5, coords);
 
-  coords << 1, 1, 1;
+  coords << 2, 2, 2;
   std::shared_ptr<mpm::NodeBase<Dim>> node6 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(6, coords);
 
-  coords << 0, 1, 1;
+  coords << 0, 2, 2;
   std::shared_ptr<mpm::NodeBase<Dim>> node7 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(7, coords);
 
@@ -232,7 +232,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
       REQUIRE(cell->volume() ==
               Approx(std::numeric_limits<double>::max()).epsilon(Tolerance));
       cell->compute_volume();
-      REQUIRE(cell->volume() == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(cell->volume() == Approx(8.0).epsilon(Tolerance));
 
       SECTION("Check if a point is in a cell") {
         // Check point in cell

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -29,7 +29,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   std::shared_ptr<mpm::NodeBase<Dim>> node0 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(0, coords);
 
-  coords << 0., 2.;
+  coords << 2., 0.;
   std::shared_ptr<mpm::NodeBase<Dim>> node1 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(1, coords);
 
@@ -37,7 +37,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   std::shared_ptr<mpm::NodeBase<Dim>> node2 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(2, coords);
 
-  coords << 2., 0.;
+  coords << 0., 2.;
   std::shared_ptr<mpm::NodeBase<Dim>> node3 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
@@ -253,7 +253,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
         REQUIRE(cell->point_in_cell(point) == true);
 
         // Check point outside
-        point << 2., 2., 2.;
+        point << 2.5, 2.5, 2.5;
         REQUIRE(cell->point_in_cell(point) == false);
       }
     }

--- a/tests/quad_shapefn_test.cc
+++ b/tests/quad_shapefn_test.cc
@@ -104,7 +104,7 @@ TEST_CASE("Quadrilateral shape functions are checked",
       REQUIRE(gradsf(2, 1) == Approx(0.5).epsilon(Tolerance));
       REQUIRE(gradsf(3, 1) == Approx(0.0).epsilon(Tolerance));
     }
-   
+
     SECTION("Four noded quadrilateral shape function for corner indices") {
       // Check for corner indices
       Eigen::VectorXi indices = quadsf->corner_indices();
@@ -120,10 +120,10 @@ TEST_CASE("Quadrilateral shape functions are checked",
       Eigen::MatrixXi indices = quadsf->inhedron_indices();
       REQUIRE(indices.rows() == 4);
       REQUIRE(indices.cols() == 2);
-      
+
       REQUIRE(indices(0, 0) == 0);
       REQUIRE(indices(0, 1) == 1);
-      
+
       REQUIRE(indices(1, 0) == 1);
       REQUIRE(indices(1, 1) == 2);
 
@@ -268,7 +268,7 @@ TEST_CASE("Quadrilateral shape functions are checked",
       REQUIRE(gradsf(6, 1) == Approx(0.0).epsilon(Tolerance));
       REQUIRE(gradsf(7, 1) == Approx(0.0).epsilon(Tolerance));
     }
-   
+
     SECTION("Eight noded quadrilateral shape function for corner indices") {
       // Check for corner indices
       Eigen::VectorXi indices = quadsf->corner_indices();
@@ -278,16 +278,16 @@ TEST_CASE("Quadrilateral shape functions are checked",
       REQUIRE(indices(2) == 2);
       REQUIRE(indices(3) == 3);
     }
-    
+
     SECTION("Eight noded quadrilateral shape function for inhedron indices") {
       // Check for inhedron indices
       Eigen::MatrixXi indices = quadsf->inhedron_indices();
       REQUIRE(indices.rows() == 4);
       REQUIRE(indices.cols() == 2);
-      
+
       REQUIRE(indices(0, 0) == 0);
       REQUIRE(indices(0, 1) == 1);
-      
+
       REQUIRE(indices(1, 0) == 1);
       REQUIRE(indices(1, 1) == 2);
 
@@ -439,7 +439,7 @@ TEST_CASE("Quadrilateral shape functions are checked",
       REQUIRE(gradsf(7, 1) == Approx(0.0).epsilon(Tolerance));
       REQUIRE(gradsf(8, 1) == Approx(0.0).epsilon(Tolerance));
     }
-       
+
     SECTION("Nine noded quadrilateral shape function for corner indices") {
       // Check for corner indices
       Eigen::VectorXi indices = quadsf->corner_indices();
@@ -450,16 +450,15 @@ TEST_CASE("Quadrilateral shape functions are checked",
       REQUIRE(indices(3) == 3);
     }
 
-    
     SECTION("Nine noded quadrilateral shape function for inhedron indices") {
       // Check for inhedron indices
       Eigen::MatrixXi indices = quadsf->inhedron_indices();
       REQUIRE(indices.rows() == 4);
       REQUIRE(indices.cols() == 2);
-      
+
       REQUIRE(indices(0, 0) == 0);
       REQUIRE(indices(0, 1) == 1);
-      
+
       REQUIRE(indices(1, 0) == 1);
       REQUIRE(indices(1, 1) == 2);
 


### PR DESCRIPTION
Fixes #49 by replacing `template <> cell<2>` and `template <> cell<3>` with an overloading of functions, except for compute volume where a switch statement with dimension as argument and some static_casting is required to keep Eigen happy.