### PR TITLE
Thread safety - fixes #71

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -71,7 +71,7 @@ class Cell {
   //! \param[in] local_id local id of the node
   //! \param[in] node A shared pointer to the node
   //! \retval insertion_status Return the successful addition of a node
-  bool add_node(unsigned local_id, const std::shared_ptr<NodeBase<Tdim>>& node);
+  bool add_node(unsigned local_id, std::shared_ptr<NodeBase<Tdim>> node);
 
   //! Add a neighbour cell
   //! \param[in] local_id local id of the neighbouring cell

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -55,8 +55,8 @@ bool mpm::Cell<Tdim>::shapefn(
 
 //! Add a node pointer and return the status of addition of a node
 template <unsigned Tdim>
-bool mpm::Cell<Tdim>::add_node(
-    unsigned local_id, const std::shared_ptr<mpm::NodeBase<Tdim>>& node_ptr) {
+bool mpm::Cell<Tdim>::add_node(unsigned local_id,
+                               std::shared_ptr<mpm::NodeBase<Tdim>> node_ptr) {
   bool insertion_status = false;
   try {
     // If number of node ptrs in a cell is less than the maximum number of nodes

--- a/include/node.h
+++ b/include/node.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <vector>
 
 #include "node_base.h"
@@ -139,6 +140,8 @@ class Node : public NodeBase<Tdim> {
   }
 
  private:
+  //! Mutex
+  std::mutex node_mutex_;
   //! nodebase id
   Index id_{std::numeric_limits<Index>::max()};
   //! nodal coordinates

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -33,6 +33,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_mass(bool update, unsigned nphase,
   if (!update) factor = 0.;
 
   // Update/assign mass
+  std::lock_guard<std::mutex> guard(node_mutex_);
   mass_(0, nphase) = mass_(0, nphase) * factor + mass;
 }
 
@@ -46,6 +47,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_volume(bool update,
   if (!update) factor = 0.;
 
   // Update/assign volume
+  std::lock_guard<std::mutex> guard(node_mutex_);
   volume_(0, nphase) = volume_(0, nphase) * factor + volume;
 }
 
@@ -67,6 +69,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_external_force(
     if (!update) factor = 0.;
 
     // Update/assign external force
+    std::lock_guard<std::mutex> guard(node_mutex_);
     external_force_.col(nphase) = external_force_.col(nphase) * factor + force;
   } catch (std::exception& exception) {
     std::cerr << exception.what() << '\n';
@@ -91,6 +94,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_internal_force(
     if (!update) factor = 0.;
 
     // Update/assign internal force
+    std::lock_guard<std::mutex> guard(node_mutex_);
     internal_force_.col(nphase) = internal_force_.col(nphase) * factor + force;
   } catch (std::exception& exception) {
     std::cerr << exception.what() << '\n';
@@ -114,6 +118,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_momentum(
     if (!update) factor = 0.;
 
     // Update/assign momentum
+    std::lock_guard<std::mutex> guard(node_mutex_);
     momentum_.col(nphase) = momentum_.col(nphase) * factor + momentum;
   } catch (std::exception& exception) {
     std::cerr << exception.what() << '\n';
@@ -152,6 +157,7 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_acceleration(
     if (!update) factor = 0.;
 
     //! Update/assign acceleration
+    std::lock_guard<std::mutex> guard(node_mutex_);
     acceleration_.col(nphase) =
         acceleration_.col(nphase) * factor + acceleration;
   } catch (std::exception& exception) {


### PR DESCRIPTION
Fixes #71 Uses thread safety on node update. Pass `node` shared_ptr by value