### PR TITLE
:fire: Remove construction of a cell without shape function fixes #94

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -30,11 +30,6 @@ class Cell {
   //! Define DOF for stresses
   static const unsigned Tdof = (Tdim == 2) ? 3 : 6;
 
-  //! Constructor with id and number of nodes
-  //! \param[in] id Global cell id
-  //! \param[in] nnodes Number of nodes per cell
-  Cell(Index id, unsigned nnodes);
-
   //! Constructor with id, number of nodes and shapefn
   //! \param[in] id Global cell id
   //! \param[in] nnodes Number of nodes per cell

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -1,25 +1,10 @@
-//! Constructor with global cell id and number of nodes
-template <unsigned Tdim>
-mpm::Cell<Tdim>::Cell(Index id, unsigned nnodes) : id_{id}, nnodes_{nnodes} {
-  // Check if the dimension is between 1 & 3
-  static_assert((Tdim >= 1 && Tdim <= 3), "Invalid global dimension");
-  try {
-    // Number of nodes should be greater than dimensions
-    if (!(nnodes > Tdim)) {
-      throw std::runtime_error(
-          "Specified number of nodes for a cell is too low");
-    }
-  } catch (std::exception& exception) {
-    std::cerr << exception.what() << '\n';
-    std::abort();
-  }
-}
-
 //! Constructor with cell id, number of nodes and shapefn
 template <unsigned Tdim>
 mpm::Cell<Tdim>::Cell(Index id, unsigned nnodes,
                       const std::shared_ptr<ShapeFn<Tdim>>& shapefnptr)
-    : mpm::Cell<Tdim>::Cell(id, nnodes) {
+    : id_{id}, nnodes_{nnodes} {
+  // Check if the dimension is between 1 & 3
+  static_assert((Tdim >= 1 && Tdim <= 3), "Invalid global dimension");
 
   try {
     if (shapefnptr->nfunctions() >= this->nnodes_) {
@@ -27,6 +12,10 @@ mpm::Cell<Tdim>::Cell(Index id, unsigned nnodes,
     } else {
       throw std::runtime_error(
           "Specified number of shape functions is not defined");
+    }
+    if (!(nnodes > Tdim)) {
+      throw std::runtime_error(
+          "Specified number of nodes for a cell is too low");
     }
   } catch (std::exception& exception) {
     std::cerr << exception.what() << '\n';

--- a/tests/cell_container_test.cc
+++ b/tests/cell_container_test.cc
@@ -98,15 +98,18 @@ TEST_CASE("Cell container is checked for 2D case", "[cellcontainer][2D]") {
       REQUIRE((*itr)->nfunctions() == 4);
     }
 
-    // Iterate through cell container to update coordinaates
-    // TODO: Remove shapefn call
+    // Iterate through cell container to update shapefn
+    // 8-noded quadrilateral shape function
+    std::shared_ptr<mpm::ShapeFn<Dim>> quadsf =
+        std::make_shared<mpm::QuadrilateralShapeFn<Dim, 8>>();
+
     cellcontainer->for_each(
-        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, shapefn));
+        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, quadsf));
 
     // Check if update has gone through
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();
          ++itr) {
-      REQUIRE((*itr)->nfunctions() == 4);
+      REQUIRE((*itr)->nfunctions() == 8);
     }
   }
 }
@@ -114,7 +117,7 @@ TEST_CASE("Cell container is checked for 2D case", "[cellcontainer][2D]") {
 //! \brief Check cell container class for 3D case
 TEST_CASE("Cell container is checked for 3D case", "[cellcontainer][3D]") {
   // Dimension
-  const unsigned Dim = 3;  // Dimension
+  const unsigned Dim = 3;
   // Number of nodes per cell
   const unsigned Nnodes = 8;
 
@@ -198,15 +201,18 @@ TEST_CASE("Cell container is checked for 3D case", "[cellcontainer][3D]") {
       REQUIRE((*itr)->nfunctions() == 8);
     }
 
-    // Iterate through cell container to update coordinaates
-    // TODO: Remove functions
+    // Iterate through cell container to update shape function
+    // Hexahedron 20 noded function
+    std::shared_ptr<mpm::ShapeFn<Dim>> hexsf =
+        std::make_shared<mpm::HexahedronShapeFn<Dim, 20>>();
+
     cellcontainer->for_each(
-        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, shapefn));
+        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, hexsf));
 
     // Check if update has gone through
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();
          ++itr) {
-      REQUIRE((*itr)->nfunctions() == 8);
+      REQUIRE((*itr)->nfunctions() == 20);
     }
   }
 }

--- a/tests/cell_container_test.cc
+++ b/tests/cell_container_test.cc
@@ -9,6 +9,7 @@
 #include "container.h"
 #include "hex_shapefn.h"
 #include "quad_shapefn.h"
+#include "shapefn.h"
 
 //! \brief Check cell container class for 2D case
 TEST_CASE("Cell container is checked for 2D case", "[cellcontainer][2D]") {
@@ -20,13 +21,17 @@ TEST_CASE("Cell container is checked for 2D case", "[cellcontainer][2D]") {
   // Tolerance
   const double Tolerance = 1.E-7;
 
+  // Shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
+
   // Cell 1
   mpm::Index id1 = 0;
-  auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+  auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
   // Cell 2
   mpm::Index id2 = 1;
-  auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes);
+  auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes, shapefn);
 
   // Cell container
   auto cellcontainer = std::make_shared<mpm::Container<mpm::Cell<Dim>>>();
@@ -90,15 +95,13 @@ TEST_CASE("Cell container is checked for 2D case", "[cellcontainer][2D]") {
 
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();
          ++itr) {
-      REQUIRE((*itr)->nfunctions() == 0);
+      REQUIRE((*itr)->nfunctions() == 4);
     }
 
-    std::shared_ptr<mpm::ShapeFn<Dim>> quadsf =
-        std::make_shared<mpm::QuadrilateralShapeFn<Dim, Nnodes>>();
-
     // Iterate through cell container to update coordinaates
+    // TODO: Remove shapefn call
     cellcontainer->for_each(
-        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, quadsf));
+        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, shapefn));
 
     // Check if update has gone through
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();
@@ -118,13 +121,17 @@ TEST_CASE("Cell container is checked for 3D case", "[cellcontainer][3D]") {
   // Tolerance
   const double Tolerance = 1.E-7;
 
+  // Shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
+
   // Cell 1
   mpm::Index id1 = 0;
-  auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+  auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
   // Cell 2
   mpm::Index id2 = 1;
-  auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes);
+  auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes, shapefn);
 
   // Cell container
   auto cellcontainer = std::make_shared<mpm::Container<mpm::Cell<Dim>>>();
@@ -188,15 +195,13 @@ TEST_CASE("Cell container is checked for 3D case", "[cellcontainer][3D]") {
 
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();
          ++itr) {
-      REQUIRE((*itr)->nfunctions() == 0);
+      REQUIRE((*itr)->nfunctions() == 8);
     }
 
-    std::shared_ptr<mpm::ShapeFn<Dim>> hexsf =
-        std::make_shared<mpm::HexahedronShapeFn<Dim, Nnodes>>();
-
     // Iterate through cell container to update coordinaates
+    // TODO: Remove functions
     cellcontainer->for_each(
-        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, hexsf));
+        std::bind(&mpm::Cell<Dim>::shapefn, std::placeholders::_1, shapefn));
 
     // Check if update has gone through
     for (auto itr = cellcontainer->cbegin(); itr != cellcontainer->cend();

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -23,6 +23,10 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   // Tolerance
   const double Tolerance = 1.E-7;
 
+  // Shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
+
   Eigen::Vector2d coords;
   coords.setZero();
 
@@ -46,21 +50,21 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     //! Check for id = 0
     SECTION("Cell id is zero") {
       mpm::Index id = 0;
-      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
       REQUIRE(cell->id() == 0);
     }
 
     SECTION("Cell id is positive") {
       //! Check for id is a positive value
       mpm::Index id = std::numeric_limits<mpm::Index>::max();
-      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
       REQUIRE(cell->id() == std::numeric_limits<mpm::Index>::max());
     }
   }
 
   SECTION("Add nodes") {
     mpm::Index id = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
     // Check if cell is initialised, before addition of nodes
     REQUIRE(cell->is_initialised() == false);
 
@@ -75,9 +79,6 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
     // Check centroid calculation
     SECTION("Compute centroid of a cell") {
-      std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-          std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
-      cell->shapefn(shapefn);
       REQUIRE(cell->nfunctions() == 4);
 
       // Compute centroid
@@ -98,9 +99,6 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
     // Check cell volume
     SECTION("Compute volume of a cell") {
-      std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-          std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
-      cell->shapefn(shapefn);
       REQUIRE(cell->nfunctions() == 4);
 
       // Check if cell is initialised, after addition of shapefn
@@ -137,8 +135,8 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   }
 
   SECTION("Add neighbours") {
-    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes);
-    auto neighbourcell = std::make_shared<mpm::Cell<Dim>>(1, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes, shapefn);
+    auto neighbourcell = std::make_shared<mpm::Cell<Dim>>(1, Nnodes, shapefn);
     REQUIRE(cell->nneighbours() == 0);
     cell->add_neighbour(0, neighbourcell);
     REQUIRE(cell->nneighbours() == 1);
@@ -171,7 +169,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
   SECTION("Test particle addition deletion") {
     mpm::Index pid = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes, shapefn);
     REQUIRE(cell->status() == false);
     bool status = cell->add_particle_id(pid);
     REQUIRE(status == true);
@@ -182,7 +180,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
   SECTION("Test particle information mapping") {
     mpm::Index id = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
     cell->add_node(0, node0);
     cell->add_node(1, node1);
     cell->add_node(2, node2);
@@ -194,7 +192,6 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
     std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
         std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
-    cell->shapefn(shapefn);
 
     // Local coordinate of a particle
     Eigen::Vector2d xi = Eigen::Vector2d::Zero();
@@ -436,19 +433,23 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
   std::shared_ptr<mpm::NodeBase<Dim>> node7 =
       std::make_shared<mpm::Node<Dim, Dof, Nphases>>(7, coords);
 
+  // Assign hexahedron shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
+
   //! Check Cell IDs
   SECTION("Check cell ids") {
     //! Check for id = 0
     SECTION("Cell id is zero") {
       mpm::Index id = 0;
-      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
       REQUIRE(cell->id() == 0);
     }
 
     SECTION("Cell id is positive") {
       //! Check for id is a positive value
       mpm::Index id = std::numeric_limits<mpm::Index>::max();
-      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+      auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
       REQUIRE(cell->id() == std::numeric_limits<mpm::Index>::max());
     }
   }
@@ -456,7 +457,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
   // Check node additions
   SECTION("Add nodes") {
     mpm::Index id = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
 
     // Check if cell is initialised, before addition of nodes
     REQUIRE(cell->is_initialised() == false);
@@ -476,9 +477,6 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
     // Check centroid calculation
     SECTION("Compute centroid of a cell") {
-      std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-          std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
-      cell->shapefn(shapefn);
       REQUIRE(cell->nfunctions() == 8);
 
       // Compute centroid
@@ -499,9 +497,6 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
     // Check cell volume calculation
     SECTION("Compute volume of a cell") {
-      std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-          std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
-      cell->shapefn(shapefn);
       REQUIRE(cell->nfunctions() == 8);
 
       // Check if cell is initialised, after addition of shapefn
@@ -542,8 +537,8 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
   }
 
   SECTION("Add neighbours") {
-    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes);
-    auto neighbourcell = std::make_shared<mpm::Cell<Dim>>(1, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes, shapefn);
+    auto neighbourcell = std::make_shared<mpm::Cell<Dim>>(1, Nnodes, shapefn);
     REQUIRE(cell->nneighbours() == 0);
     cell->add_neighbour(0, neighbourcell);
     REQUIRE(cell->nneighbours() == 1);
@@ -569,7 +564,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
   SECTION("Test particle addition deletion") {
     mpm::Index pid = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(0, Nnodes, shapefn);
     REQUIRE(cell->status() == false);
     bool status = cell->add_particle_id(pid);
     REQUIRE(status == true);
@@ -580,7 +575,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
   SECTION("Test particle information mapping") {
     mpm::Index id = 0;
-    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, shapefn);
     cell->add_node(0, node0);
     cell->add_node(1, node1);
     cell->add_node(2, node2);
@@ -594,11 +589,6 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
     // Create a vector of node pointers
     std::vector<std::shared_ptr<mpm::NodeBase<Dim>>> nodes{
         node0, node1, node2, node3, node4, node5, node6, node7};
-
-    // Assign shape function to cell
-    std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-        std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
-    cell->shapefn(shapefn);
 
     // Local coordinate of a particle
     Eigen::Vector3d xi = Eigen::Vector3d::Zero();

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -23,6 +23,10 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
   // Tolerance
   const double Tolerance = 1.E-9;
 
+  // Shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
+
   //! Check Mesh IDs
   SECTION("Check mesh ids") {
     //! Check for id = 0
@@ -178,15 +182,16 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
 
   // Check add / remove cell
   SECTION("Check add / remove cell functionality") {
+
     // Cell 1
     mpm::Index id1 = 0;
     Eigen::Vector2d coords;
     coords.setZero();
-    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
     // Cell 2
     mpm::Index id2 = 1;
-    auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes);
+    auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes, shapefn);
 
     auto mesh = std::make_shared<mpm::Mesh<Dim>>(0);
     // Check mesh is active
@@ -261,7 +266,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
 
     // Create cell1
     coords.setZero();
-    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
     // Add nodes to cell
     cell1->add_node(0, node0);
@@ -503,6 +508,10 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
   // Tolerance
   const double Tolerance = 1.E-9;
 
+  // Shape function
+  std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+      std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
+
   //! Check Mesh IDs
   SECTION("Check mesh ids") {
     //! Check for id = 0
@@ -636,11 +645,11 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     mpm::Index id1 = 0;
     Eigen::Vector3d coords;
     coords.setZero();
-    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
     // Cell 2
     mpm::Index id2 = 1;
-    auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes);
+    auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes, shapefn);
 
     auto mesh = std::make_shared<mpm::Mesh<Dim>>(0);
     // Check mesh is active
@@ -718,7 +727,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
 
     // Create cell1
     coords.setZero();
-    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes);
+    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id1, Nnodes, shapefn);
 
     // Add nodes to cell
     cell1->add_node(0, node0);

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -266,8 +266,12 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     for (unsigned i = 0; i < coordinates.size(); ++i)
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
+    // Shape function
+    std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+        std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
+
     // Create cell
-    auto cell = std::make_shared<mpm::Cell<Dim>>(10, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(10, Nnodes, shapefn);
     // Add nodes to cell
     coords << 0.5, 0.5;
     std::shared_ptr<mpm::NodeBase<Dim>> node0 =
@@ -297,9 +301,6 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->cell_id() == 10);
 
     // Assign shapefunction to cell
-    std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-        std::make_shared<mpm::QuadrilateralShapeFn<Dim, 4>>();
-    cell->shapefn(shapefn);
     cell->compute_volume();
 
     // Check if cell is initialised
@@ -508,8 +509,12 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     for (unsigned i = 0; i < coordinates.size(); ++i)
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
+    // Assign hexahedron shape function
+    std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
+        std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
+
     // Create cell
-    auto cell = std::make_shared<mpm::Cell<Dim>>(10, Nnodes);
+    auto cell = std::make_shared<mpm::Cell<Dim>>(10, Nnodes, shapefn);
     // Add nodes
     coords << 0, 0, 0;
     std::shared_ptr<mpm::NodeBase<Dim>> node0 =
@@ -554,9 +559,6 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(cell->nnodes() == 8);
 
     // Assign shapefunction to cell
-    std::shared_ptr<mpm::ShapeFn<Dim>> shapefn =
-        std::make_shared<mpm::HexahedronShapeFn<Dim, 8>>();
-    cell->shapefn(shapefn);
     cell->compute_volume();
     // Check if cell is initialised
     REQUIRE(cell->is_initialised() == true);


### PR DESCRIPTION
* Remove the possibility to construct a cell without its shape functions. Fixes #94 