### PR TITLE
:rocket: :computer: Add shapefn to particle for performance

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -67,6 +67,9 @@ class Cell {
   //! \param[in] shapefnptr Pointer to a shape function
   bool shapefn(const std::shared_ptr<ShapeFn<Tdim>>& shapefnptr);
 
+  //! Return a pointer to shape function of a cell
+  std::shared_ptr<ShapeFn<Tdim>> shapefn_ptr() { return shapefn_; }
+
   //! Return the number of shape functions, returns zero if the shapefunction is
   //! not set.
   unsigned nfunctions() const {

--- a/include/particle.h
+++ b/include/particle.h
@@ -63,7 +63,7 @@ class Particle : public ParticleBase<Tdim> {
   Index cell_id() const { return cell_id_; }
 
   //! Compute shape functions of a particle, based on local coordinates
-  //! \retval status Returns if compue shapefns was successful
+  //! \retval status Returns if compute shapefns was successful
   bool compute_shapefn();
 
   //! Assign nodal mass to particles

--- a/include/particle.h
+++ b/include/particle.h
@@ -53,7 +53,7 @@ class Particle : public ParticleBase<Tdim> {
   void compute_reference_location();
 
   //! Return reference location
-  VectorDim reference_location() const { return reference_location_; }
+  VectorDim reference_location() const { return xi_; }
 
   // Assign a cell to particle
   //! \param[in] cellptr Pointer to a cell
@@ -61,6 +61,10 @@ class Particle : public ParticleBase<Tdim> {
 
   //! Return cell id
   Index cell_id() const { return cell_id_; }
+
+  //! Compute shape functions of a particle, based on local coordinates
+  //! \retval status Returns if compue shapefns was successful
+  bool compute_shapefn();
 
   //! Assign nodal mass to particles
   //! \param[in] nphase Index corresponding to the phase
@@ -127,7 +131,7 @@ class Particle : public ParticleBase<Tdim> {
   //! coordinates
   using ParticleBase<Tdim>::coordinates_;
   //! Reference coordinates (in a cell)
-  Eigen::Matrix<double, Tdim, 1> reference_location_;
+  Eigen::Matrix<double, Tdim, 1> xi_;
   //! Cell
   std::shared_ptr<Cell<Tdim>> cell_;
   //! Cell id
@@ -144,6 +148,12 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::Matrix<double, Tdim, Tnphases> momentum_;
   //! Acceleration
   Eigen::Matrix<double, Tdim, Tnphases> acceleration_;
+  //! Shape functions
+  Eigen::VectorXd shapefn_;
+  //! Gradient of shape functions
+  Eigen::MatrixXd grad_shapefn_;
+  //! B-Matrix
+  std::vector<Eigen::MatrixXd> bmatrix_;
 
 };  // Particle class
 }  // namespace mpm

--- a/include/particle.h
+++ b/include/particle.h
@@ -50,7 +50,7 @@ class Particle : public ParticleBase<Tdim> {
   void initialise();
 
   //! Compute reference coordinates in a cell
-  void compute_reference_location();
+  bool compute_reference_location();
 
   //! Return reference location
   VectorDim reference_location() const { return xi_; }
@@ -63,7 +63,6 @@ class Particle : public ParticleBase<Tdim> {
   Index cell_id() const { return cell_id_; }
 
   //! Compute shape functions of a particle, based on local coordinates
-  //! \retval status Returns if compute shapefns was successful
   bool compute_shapefn();
 
   //! Assign nodal mass to particles

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -39,8 +39,9 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
 template <unsigned Tdim, unsigned Tnphases>
 void mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
   try {
-    // Get reference location of a particle
+    // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
+      // Get reference location of a particle
       this->xi_ = cell_->local_coordinates_point(this->coordinates_);
     } else {
       throw std::runtime_error(
@@ -58,6 +59,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
 
   bool status = false;
   try {
+    // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Compute local coordinates
       this->compute_reference_location();

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -37,12 +37,14 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
 
 // Compute reference location cell to particle
 template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
+bool mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
+  bool status = false;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Get reference location of a particle
       this->xi_ = cell_->local_coordinates_point(this->coordinates_);
+      status = true;
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "
@@ -51,6 +53,7 @@ void mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
   } catch (std::exception& exception) {
     std::cerr << exception.what() << '\n';
   }
+  return status;
 }
 
 // Compute shape functions and gradients

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -3,6 +3,7 @@ template <unsigned Tdim, unsigned Tnphases>
 mpm::Particle<Tdim, Tnphases>::Particle(Index id, const VectorDim& coord)
     : mpm::ParticleBase<Tdim>(id, coord) {
   this->initialise();
+  cell_ = nullptr;
 }
 
 //! Construct a particle with id, coordinates and status
@@ -11,6 +12,7 @@ mpm::Particle<Tdim, Tnphases>::Particle(Index id, const VectorDim& coord,
                                         bool status)
     : mpm::ParticleBase<Tdim>(id, coord, status) {
   this->initialise();
+  cell_ = nullptr;
 }
 
 // Initialise particle properties
@@ -38,7 +40,7 @@ template <unsigned Tdim, unsigned Tnphases>
 void mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
   try {
     // Get reference location of a particle
-    if (this->cell_->is_initialised()) {
+    if (cell_ != nullptr) {
       this->xi_ = cell_->local_coordinates_point(this->coordinates_);
     } else {
       throw std::runtime_error(
@@ -56,7 +58,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
 
   bool status = false;
   try {
-    if (this->cell_->is_initialised()) {
+    if (cell_ != nullptr) {
       // Compute local coordinates
       this->compute_reference_location();
 
@@ -71,7 +73,6 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
       bmatrix_ = sfn->bmatrix(this->xi_);
       // Return update status
       status = true;
-
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -56,7 +56,7 @@ class ParticleBase {
   VectorDim coordinates() const { return coordinates_; }
 
   //! Compute reference coordinates in a cell
-  virtual void compute_reference_location() = 0;
+  virtual bool compute_reference_location() = 0;
 
   //! Return reference location
   virtual VectorDim reference_location() const = 0;

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -67,6 +67,9 @@ class ParticleBase {
   //! Return cell id
   virtual Index cell_id() const = 0;
 
+  //! Compute shape functions
+  virtual bool compute_shapefn() = 0;
+
   //! Assign status
   void assign_status(bool status) { status_ = status; }
 

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -99,6 +99,12 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
       REQUIRE(cell->mean_length() == Approx(length).epsilon(Tolerance));
     }
 
+    // Check shape functions
+    SECTION("Check shape functions") {
+     const auto sf_ptr = cell->shapefn_ptr();
+     REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
+    }
+    
     // Check centroid calculation
     SECTION("Compute centroid of a cell") {
       REQUIRE(cell->nfunctions() == 4);
@@ -685,6 +691,12 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
       // Check centroid calculations
       for (unsigned i = 0; i < check_centroid.size(); ++i)
         REQUIRE(check_centroid[i] == Approx(centroid[i]).epsilon(Tolerance));
+    }
+
+    // Check shape functions
+    SECTION("Check shape functions") {
+     const auto sf_ptr = cell->shapefn_ptr();
+     REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
     }
 
     // Check cell volume calculation

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -101,10 +101,10 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
     // Check shape functions
     SECTION("Check shape functions") {
-     const auto sf_ptr = cell->shapefn_ptr();
-     REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
+      const auto sf_ptr = cell->shapefn_ptr();
+      REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
     }
-    
+
     // Check centroid calculation
     SECTION("Compute centroid of a cell") {
       REQUIRE(cell->nfunctions() == 4);
@@ -695,8 +695,8 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
     // Check shape functions
     SECTION("Check shape functions") {
-     const auto sf_ptr = cell->shapefn_ptr();
-     REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
+      const auto sf_ptr = cell->shapefn_ptr();
+      REQUIRE(sf_ptr->nfunctions() == shapefn->nfunctions());
     }
 
     // Check cell volume calculation

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -279,12 +279,18 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Add cell to particle
     REQUIRE(cell->status() == false);
+    // Check compute shape functions of a particle
+    REQUIRE(particle->compute_shapefn() == false);
+    
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
     REQUIRE(particle->cell_id() == 10);
 
     // Check if cell is initialised
     REQUIRE(cell->is_initialised() == true);
+
+    // Check compute shape functions of a particle
+    REQUIRE(particle->compute_shapefn() == true);
 
     // Check reference location
     coords << -0.5, -0.5;
@@ -530,9 +536,18 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     // Add cell to particle
     REQUIRE(cell->status() == false);
+    // Check compute shape functions of a particle
+    REQUIRE(particle->compute_shapefn() == false);
+    
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
     REQUIRE(particle->cell_id() == 10);
+
+    // Check if cell is initialised
+    REQUIRE(cell->is_initialised() == true);
+
+    // Check compute shape functions of a particle
+    REQUIRE(particle->compute_shapefn() == true);
 
     // Check reference location
     coords << 0.5, 0.5, 0.5;

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -281,7 +281,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(cell->status() == false);
     // Check compute shape functions of a particle
     REQUIRE(particle->compute_shapefn() == false);
-    
+
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
     REQUIRE(particle->cell_id() == 10);
@@ -538,7 +538,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(cell->status() == false);
     // Check compute shape functions of a particle
     REQUIRE(particle->compute_shapefn() == false);
-    
+
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
     REQUIRE(particle->cell_id() == 10);

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -281,6 +281,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(cell->status() == false);
     // Check compute shape functions of a particle
     REQUIRE(particle->compute_shapefn() == false);
+    // Compute reference location should throw
+    REQUIRE(particle->compute_reference_location() == false);
 
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
@@ -294,7 +296,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Check reference location
     coords << -0.5, -0.5;
-    particle->compute_reference_location();
+    REQUIRE(particle->compute_reference_location() == true);
     auto ref_coordinates = particle->reference_location();
     for (unsigned i = 0; i < ref_coordinates.size(); ++i)
       REQUIRE(ref_coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
@@ -538,6 +540,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(cell->status() == false);
     // Check compute shape functions of a particle
     REQUIRE(particle->compute_shapefn() == false);
+    // Compute reference location should throw
+    REQUIRE(particle->compute_reference_location() == false);
 
     particle->assign_cell(cell);
     REQUIRE(cell->status() == true);
@@ -551,7 +555,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     // Check reference location
     coords << 0.5, 0.5, 0.5;
-    particle->compute_reference_location();
+    REQUIRE(particle->compute_reference_location() == true);
     auto ref_coordinates = particle->reference_location();
     for (unsigned i = 0; i < ref_coordinates.size(); ++i)
       REQUIRE(ref_coordinates(i) == Approx(coords(i)).epsilon(Tolerance));


### PR DESCRIPTION
Precompute particle shapefunction, gradient, and b-matrix to improve performance and reduce redundant computation.