### PR TITLE
:computer: Assign and remove cell associated with a particle

### DIFF
--- a/include/particle.h
+++ b/include/particle.h
@@ -65,6 +65,9 @@ class Particle : public ParticleBase<Tdim> {
   //! Return cell id
   Index cell_id() const { return cell_id_; }
 
+  //! Remove cell associated with the particle
+  void remove_cell();
+
   //! Compute shape functions of a particle, based on local coordinates
   bool compute_shapefn();
 

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -37,7 +37,7 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
     // Assign cell to the new cell ptr, if point can be found in new cell
     if (cellptr->is_point_in_cell(this->coordinates_)) {
       // if a cell already exists remove particle from that cell
-      if (cell_ != nullptr) cell_->remove_particle_id(this->id());
+      if (cell_ != nullptr) cell_->remove_particle_id(this->id_);
 
       cell_ = cellptr;
       cell_id_ = cellptr->id();
@@ -45,8 +45,6 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
       this->compute_reference_location();
       status = cell_->add_particle_id(this->id());
     } else {
-      // If the point is in not current cell, set as null ptr
-      if (!cell_->is_point_in_cell(this->coordinates_)) cell_ = nullptr;
       throw std::runtime_error("Point cannot be found in cell!");
     }
   } catch (std::exception& exception) {
@@ -54,6 +52,14 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
     status = false;
   }
   return status;
+}
+
+// Remove cell for the particle
+template <unsigned Tdim, unsigned Tnphases>
+void mpm::Particle<Tdim, Tnphases>::remove_cell() {
+  // if a cell is not nullptr
+  if (cell_ != nullptr) cell_->remove_particle_id(this->id_);
+  cell_id_ = std::numeric_limits<Index>::max();
 }
 
 // Assign a material to particle

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -68,6 +68,9 @@ class ParticleBase {
   //! Return cell id
   virtual Index cell_id() const = 0;
 
+  //! Remove cell
+  virtual void remove_cell() = 0;
+
   //! Compute shape functions
   virtual bool compute_shapefn() = 0;
 

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -322,6 +322,10 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(cell2->status() == false);
     // Check cell status because this should not have removed the particle
     REQUIRE(cell->status() == true);
+
+    // Remove assigned cell
+    particle->remove_cell();
+    REQUIRE(particle->assign_cell(cell) == true);
   }
 
   //! Test particle, cell and node functions
@@ -954,6 +958,10 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(cell2->status() == false);
     // Check cell status because this should not have removed the particle
     REQUIRE(cell->status() == true);
+
+    // Remove assigned cell
+    particle->remove_cell();
+    REQUIRE(particle->assign_cell(cell) == true);
   }
 
   //! Test particle, cell and node functions


### PR DESCRIPTION
* Add ability to remove particles, useful when particles are not found in the mesh anymore. 
* Relates to #152 