### PR TITLE
:checkered_flag: Parallel implementation of locate particles in mesh Fixes #155 

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -155,8 +155,7 @@ class Mesh {
 
  private:
   // Locate a particle in mesh
-  bool locate_particle_mesh(
-      const std::shared_ptr<mpm::ParticleBase<Tdim>>& particle);
+  bool locate_particle_mesh(std::shared_ptr<mpm::ParticleBase<Tdim>> particle);
 
  protected:
   //! mesh id

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -154,8 +154,8 @@ class Mesh {
   unsigned nneighbours() const { return neighbour_meshes_.size(); }
 
  private:
-  // Locate a particle in mesh
-  bool locate_particle_mesh(std::shared_ptr<mpm::ParticleBase<Tdim>> particle);
+  // Locate a particle in mesh cells
+  bool locate_particle_cells(std::shared_ptr<mpm::ParticleBase<Tdim>> particle);
 
  protected:
   //! mesh id

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -189,8 +189,8 @@ bool mpm::Mesh<Tdim>::add_particle(
     const std::shared_ptr<mpm::ParticleBase<Tdim>>& particle) {
   bool status = false;
   try {
-    // Add only if particle can be located in a mesh
-    if (this->locate_particle_mesh(particle))
+    // Add only if particle can be located in any cell of the mesh
+    if (this->locate_particle_cells(particle))
       status = particles_.add(particle);
     else
       throw std::runtime_error("Particle not found in mesh");
@@ -217,37 +217,39 @@ std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>>
 
   std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>> particles;
 
-  tbb::parallel_for_each(particles_.cbegin(), particles_.cend(),
-                         [=, &particles](std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
-                           // If particle is not found in mesh add to a list of particles
-                           if(!this->locate_particle_mesh(particle))
-                             // Needs a lock guard here
-                             particles.emplace_back(particle);
-                         });
+  tbb::parallel_for_each(
+      particles_.cbegin(), particles_.cend(),
+      [=, &particles](std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
+        // If particle is not found in mesh add to a list of particles
+        if (!this->locate_particle_cells(particle))
+          // Needs a lock guard here
+          particles.emplace_back(particle);
+      });
 
   return particles;
 }
 
 //! Locate particles in a cell
 template <unsigned Tdim>
-bool mpm::Mesh<Tdim>::locate_particle_mesh(
+bool mpm::Mesh<Tdim>::locate_particle_cells(
     std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
-
-  std::string put =  "Particleid: " + std::to_string(particle ->id() ) + "\n";
-  std::cout << put;
   // Check the current cell if it is not invalid
   if (particle->cell_id() != std::numeric_limits<mpm::Index>::max())
     if (particle->compute_reference_location()) return true;
 
-  for (auto citr = cells_.cbegin(); citr != cells_.cend(); ++citr) {
-    // Check if co-ordinates is within the cell, if true add particle to
-    // cell
-    if ((*citr)->point_in_cell(particle->coordinates())) {
-      particle->assign_cell(*citr);
-      return true;
-    }
-  }
-  return false;
+  bool status = false;
+  tbb::parallel_for_each(
+      cells_.cbegin(), cells_.cend(),
+      [=, &status](std::shared_ptr<mpm::Cell<Tdim>> cell) {
+        // Check if co-ordinates is within the cell, if true
+        // add particle to cell
+        if (cell->is_point_in_cell(particle->coordinates())) {
+          particle->assign_cell(cell);
+          status = true;
+        }
+      });
+
+  return status;
 }
 
 //! Iterate over particles

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -218,18 +218,13 @@ std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>>
   std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>> particles;
 
   tbb::parallel_for_each(particles_.cbegin(), particles_.cend(),
-                         [=](std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
-                           locate_particle_mesh(particle);
+                         [=, &particles](std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
+                           // If particle is not found in mesh add to a list of particles
+                           if(!this->locate_particle_mesh(particle))
+                             // Needs a lock guard here
+                             particles.emplace_back(particle);
                          });
 
-  /*
-  // Iterate through each particle and
-  for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr) {
-    bool find_cell = this->locate_particle_mesh(*pitr);
-    // If particle is not found in mesh add to a list of particles
-    if (!find_cell) particles.emplace_back(*pitr);
-  }
-  */
   return particles;
 }
 

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -217,20 +217,29 @@ std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>>
 
   std::vector<std::shared_ptr<mpm::ParticleBase<Tdim>>> particles;
 
+  tbb::parallel_for_each(particles_.cbegin(), particles_.cend(),
+                         [=](std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
+                           locate_particle_mesh(particle);
+                         });
+
+  /*
   // Iterate through each particle and
   for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr) {
     bool find_cell = this->locate_particle_mesh(*pitr);
     // If particle is not found in mesh add to a list of particles
     if (!find_cell) particles.emplace_back(*pitr);
   }
+  */
   return particles;
 }
 
 //! Locate particles in a cell
 template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::locate_particle_mesh(
-    const std::shared_ptr<mpm::ParticleBase<Tdim>>& particle) {
+    std::shared_ptr<mpm::ParticleBase<Tdim>> particle) {
 
+  std::string put =  "Particleid: " + std::to_string(particle ->id() ) + "\n";
+  std::cout << put;
   // Check the current cell if it is not invalid
   if (particle->cell_id() != std::numeric_limits<mpm::Index>::max())
     if (particle->compute_reference_location()) return true;


### PR DESCRIPTION
Fixes #155 
Relates to #152 

Additional check to ensure particle can't be added to a mesh before it can be located in the mesh.