### PR TITLE
:checkered_flag: Refactor material class to add particle handle

### DIFF
--- a/include/material/linear_elastic.h
+++ b/include/material/linear_elastic.h
@@ -35,31 +35,25 @@ class LinearElastic : public Material<Tdim> {
 
   //! Read material properties
   //! \param[in] materail_properties Material properties
-  void properties(const Json& material_properties );
+  void properties(const Json& material_properties);
 
   //! Compute elastic tensor
   //! \retval de_ Elastic tensor
   Matrix6x6 elastic_tensor();
 
   //! Compute stress
-  //! \param[in] strain Strain
   //! \param[in] stress Stress
+  //! \param[in] dstrain Strain
   //! \retval updated_stress Updated value of stress
-  Vector6d compute_stress(const Vector6d& stress, const Vector6d& strain);
+  Vector6d compute_stress(const Vector6d& stress, const Vector6d& dstrain);
 
   //! Compute stress
-  //! \param[in] strain Strain
   //! \param[in] stress Stress
+  //! \param[in] dstrain Strain
   //! \param[in] particle Constant point to particle base
   //! \retval updated_stress Updated value of stress
-  Vector6d compute_stress(const Vector6d& stress, const Vector6d& strain,
+  Vector6d compute_stress(const Vector6d& stress, const Vector6d& dstrain,
                           const ParticleBase<Tdim>* ptr);
-
-  void testfn(const ParticleBase<Tdim>* ptr) {
-    std::string out = "Pointer : " + std::to_string(ptr->id()) +
-                      " cell: " + std::to_string(ptr->cell_id()) + "\n";
-    std::cout << out;
-  }
 
  protected:
   //! material id
@@ -68,6 +62,7 @@ class LinearElastic : public Material<Tdim> {
   using Material<Tdim>::status_;
   //! Material properties
   using Material<Tdim>::properties_;
+
  private:
   //! Elastic stiffness matrix
   Matrix6x6 de_;

--- a/include/material/linear_elastic.h
+++ b/include/material/linear_elastic.h
@@ -45,7 +45,15 @@ class LinearElastic : public Material<Tdim> {
   //! \param[in] strain Strain
   //! \param[in] stress Stress
   //! \retval updated_stress Updated value of stress
-  void compute_stress(Vector6d& stress, const Vector6d& strain);
+  Vector6d compute_stress(const Vector6d& stress, const Vector6d& strain);
+
+  //! Compute stress
+  //! \param[in] strain Strain
+  //! \param[in] stress Stress
+  //! \param[in] particle Constant point to particle base
+  //! \retval updated_stress Updated value of stress
+  Vector6d compute_stress(const Vector6d& stress, const Vector6d& strain,
+                          const ParticleBase<Tdim>* ptr);
 
   void testfn(const ParticleBase<Tdim>* ptr) {
     std::string out = "Pointer : " + std::to_string(ptr->id()) +

--- a/include/material/linear_elastic.h
+++ b/include/material/linear_elastic.h
@@ -55,6 +55,9 @@ class LinearElastic : public Material<Tdim> {
   Vector6d compute_stress(const Vector6d& stress, const Vector6d& dstrain,
                           const ParticleBase<Tdim>* ptr);
 
+  //! Check if this material needs a particle handle
+  bool property_handle() const { return false; }
+
  protected:
   //! material id
   using Material<Tdim>::id_;

--- a/include/material/linear_elastic.h
+++ b/include/material/linear_elastic.h
@@ -12,7 +12,9 @@ namespace mpm {
 //! LinearElastic class
 //! \brief Linear Elastic material model
 //! \details LinearElastic class stresses and strains
-class LinearElastic : public Material {
+//! \tparam Tdim Dimension
+template <unsigned Tdim>
+class LinearElastic : public Material<Tdim> {
  public:
   //! Define a vector of 6 dof
   using Vector6d = Eigen::Matrix<double, 6, 1>;
@@ -20,7 +22,7 @@ class LinearElastic : public Material {
   using Matrix6x6 = Eigen::Matrix<double, 6, 6>;
 
   //! Constructor with id
-  LinearElastic(unsigned id) : Material(id){};
+  LinearElastic(unsigned id) : Material<Tdim>(id){};
 
   //! Destructor
   virtual ~LinearElastic(){};
@@ -45,13 +47,19 @@ class LinearElastic : public Material {
   //! \retval updated_stress Updated value of stress
   void compute_stress(Vector6d& stress, const Vector6d& strain);
 
+  void testfn(const ParticleBase<Tdim>* ptr) {
+    std::string out = "Pointer : " + std::to_string(ptr->id()) +
+                      " cell: " + std::to_string(ptr->cell_id()) + "\n";
+    std::cout << out;
+  }
+
  protected:
   //! material id
-  using Material::id_;
+  using Material<Tdim>::id_;
   //! material status
-  using Material::status_;
+  using Material<Tdim>::status_;
   //! Material properties
-  using Material::properties_;
+  using Material<Tdim>::properties_;
  private:
   //! Elastic stiffness matrix
   Matrix6x6 de_;

--- a/include/material/linear_elastic.tcc
+++ b/include/material/linear_elastic.tcc
@@ -39,9 +39,18 @@ Eigen::Matrix<double, 6, 6> mpm::LinearElastic<Tdim>::elastic_tensor() {
 
 //! Compute stress
 template <unsigned Tdim>
-void mpm::LinearElastic<Tdim>::compute_stress(Vector6d& stress,
-                                              const Vector6d& dstrain) {
-
+Eigen::Matrix<double, 6, 1> mpm::LinearElastic<Tdim>::compute_stress(
+    const Vector6d& stress, const Vector6d& dstrain) {
+  
   Vector6d dstress = this->elastic_tensor() * dstrain;
-  stress += dstress;
+  return (stress + dstress);
+}
+
+//! Compute stress
+template <unsigned Tdim>
+Eigen::Matrix<double, 6, 1> mpm::LinearElastic<Tdim>::compute_stress(
+    const Vector6d& stress, const Vector6d& dstrain,
+    const ParticleBase<Tdim>* ptr) {
+
+  return this->compute_stress(stress, dstrain);
 }

--- a/include/material/linear_elastic.tcc
+++ b/include/material/linear_elastic.tcc
@@ -1,5 +1,6 @@
 //! Read material properties
-void mpm::LinearElastic::properties(const Json& material_properties) {
+template <unsigned Tdim>
+void mpm::LinearElastic<Tdim>::properties(const Json& material_properties) {
   try {
     density_ = material_properties["density"].template get<double>();
     youngs_modulus_ =
@@ -14,7 +15,8 @@ void mpm::LinearElastic::properties(const Json& material_properties) {
 }
 
 //! Return elastic tensor
-mpm::Material::Matrix6x6 mpm::LinearElastic::elastic_tensor() {
+template <unsigned Tdim>
+Eigen::Matrix<double, 6, 6> mpm::LinearElastic<Tdim>::elastic_tensor() {
   // Bulk and shear modulus
   const double K = youngs_modulus_ / (3.0 * (1. - 2. * poisson_ratio_));
   const double G = youngs_modulus_ / (2.0 * (1. + poisson_ratio_));
@@ -36,9 +38,10 @@ mpm::Material::Matrix6x6 mpm::LinearElastic::elastic_tensor() {
 }
 
 //! Compute stress
-void mpm::LinearElastic::compute_stress(Vector6d& stress,
-                                        const Vector6d& strain) {
+template <unsigned Tdim>
+void mpm::LinearElastic<Tdim>::compute_stress(Vector6d& stress,
+                                              const Vector6d& dstrain) {
 
-  Vector6d dstress = this->elastic_tensor() * strain;
+  Vector6d dstress = this->elastic_tensor() * dstrain;
   stress += dstress;
 }

--- a/include/material/material.h
+++ b/include/material/material.h
@@ -80,6 +80,11 @@ class Material {
                                   const Vector6d& dstrain,
                                   const ParticleBase<Tdim>* ptr) = 0;
 
+  //! Check if this material needs a particle handle
+  //! Set true, if material needs other parameters from the particle
+  //! For eg, dstrain_rate. These function calls can only to const functions
+  virtual bool property_handle() const = 0;
+  
  protected:
   //! material id
   unsigned id_{std::numeric_limits<unsigned>::max()};

--- a/include/material/material.h
+++ b/include/material/material.h
@@ -65,23 +65,20 @@ class Material {
   virtual Matrix6x6 elastic_tensor() = 0;
 
   //! Compute stress
-  //! \param[in] strain Strain
   //! \param[in] stress Stress
+  //! \param[in] dstrain Strain
   //! \retval updated_stress Updated value of stress
   virtual Vector6d compute_stress(const Vector6d& stress,
-                                  const Vector6d& strain) = 0;
+                                  const Vector6d& dstrain) = 0;
 
   //! Compute stress
-  //! \param[in] strain Strain
   //! \param[in] stress Stress
+  //! \param[in] dstrain Strain
   //! \param[in] particle Constant point to particle base
   //! \retval updated_stress Updated value of stress
   virtual Vector6d compute_stress(const Vector6d& stress,
-                                  const Vector6d& strain,
+                                  const Vector6d& dstrain,
                                   const ParticleBase<Tdim>* ptr) = 0;
-
-  // Test function
-  virtual void testfn(const ParticleBase<Tdim>* ptr) = 0;
 
  protected:
   //! material id

--- a/include/material/material.h
+++ b/include/material/material.h
@@ -8,8 +8,8 @@
 #include "json.hpp"
 
 #include "factory.h"
-#include "particle_base.h"
 #include "particle.h"
+#include "particle_base.h"
 
 // JSON
 using Json = nlohmann::json;
@@ -58,15 +58,7 @@ class Material {
   //! Get material property
   //! \param[in] key Material properties key
   //! \retval result Value of material property
-  double property(const std::string& key) {
-    double result = std::numeric_limits<double>::max();
-    try {
-      result = properties_[key].template get<double>();
-    } catch (std::exception& except) {
-      std::cerr << "Material parameter not found: " << except.what() << '\n';
-    }
-    return result;
-  }
+  double property(const std::string& key);
 
   //! Compute elastic tensor
   //! \retval de_ Elastic tensor
@@ -76,10 +68,20 @@ class Material {
   //! \param[in] strain Strain
   //! \param[in] stress Stress
   //! \retval updated_stress Updated value of stress
-  virtual void compute_stress(Vector6d& stress, const Vector6d& strain) = 0;
+  virtual Vector6d compute_stress(const Vector6d& stress,
+                                  const Vector6d& strain) = 0;
+
+  //! Compute stress
+  //! \param[in] strain Strain
+  //! \param[in] stress Stress
+  //! \param[in] particle Constant point to particle base
+  //! \retval updated_stress Updated value of stress
+  virtual Vector6d compute_stress(const Vector6d& stress,
+                                  const Vector6d& strain,
+                                  const ParticleBase<Tdim>* ptr) = 0;
 
   // Test function
-  virtual void testfn(const ParticleBase<Tdim>* ptr) = 0; 
+  virtual void testfn(const ParticleBase<Tdim>* ptr) = 0;
 
  protected:
   //! material id
@@ -90,5 +92,7 @@ class Material {
   Json properties_;
 };  // Material class
 }  // namespace mpm
+
+#include "material.tcc"
 
 #endif  // MPM_MATERIAL_MATERIAL_H_

--- a/include/material/material.h
+++ b/include/material/material.h
@@ -8,15 +8,23 @@
 #include "json.hpp"
 
 #include "factory.h"
+#include "particle_base.h"
+#include "particle.h"
 
 // JSON
 using Json = nlohmann::json;
 
 namespace mpm {
 
+// Forward declaration of ParticleBase
+template <unsigned Tdim>
+class ParticleBase;
+
 //! Material base class
 //! \brief Base class that stores the information about materials
 //! \details Material class stresses and strains
+//! \tparam Tdim Dimension
+template <unsigned Tdim>
 class Material {
  public:
   //! Define a vector of 6 dof
@@ -69,6 +77,9 @@ class Material {
   //! \param[in] stress Stress
   //! \retval updated_stress Updated value of stress
   virtual void compute_stress(Vector6d& stress, const Vector6d& strain) = 0;
+
+  // Test function
+  virtual void testfn(const ParticleBase<Tdim>* ptr) = 0; 
 
  protected:
   //! material id

--- a/include/material/material.tcc
+++ b/include/material/material.tcc
@@ -1,0 +1,11 @@
+//! Get material property
+template <unsigned Tdim>
+double mpm::Material<Tdim>::property(const std::string& key) {
+  double result = std::numeric_limits<double>::max();
+  try {
+    result = properties_[key].template get<double>();
+  } catch (std::exception& except) {
+    std::cerr << "Material parameter not found: " << except.what() << '\n';
+  }
+  return result;
+}

--- a/include/mpm.h
+++ b/include/mpm.h
@@ -51,7 +51,7 @@ class MPM {
   //! Mesh object
   std::vector<std::unique_ptr<mpm::Mesh<Tdim>>> meshes_;
   //! Materials
-  std::map<unsigned, std::shared_ptr<mpm::Material>> materials_;
+  std::map<unsigned, std::shared_ptr<mpm::Material<Tdim>>> materials_;
   //! A unique ptr to IO object
   std::unique_ptr<mpm::IO> io_;
   //! JSON analysis object

--- a/include/mpm_explicit.tcc
+++ b/include/mpm_explicit.tcc
@@ -116,7 +116,7 @@ bool mpm::MPMExplicit<Tdim>::initialise_materials() {
       unsigned material_id = material_props["id"].template get<unsigned>();
 
       // Create a new material from JSON object
-      auto mat = Factory<mpm::Material, unsigned>::instance()->create(
+      auto mat = Factory<mpm::Material<Tdim>, unsigned>::instance()->create(
           material_type, std::move(material_id));
 
       // Initialise material properties

--- a/include/particle.h
+++ b/include/particle.h
@@ -100,7 +100,7 @@ class Particle : public ParticleBase<Tdim> {
 
   //! Assign material
   //! \param[in] material Pointer to a material
-  bool assign_material(const std::shared_ptr<Material>& material);
+  bool assign_material(const std::shared_ptr<Material<Tdim>>& material);
 
   //! Compute strain
   //! \param[in] phase Index corresponding to the phase

--- a/include/particle.h
+++ b/include/particle.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "cell.h"

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -240,12 +240,20 @@ void mpm::Particle<Tdim, Tnphases>::compute_strain(unsigned phase, double dt) {
 template <unsigned Tdim, unsigned Tnphases>
 bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
   bool status = true;
+  Eigen::Matrix<double, 6, 1> stress;
+  stress.setZero();
   try {
     // Check if  material ptr is valid
     if (material_ != nullptr) {
-      // Calculate stress
-      auto stress = material_->compute_stress(this->stress_.col(phase),
-                                              this->dstrain_.col(phase), this);
+      // Check if material needs property handle
+      if (material_->property_handle())
+        // Calculate stress
+        stress = material_->compute_stress(this->stress_.col(phase),
+                                           this->dstrain_.col(phase), this);
+      else
+        // Calculate stress without sending particle handle
+        stress = material_->compute_stress(this->stress_.col(phase),
+                                           this->dstrain_.col(phase));
       // Assign stress
       this->assign_stress(phase, stress);
     } else {

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -246,7 +246,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
     // Check if  material ptr is valid
     if (material_ != nullptr) {
       // Calculate stress
-      material_->compute_stress(stress, this->dstrain_.col(phase));
+      stress = material_->compute_stress(stress, this->dstrain_.col(phase));
 
       material_->testfn(this);
 

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -240,13 +240,12 @@ void mpm::Particle<Tdim, Tnphases>::compute_strain(unsigned phase, double dt) {
 template <unsigned Tdim, unsigned Tnphases>
 bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
   bool status = true;
-  Eigen::Matrix<double, 6, 1> stress;
-  stress.setZero();
   try {
     // Check if  material ptr is valid
     if (material_ != nullptr) {
       // Calculate stress
-      stress = material_->compute_stress(stress, this->dstrain_.col(phase), this);
+      auto stress = material_->compute_stress(this->stress_.col(phase),
+                                              this->dstrain_.col(phase), this);
       // Assign stress
       this->assign_stress(phase, stress);
     } else {

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -246,7 +246,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
     // Check if  material ptr is valid
     if (material_ != nullptr) {
       // Calculate stress
-      stress = material_->compute_stress(stress, this->dstrain_.col(phase));
+      stress = material_->compute_stress(stress, this->dstrain_.col(phase), this);
       // Assign stress
       this->assign_stress(phase, stress);
     } else {

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -247,9 +247,6 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
     if (material_ != nullptr) {
       // Calculate stress
       stress = material_->compute_stress(stress, this->dstrain_.col(phase));
-
-      material_->testfn(this);
-
       // Assign stress
       this->assign_stress(phase, stress);
     } else {

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -66,7 +66,7 @@ void mpm::Particle<Tdim, Tnphases>::remove_cell() {
 // Assign a material to particle
 template <unsigned Tdim, unsigned Tnphases>
 bool mpm::Particle<Tdim, Tnphases>::assign_material(
-    const std::shared_ptr<Material>& material) {
+    const std::shared_ptr<Material<Tdim>>& material) {
   bool status = false;
   try {
     // Check if material is valid and properties are set
@@ -247,6 +247,9 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
     if (material_ != nullptr) {
       // Calculate stress
       material_->compute_stress(stress, this->dstrain_.col(phase));
+
+      material_->testfn(this);
+
       // Assign stress
       this->assign_stress(phase, stress);
     } else {

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -12,6 +12,10 @@
 
 namespace mpm {
 
+// Forward declaration of Material
+template <unsigned Tdim>
+class Material;
+
 //! Global index type for the particleBase
 using Index = unsigned long long;
 
@@ -90,7 +94,8 @@ class ParticleBase {
   virtual bool map_mass_momentum_to_nodes(unsigned phase) = 0;
 
   // Assign material
-  virtual bool assign_material(const std::shared_ptr<Material>& material) = 0;
+  virtual bool assign_material(
+      const std::shared_ptr<Material<Tdim>>& material) = 0;
 
   //! Assign status
   void assign_status(bool status) { status_ = status; }
@@ -172,7 +177,7 @@ class ParticleBase {
   //! Cell
   std::shared_ptr<Cell<Tdim>> cell_;
   //! Material
-  std::shared_ptr<Material> material_;
+  std::shared_ptr<Material<Tdim>> material_;
 };  // ParticleBase class
 }  // namespace mpm
 

--- a/src/material.cc
+++ b/src/material.cc
@@ -1,6 +1,10 @@
 #include "material/material.h"
 #include "material/linear_elastic.h"
 
-// LinearElastic
-static Register<mpm::Material, mpm::LinearElastic, unsigned> linear_elastic(
-    "LinearElastic");
+// LinearElastic 2D
+static Register<mpm::Material<2>, mpm::LinearElastic<2>, unsigned>
+    linear_elastic_2d("LinearElastic2D");
+
+// LinearElastic 3D
+static Register<mpm::Material<3>, mpm::LinearElastic<3>, unsigned>
+    linear_elastic("LinearElastic");

--- a/src/material.cc
+++ b/src/material.cc
@@ -7,4 +7,4 @@ static Register<mpm::Material<2>, mpm::LinearElastic<2>, unsigned>
 
 // LinearElastic 3D
 static Register<mpm::Material<3>, mpm::LinearElastic<3>, unsigned>
-    linear_elastic("LinearElastic");
+    linear_elastic_3d("LinearElastic3D");

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -23,7 +23,7 @@ bool write_json(unsigned dim, const std::string& file_name) {
     node_type = "N3D";
     cell_type = "SFH8";
     mesh_reader = "Ascii3D";
-    material = "LinearElastic";
+    material = "LinearElastic3D";
     gravity.clear();
     gravity = {0., 0., -9.81};
   }

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -13,6 +13,7 @@ bool write_json(unsigned dim, const std::string& file_name) {
   auto node_type = "N2D";
   auto cell_type = "SFQ4";
   auto mesh_reader = "Ascii2D";
+  std::string material = "LinearElastic2D";
   std::vector<double> gravity{{0., -9.81}};
 
   // 3D
@@ -22,6 +23,7 @@ bool write_json(unsigned dim, const std::string& file_name) {
     node_type = "N3D";
     cell_type = "SFH8";
     mesh_reader = "Ascii3D";
+    material = "LinearElastic";
     gravity.clear();
     gravity = {0., 0., -9.81};
   }
@@ -43,12 +45,12 @@ bool write_json(unsigned dim, const std::string& file_name) {
         {"particle_type", particle_type}}},
       {"materials",
        {{{"id", 0},
-         {"type", "LinearElastic"},
+         {"type", material},
          {"density", 1000.},
          {"youngs_modulus", 1.0E+8},
          {"poisson_ratio", 0.495}},
         {{"id", 1},
-         {"type", "LinearElastic"},
+         {"type", material},
          {"density", 2300.},
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},

--- a/tests/include/write_mesh_particles_unitcell.h
+++ b/tests/include/write_mesh_particles_unitcell.h
@@ -13,6 +13,7 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
   auto node_type = "N2D";
   auto cell_type = "SFQ4";
   auto mesh_reader = "Ascii2D";
+  std::string material = "LinearElastic2D";
   std::vector<double> gravity{{0., -9.81}};
 
   // 3D
@@ -22,6 +23,7 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
     node_type = "N3D";
     cell_type = "SFH8";
     mesh_reader = "Ascii3D";
+    material = "LinearElastic";
     gravity.clear();
     gravity = {0., 0., -9.81};
   }
@@ -43,12 +45,12 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
         {"particle_type", particle_type}}},
       {"materials",
        {{{"id", 0},
-         {"type", "LinearElastic"},
+         {"type", material},
          {"density", 1000.},
          {"youngs_modulus", 1.0E+8},
          {"poisson_ratio", 0.495}},
         {{"id", 1},
-         {"type", "LinearElastic"},
+         {"type", material},
          {"density", 2300.},
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},

--- a/tests/include/write_mesh_particles_unitcell.h
+++ b/tests/include/write_mesh_particles_unitcell.h
@@ -23,7 +23,7 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
     node_type = "N3D";
     cell_type = "SFH8";
     mesh_reader = "Ascii3D";
-    material = "LinearElastic";
+    material = "LinearElastic3D";
     gravity.clear();
     gravity = {0., 0., -9.81};
   }

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -197,6 +197,9 @@ TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
     // Compute updated stress
     stress = material->compute_stress(stress, strain, particle.get());
 
+    // Check if property handle is needed
+    REQUIRE(material->property_handle() == false);
+
     // Check stressees
     REQUIRE(stress(0) == Approx(1.63461538461538e+04).epsilon(Tolerance));
     REQUIRE(stress(1) == Approx(1.25000000000000e+04).epsilon(Tolerance));
@@ -393,6 +396,9 @@ TEST_CASE("LinearElastic is checked in 3D", "[material][linear_elastic][3D]") {
     // Compute updated stress
     stress = material->compute_stress(stress, strain, particle.get());
 
+    // Check if property handle is needed
+    REQUIRE(material->property_handle() == false);
+    
     // Check stressees
     REQUIRE(stress(0) == Approx(1.92307692307333e+04).epsilon(Tolerance));
     REQUIRE(stress(1) == Approx(1.53846153845333e+04).epsilon(Tolerance));

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -11,10 +11,12 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
   // Tolerance
   const double Tolerance = 1.E-7;
 
+  const unsigned Dim = 3;
+  
   //! Check for id = 0
   SECTION("LinearElastic id is zero") {
     unsigned id = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(id));
     REQUIRE(material->id() == 0);
   }
@@ -22,7 +24,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
   SECTION("LinearElastic id is positive") {
     //! Check for id is a positive value
     unsigned id = std::numeric_limits<unsigned>::max();
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(id));
     REQUIRE(material->id() == std::numeric_limits<unsigned>::max());
   }
@@ -30,7 +32,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
   //! Read material properties
   SECTION("LinearElastic check stiffness matrix") {
     unsigned id = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(id));
     REQUIRE(material->id() == 0);
 
@@ -65,7 +67,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
     const double a1 = 13461538.461566667;
     const double a2 = 5769230.769166667;
 
-    mpm::Material::Matrix6x6 de = material->elastic_tensor();
+    mpm::Material<Dim>::Matrix6x6 de = material->elastic_tensor();
     REQUIRE(de(0, 0) == Approx(a1).epsilon(Tolerance));
     REQUIRE(de(0, 1) == Approx(a2).epsilon(Tolerance));
     REQUIRE(de(0, 2) == Approx(a2).epsilon(Tolerance));
@@ -111,7 +113,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
 
   SECTION("LinearElastic check stresses") {
     unsigned id = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(id));
     REQUIRE(material->id() == 0);
 
@@ -123,10 +125,10 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
 
     material->properties(jmaterial);
 
-    mpm::Material::Matrix6x6 de = material->elastic_tensor();
+    mpm::Material<Dim>::Matrix6x6 de = material->elastic_tensor();
 
     // Initialise stress
-    mpm::Material::Vector6d stress;
+    mpm::Material<Dim>::Vector6d stress;
     stress.setZero();
     REQUIRE(stress(0) == Approx(0.).epsilon(Tolerance));
     REQUIRE(stress(1) == Approx(0.).epsilon(Tolerance));
@@ -136,7 +138,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
     REQUIRE(stress(5) == Approx(0.).epsilon(Tolerance));
 
     // Initialise strain
-    mpm::Material::Vector6d strain;
+    mpm::Material<Dim>::Vector6d strain;
     strain.setZero();
     strain(0) = 0.0010000;
     strain(1) = 0.0005000;

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -6,18 +6,18 @@
 
 #include "material/material.h"
 
-//! \brief Check linearelastic class
-TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
+//! Check linearelastic class in 2D
+TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
   // Tolerance
   const double Tolerance = 1.E-7;
 
-  const unsigned Dim = 3;
+  const unsigned Dim = 2;
   
   //! Check for id = 0
   SECTION("LinearElastic id is zero") {
     unsigned id = 0;
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(id));
+        "LinearElastic2D", std::move(id));
     REQUIRE(material->id() == 0);
   }
 
@@ -25,7 +25,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
     //! Check for id is a positive value
     unsigned id = std::numeric_limits<unsigned>::max();
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(id));
+        "LinearElastic2D", std::move(id));
     REQUIRE(material->id() == std::numeric_limits<unsigned>::max());
   }
 
@@ -33,7 +33,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
   SECTION("LinearElastic check stiffness matrix") {
     unsigned id = 0;
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(id));
+        "LinearElastic2D", std::move(id));
     REQUIRE(material->id() == 0);
 
     // Initialise material
@@ -114,7 +114,184 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
   SECTION("LinearElastic check stresses") {
     unsigned id = 0;
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(id));
+        "LinearElastic2D", std::move(id));
+    REQUIRE(material->id() == 0);
+
+    // Initialise material
+    Json jmaterial;
+    jmaterial["density"] = 1000.;
+    jmaterial["youngs_modulus"] = 1.0E+7;
+    jmaterial["poisson_ratio"] = 0.3;
+
+    material->properties(jmaterial);
+
+    mpm::Material<Dim>::Matrix6x6 de = material->elastic_tensor();
+
+    // Initialise stress
+    mpm::Material<Dim>::Vector6d stress;
+    stress.setZero();
+    REQUIRE(stress(0) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(stress(1) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(stress(2) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(stress(3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(stress(4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(stress(5) == Approx(0.).epsilon(Tolerance));
+
+    // Initialise strain
+    mpm::Material<Dim>::Vector6d strain;
+    strain.setZero();
+    strain(0) = 0.0010000;
+    strain(1) = 0.0005000;
+    strain(2) = 0.0000000;
+    strain(3) = 0.0000000;
+    strain(4) = 0.0000000;
+    strain(5) = 0.0000000;
+
+    // Compute updated stress
+    stress = material->compute_stress(stress, strain);
+
+    // Check stressees
+    REQUIRE(stress(0) == Approx(1.63461538461538e+04).epsilon(Tolerance));
+    REQUIRE(stress(1) == Approx(1.25000000000000e+04).epsilon(Tolerance));
+    REQUIRE(stress(2) == Approx(0.86538461538462e+04).epsilon(Tolerance));
+    REQUIRE(stress(3) == Approx(0.000000e+00).epsilon(Tolerance));
+    REQUIRE(stress(4) == Approx(0.000000e+00).epsilon(Tolerance));
+    REQUIRE(stress(5) == Approx(0.000000e+00).epsilon(Tolerance));
+
+    // Initialise strain
+    strain(0) = 0.0010000;
+    strain(1) = 0.0005000;
+    strain(2) = 0.0000000;
+    strain(3) = 0.0000100;
+    strain(4) = 0.0000000;
+    strain(5) = 0.0000000;
+
+    // Reset stress
+    stress.setZero();
+
+    // Compute updated stress
+    stress = material->compute_stress(stress, strain);
+
+    // Check stressees
+    REQUIRE(stress(0) == Approx(1.63461538461538e+04).epsilon(Tolerance));
+    REQUIRE(stress(1) == Approx(1.25000000000000e+04).epsilon(Tolerance));
+    REQUIRE(stress(2) == Approx(0.86538461538462e+04).epsilon(Tolerance));
+    REQUIRE(stress(3) == Approx(3.84615384615385e+01).epsilon(Tolerance));
+    REQUIRE(stress(4) == Approx(0.00000000000000e+00).epsilon(Tolerance));
+    REQUIRE(stress(5) == Approx(0.00000000000000e+00).epsilon(Tolerance));
+  }
+}
+
+
+//! Check linearelastic class in 3D
+TEST_CASE("LinearElastic is checked in 3D", "[material][linear_elastic][3D]") {
+  // Tolerance
+  const double Tolerance = 1.E-7;
+
+  const unsigned Dim = 3;
+  
+  //! Check for id = 0
+  SECTION("LinearElastic id is zero") {
+    unsigned id = 0;
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic3D", std::move(id));
+    REQUIRE(material->id() == 0);
+  }
+
+  SECTION("LinearElastic id is positive") {
+    //! Check for id is a positive value
+    unsigned id = std::numeric_limits<unsigned>::max();
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic3D", std::move(id));
+    REQUIRE(material->id() == std::numeric_limits<unsigned>::max());
+  }
+
+  //! Read material properties
+  SECTION("LinearElastic check stiffness matrix") {
+    unsigned id = 0;
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic3D", std::move(id));
+    REQUIRE(material->id() == 0);
+
+    // Initialise material
+    Json jmaterial;
+    jmaterial["density"] = 1000.;
+    jmaterial["youngs_modulus"] = 1.0E+7;
+    jmaterial["poisson_ratio"] = 0.3;
+
+    // Check material status before assigning material property
+    REQUIRE(material->status() == false);
+    
+    // Get material properties
+    REQUIRE(material->property("density") ==
+            Approx(std::numeric_limits<double>::max()).epsilon(Tolerance));
+
+    // Check for property that does not exist
+    REQUIRE(material->property("noproperty") ==
+            Approx(std::numeric_limits<double>::max()).epsilon(Tolerance));
+
+    material->properties(jmaterial);
+
+    // Check material status after assigning material property
+    REQUIRE(material->status() == true);
+
+    // Get material properties
+    REQUIRE(material->property("density") == Approx(jmaterial["density"]).epsilon(Tolerance));
+    
+    // Calculate modulus values
+    const double K = 8333333.333333333;
+    const double G = 3846153.846153846;
+    const double a1 = 13461538.461566667;
+    const double a2 = 5769230.769166667;
+
+    mpm::Material<Dim>::Matrix6x6 de = material->elastic_tensor();
+    REQUIRE(de(0, 0) == Approx(a1).epsilon(Tolerance));
+    REQUIRE(de(0, 1) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(0, 2) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(0, 3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(0, 4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(0, 5) == Approx(0.).epsilon(Tolerance));
+
+    REQUIRE(de(1, 0) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(1, 1) == Approx(a1).epsilon(Tolerance));
+    REQUIRE(de(1, 2) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(1, 3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(1, 4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(1, 5) == Approx(0.).epsilon(Tolerance));
+
+    REQUIRE(de(2, 0) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(2, 1) == Approx(a2).epsilon(Tolerance));
+    REQUIRE(de(2, 2) == Approx(a1).epsilon(Tolerance));
+    REQUIRE(de(2, 3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(2, 4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(2, 5) == Approx(0.).epsilon(Tolerance));
+
+    REQUIRE(de(3, 0) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(3, 1) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(3, 2) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(3, 3) == Approx(G).epsilon(Tolerance));
+    REQUIRE(de(3, 4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(3, 5) == Approx(0.).epsilon(Tolerance));
+
+    REQUIRE(de(4, 0) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(4, 1) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(4, 2) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(4, 3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(4, 4) == Approx(G).epsilon(Tolerance));
+    REQUIRE(de(4, 5) == Approx(0.).epsilon(Tolerance));
+
+    REQUIRE(de(5, 0) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(5, 1) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(5, 2) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(5, 3) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(5, 4) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(de(5, 5) == Approx(G).epsilon(Tolerance));
+  }
+
+  SECTION("LinearElastic check stresses") {
+    unsigned id = 0;
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic3D", std::move(id));
     REQUIRE(material->id() == 0);
 
     // Initialise material
@@ -148,7 +325,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
     strain(5) = 0.0000000;
 
     // Compute updated stress
-    material->compute_stress(stress, strain);
+    stress = material->compute_stress(stress, strain);
 
     // Check stressees
     REQUIRE(stress(0) == Approx(1.92307692307333e+04).epsilon(Tolerance));
@@ -170,7 +347,7 @@ TEST_CASE("LinearElastic is checked", "[material][linear_elastic]") {
     stress.setZero();
 
     // Compute updated stress
-    material->compute_stress(stress, strain);
+    stress = material->compute_stress(stress, strain);
 
     // Check stressees
     REQUIRE(stress(0) == Approx(1.92307692307333e+04).epsilon(Tolerance));

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -4,7 +4,13 @@
 #include "catch.hpp"
 #include "json.hpp"
 
+#include "cell.h"
+#include "hex_shapefn.h"
 #include "material/material.h"
+#include "node.h"
+#include "particle.h"
+#include "quad_shapefn.h"
+#include "shapefn.h"
 
 //! Check linearelastic class in 2D
 TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
@@ -171,6 +177,25 @@ TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
 
     // Compute updated stress
     stress = material->compute_stress(stress, strain);
+
+    // Check stressees
+    REQUIRE(stress(0) == Approx(1.63461538461538e+04).epsilon(Tolerance));
+    REQUIRE(stress(1) == Approx(1.25000000000000e+04).epsilon(Tolerance));
+    REQUIRE(stress(2) == Approx(0.86538461538462e+04).epsilon(Tolerance));
+    REQUIRE(stress(3) == Approx(3.84615384615385e+01).epsilon(Tolerance));
+    REQUIRE(stress(4) == Approx(0.00000000000000e+00).epsilon(Tolerance));
+    REQUIRE(stress(5) == Approx(0.00000000000000e+00).epsilon(Tolerance));
+
+    // Add particle
+    mpm::Index pid = 0;
+    Eigen::Matrix<double, Dim, 1> coords;
+    coords << 0.75, 0.75;
+    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+
+    // Reset stress
+    stress.setZero();
+    // Compute updated stress
+    stress = material->compute_stress(stress, strain, particle.get());
 
     // Check stressees
     REQUIRE(stress(0) == Approx(1.63461538461538e+04).epsilon(Tolerance));
@@ -348,6 +373,25 @@ TEST_CASE("LinearElastic is checked in 3D", "[material][linear_elastic][3D]") {
 
     // Compute updated stress
     stress = material->compute_stress(stress, strain);
+
+    // Check stressees
+    REQUIRE(stress(0) == Approx(1.92307692307333e+04).epsilon(Tolerance));
+    REQUIRE(stress(1) == Approx(1.53846153845333e+04).epsilon(Tolerance));
+    REQUIRE(stress(2) == Approx(1.53846153845333e+04).epsilon(Tolerance));
+    REQUIRE(stress(3) == Approx(3.84615384615385e+01).epsilon(Tolerance));
+    REQUIRE(stress(4) == Approx(7.69230769230769e+01).epsilon(Tolerance));
+    REQUIRE(stress(5) == Approx(1.15384615384615e+02).epsilon(Tolerance));
+
+    // Add particle
+    mpm::Index pid = 0;
+    Eigen::Matrix<double, Dim, 1> coords;
+    coords << 0.75, 0.75, 0.75;
+    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+
+    // Reset stress
+    stress.setZero();
+    // Compute updated stress
+    stress = material->compute_stress(stress, strain, particle.get());
 
     // Check stressees
     REQUIRE(stress(0) == Approx(1.92307692307333e+04).epsilon(Tolerance));

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -1087,7 +1087,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Assign material
     unsigned mid = 0;
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(mid));
+        "LinearElastic3D", std::move(mid));
 
     // Initialise material
     Json jmaterial;
@@ -1349,7 +1349,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     unsigned mid = 0;
     auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
-        "LinearElastic", std::move(mid));
+        "LinearElastic3D", std::move(mid));
     REQUIRE(material->id() == 0);
 
     // Initialise material

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -421,8 +421,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Assign material
     unsigned mid = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
-        "LinearElastic", std::move(mid));
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic2D", std::move(mid));
 
     // Initialise material
     Json jmaterial;
@@ -652,8 +652,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
 
     unsigned mid = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
-        "LinearElastic", std::move(mid));
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
+        "LinearElastic2D", std::move(mid));
     REQUIRE(material->id() == 0);
 
     // Initialise material
@@ -1086,7 +1086,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     // Assign material
     unsigned mid = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(mid));
 
     // Initialise material
@@ -1348,7 +1348,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
 
     unsigned mid = 0;
-    auto material = Factory<mpm::Material, unsigned>::instance()->create(
+    auto material = Factory<mpm::Material<Dim>, unsigned>::instance()->create(
         "LinearElastic", std::move(mid));
     REQUIRE(material->id() == 0);
 


### PR DESCRIPTION
* Add support to pass a const pointer to the ParticleBase. This allows to call any const functions required by the material.

* An additional boolean `property_handle` function is used to switch between `compute_stress` functions which need handle or not.