### PR TITLE
:computer: Add option to compile without tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_EXPORT_COMPILE_COMMANDS=On ..
             make -j4
-            ctest -VV
       # Clang-6.0
       - run:
           name: Clang-6.0 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
 endif()
 
+# CMake seems to have no way to enable/disable testing per subproject,
+# so we provide an option similar to BUILD_TESTING, but just for MPM.
+option(MPM_BUILD_TESTING "enable testing for mpm" ON)
 
 # CMake Modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -93,49 +96,54 @@ add_executable(mpm
 )
 
 # Unit test
-SET(test_src
-  ${mpm_SOURCE_DIR}/src/affine_transform.cc
-  ${mpm_SOURCE_DIR}/src/cell.cc
-  ${mpm_SOURCE_DIR}/src/io.cc
-  ${mpm_SOURCE_DIR}/src/logger.cc
-  ${mpm_SOURCE_DIR}/src/material.cc
-  ${mpm_SOURCE_DIR}/src/mpm.cc
-  ${mpm_SOURCE_DIR}/src/node.cc
-  ${mpm_SOURCE_DIR}/src/particle.cc
-  ${mpm_SOURCE_DIR}/src/read_mesh.cc
-  ${mpm_SOURCE_DIR}/src/element.cc
-  ${mpm_SOURCE_DIR}/src/vtk_writer.cc
-  ${mpm_SOURCE_DIR}/tests/cell_container_test.cc
-  ${mpm_SOURCE_DIR}/tests/cell_test.cc
-  ${mpm_SOURCE_DIR}/tests/hexahedron_element_test.cc
-  ${mpm_SOURCE_DIR}/tests/hex_quadrature_test.cc  
-  ${mpm_SOURCE_DIR}/tests/io_test.cc
-  ${mpm_SOURCE_DIR}/tests/material/bingham_test.cc
-  ${mpm_SOURCE_DIR}/tests/material/linear_elastic_test.cc
-  ${mpm_SOURCE_DIR}/tests/mesh_test.cc
-  ${mpm_SOURCE_DIR}/tests/mpm_explicit_usf_test.cc
-  ${mpm_SOURCE_DIR}/tests/mpm_explicit_usf_unitcell_test.cc
-  ${mpm_SOURCE_DIR}/tests/mpm_explicit_usl_test.cc
-  ${mpm_SOURCE_DIR}/tests/mpm_explicit_usl_unitcell_test.cc
-  ${mpm_SOURCE_DIR}/tests/node_container_test.cc
-  ${mpm_SOURCE_DIR}/tests/node_map_test.cc
-  ${mpm_SOURCE_DIR}/tests/node_test.cc
-  ${mpm_SOURCE_DIR}/tests/particle_container_test.cc
-  ${mpm_SOURCE_DIR}/tests/particle_test.cc
-  ${mpm_SOURCE_DIR}/tests/quadrilateral_element_test.cc
-  ${mpm_SOURCE_DIR}/tests/quad_quadrature_test.cc    
-  ${mpm_SOURCE_DIR}/tests/read_mesh_ascii_test.cc
-  ${mpm_SOURCE_DIR}/tests/write_mesh_particles.cc
-  ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
-  ${mpm_SOURCE_DIR}/tests/test_main.cc
-)   
-add_executable(mpmtest
-  ${test_src}
-)
-add_test(NAME mpmtest COMMAND $<TARGET_FILE:mpmtest>)
-enable_testing()
+if(MPM_BUILD_TESTING)
+  SET(test_src
+    ${mpm_SOURCE_DIR}/src/affine_transform.cc
+    ${mpm_SOURCE_DIR}/src/cell.cc
+    ${mpm_SOURCE_DIR}/src/io.cc
+    ${mpm_SOURCE_DIR}/src/logger.cc
+    ${mpm_SOURCE_DIR}/src/material.cc
+    ${mpm_SOURCE_DIR}/src/mpm.cc
+    ${mpm_SOURCE_DIR}/src/node.cc
+    ${mpm_SOURCE_DIR}/src/particle.cc
+    ${mpm_SOURCE_DIR}/src/read_mesh.cc
+    ${mpm_SOURCE_DIR}/src/element.cc
+    ${mpm_SOURCE_DIR}/src/vtk_writer.cc
+    ${mpm_SOURCE_DIR}/tests/cell_container_test.cc
+    ${mpm_SOURCE_DIR}/tests/cell_test.cc
+    ${mpm_SOURCE_DIR}/tests/hexahedron_element_test.cc
+    ${mpm_SOURCE_DIR}/tests/hex_quadrature_test.cc  
+    ${mpm_SOURCE_DIR}/tests/io_test.cc
+    ${mpm_SOURCE_DIR}/tests/material/bingham_test.cc
+    ${mpm_SOURCE_DIR}/tests/material/linear_elastic_test.cc
+    ${mpm_SOURCE_DIR}/tests/mesh_test.cc
+    ${mpm_SOURCE_DIR}/tests/mpm_explicit_usf_test.cc
+    ${mpm_SOURCE_DIR}/tests/mpm_explicit_usf_unitcell_test.cc
+    ${mpm_SOURCE_DIR}/tests/mpm_explicit_usl_test.cc
+    ${mpm_SOURCE_DIR}/tests/mpm_explicit_usl_unitcell_test.cc
+    ${mpm_SOURCE_DIR}/tests/node_container_test.cc
+    ${mpm_SOURCE_DIR}/tests/node_map_test.cc
+    ${mpm_SOURCE_DIR}/tests/node_test.cc
+    ${mpm_SOURCE_DIR}/tests/particle_container_test.cc
+    ${mpm_SOURCE_DIR}/tests/particle_test.cc
+    ${mpm_SOURCE_DIR}/tests/quadrilateral_element_test.cc
+    ${mpm_SOURCE_DIR}/tests/quad_quadrature_test.cc    
+    ${mpm_SOURCE_DIR}/tests/read_mesh_ascii_test.cc
+    ${mpm_SOURCE_DIR}/tests/write_mesh_particles.cc
+    ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
+    ${mpm_SOURCE_DIR}/tests/test_main.cc
+  )   
+  add_executable(mpmtest
+    ${test_src}
+  )
+  add_test(NAME mpmtest COMMAND $<TARGET_FILE:mpmtest>)
+  enable_testing()
+endif()
 
 # Coverage
 find_package(codecov)
 add_coverage(mpm)
-add_coverage(mpmtest)
+
+if(MPM_BUILD_TESTING)
+  add_coverage(mpmtest)
+endif()

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ dnf install -y boost boost-devel clang cmake cppcheck eigen3-devel findutils gcc
 
 1. Run `make clean && make -jN` (where N is the number of cores).
 
+### Compile without tests
+
+To compile without tests run: `mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DMPM_BUILD_TESTING=off /path/to/CMakeLists.txt`.
+
+
 ### Run tests
 
 0. Run `./mpmtest -s` (for a verbose output) or `ctest -VV`.
@@ -86,6 +91,3 @@ Where:
 ## References
 * [Aspect](https://github.com/geodynamics/aspect)
 * [Dealii](https://github.com/dealii/dealii)
-
-
-


### PR DESCRIPTION
Adds an option to disable compiling tests can be done using `-DMPM_BUILD_TESTS=off` in CMake