### PR TITLE
:rocket: Enable faster compilation with Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/src/read_mesh.cc
     ${mpm_SOURCE_DIR}/src/element.cc
     ${mpm_SOURCE_DIR}/src/vtk_writer.cc
+    ${mpm_SOURCE_DIR}/tests/test_main.cc
     ${mpm_SOURCE_DIR}/tests/cell_container_test.cc
     ${mpm_SOURCE_DIR}/tests/cell_test.cc
     ${mpm_SOURCE_DIR}/tests/hexahedron_element_test.cc
@@ -131,7 +132,6 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/read_mesh_ascii_test.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
-    ${mpm_SOURCE_DIR}/tests/test_main.cc
   )   
   add_executable(mpmtest
     ${test_src}

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -1,14 +1,3 @@
-#define CATCH_CONFIG_RUNNER
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_FAST_COMPILE
 #include "catch.hpp"
-
-int main(int argc, char* argv[]) {
-  Catch::Session session;
-
-  // Let Catch (using Clara) parse the command line
-  int returnCode = session.applyCommandLine(argc, argv);
-  if (returnCode != 0)  // Indicates a command line error
-    return returnCode;
-
-  int result = session.run();
-  return result;
-}


### PR DESCRIPTION
Using `#define CATCH_CONFIG_FAST_COMPILE` to enable faster Catch compilation