### PR TITLE
:checkered_flag: Update particle position from nodal velocity fixes #203

### DIFF
--- a/include/geometry.h
+++ b/include/geometry.h
@@ -1,9 +1,6 @@
 #ifndef MPM_GEOMETRY_H_
 #define MPM_GEOMETRY_H_
 
-#include <limits>
-#include <memory>
-
 #include "Eigen/Dense"
 
 namespace mpm {
@@ -17,19 +14,19 @@ class Geometry {
   //! Constructor
   Geometry() = default;
 
-  //! Return the inverse Euler rotation matrix for an orthogonal axis coordinate
-  //! system \param[in] angles Rotation angles depending on the dimension
+  //! Compute the inverse Euler rotation matrix for an orthogonal axis
+  //! coordinate system \param[in] angles Rotation angles depending on the
+  //! dimension
   Eigen::Matrix<double, Tdim, Tdim> inverse_rotation_matrix(
       const Eigen::Matrix<double, Tdim, 1>& angles) const;
 
-  //! Return the angle between two vectors in radians
+  //! Compute the angle between two vectors in radians
   //! \param[in] vector_a First vector
-  //! \param[in] vecotr_b Second vector
+  //! \param[in] vector_b Second vector
   const double angle_between_vectors(
       const Eigen::Matrix<double, Tdim, 1>& vector_a,
       const Eigen::Matrix<double, Tdim, 1>& vector_b);
-
-};  // Geometry class
+};
 }  // namespace mpm
 
 #include "geometry.tcc"

--- a/include/geometry.tcc
+++ b/include/geometry.tcc
@@ -47,7 +47,7 @@ inline Eigen::Matrix<double, 3, 3> mpm::Geometry<3>::inverse_rotation_matrix(con
   return rotation_matrix.inverse();
 }
 
-//! Return the angle between two vectors in radians
+//! Compute the angle between two vectors in radians
 template <unsigned Tdim>
 inline const double mpm::Geometry<Tdim>::angle_between_vectors(
     const Eigen::Matrix<double, Tdim, 1>& vector_a,

--- a/include/particle.h
+++ b/include/particle.h
@@ -171,6 +171,11 @@ class Particle : public ParticleBase<Tdim> {
   //! \param[in] dt Analysis time step
   bool compute_updated_position(unsigned phase, double dt) override;
 
+  //! Compute updated position of the particle based on nodal velocity
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] dt Analysis time step
+  bool compute_updated_position_velocity(unsigned phase, double dt) override;
+
  private:
   //! particle id
   using ParticleBase<Tdim>::id_;

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -393,14 +393,43 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
-      // Get interpolated nodal velocity
+      // Get interpolated nodal acceleration
       Eigen::Matrix<double, Tdim, 1> acceleration =
           cell_->interpolate_nodal_acceleration(this->shapefn_, phase);
 
-      // Update particle velocity to interpolated nodal velocity
+      // Update particle velocity from interpolated nodal acceleration
       this->velocity_.col(phase) += acceleration * dt;
 
       // New position  current position + velocity * dt
+      this->coordinates_ += this->velocity_.col(phase) * dt;
+    } else {
+      throw std::runtime_error(
+          "Cell is not initialised! "
+          "cannot compute updated coordinates of the particle");
+    }
+  } catch (std::exception& exception) {
+    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
+    status = false;
+  }
+  return status;
+}
+
+// Compute updated position of the particle based on nodal velocity
+template <unsigned Tdim, unsigned Tnphases>
+bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
+    unsigned phase, double dt) {
+  bool status = true;
+  try {
+    // Check if particle has a valid cell ptr
+    if (cell_ != nullptr) {
+      // Get interpolated nodal velocity
+      Eigen::Matrix<double, Tdim, 1> velocity =
+          cell_->interpolate_nodal_velocity(this->shapefn_, phase);
+
+      // Update particle velocity to interpolated nodal velocity
+      this->velocity_.col(phase) += velocity;
+
+      // New position current position + velocity * dt
       this->coordinates_ += this->velocity_.col(phase) * dt;
     } else {
       throw std::runtime_error(

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -151,6 +151,9 @@ class ParticleBase {
   //! Compute updated position
   virtual bool compute_updated_position(unsigned phase, double dt) = 0;
 
+  //! Compute updated position based on nodal velocity
+  virtual bool compute_updated_position_velocity(unsigned phase, double dt) = 0;
+
  protected:
   //! particleBase id
   Index id_{std::numeric_limits<Index>::max()};

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -431,6 +431,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->compute_reference_location() == false);
     // Compute updated particle location should fail
     REQUIRE(particle->compute_updated_position(phase, dt) == false);
+    // Compute updated particle location from nodal velocity should fail
+    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
     // Compute volume
     REQUIRE(particle->compute_volume() == false);
 
@@ -698,6 +700,24 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // TODO: Check coords
     coords << 0.75, .7519;
     // coords << 0.75, .6519;  // (0.75 - 0.0981)
+    // Check particle coordinates
+    coordinates = particle->coordinates();
+    for (unsigned i = 0; i < coordinates.size(); ++i)
+      REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
+
+    // Compute updated particle location from nodal velocity
+    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == true);
+    // Check particle velocity
+    // TODO: Check velocity
+    velocity << 0., 0.913;
+    //  velocity << 0., -0.981;
+    for (unsigned i = 0; i < velocity.size(); ++i)
+      REQUIRE(particle->velocity(Phase)(i) ==
+              Approx(velocity(i)).epsilon(Tolerance));
+
+    // Updated particle coordinate
+    // TODO: Check coords
+    coords << 0.75, .8432;
     // Check particle coordinates
     coordinates = particle->coordinates();
     for (unsigned i = 0; i < coordinates.size(); ++i)
@@ -1156,6 +1176,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(particle->compute_reference_location() == false);
     // Compute updated particle location should fail
     REQUIRE(particle->compute_updated_position(phase, dt) == false);
+    // Compute updated particle location from nodal velocity should fail
+    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
     // Compute volume
     REQUIRE(particle->compute_volume() == false);
 
@@ -1457,6 +1479,23 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // TODO: Check particle position
     // Updated particle coordinate
     coords << 1.5, 1.6, 1.6019;
+    // Check particle coordinates
+    coordinates = particle->coordinates();
+    for (unsigned i = 0; i < coordinates.size(); ++i)
+      REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
+
+    // Compute updated particle location based on nodal velocity
+    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == true);
+    // TODO: Check particle velocity
+    // Check particle velocity
+    velocity << 0., 6.875, 11.788;
+    for (unsigned i = 0; i < velocity.size(); ++i)
+      REQUIRE(particle->velocity(Phase)(i) ==
+              Approx(velocity(i)).epsilon(Tolerance));
+
+    // TODO: Check particle position
+    // Updated particle coordinate
+    coords << 1.5, 2.2875, 2.7807;
     // Check particle coordinates
     coordinates = particle->coordinates();
     for (unsigned i = 0; i < coordinates.size(); ++i)


### PR DESCRIPTION
Fixes #203 
For dynamic explicit, particle position can be updated based on nodal acceleration, while for a quasi-static condition the particle position can be updated from the nodal velocity. Updating based on nodal acceleration increases the rate at which stresses develop. 