### PR TITLE
Change registration name of element

### DIFF
--- a/src/element.cc
+++ b/src/element.cc
@@ -5,18 +5,18 @@
 
 // Quadrilateral 4-noded element
 static Register<mpm::Element<2>, mpm::QuadrilateralElement<2, 4>> quad4(
-    "ED2Q4");
+    "E2DQ4");
 
 // Quadrilateral 8-noded element
 static Register<mpm::Element<2>, mpm::QuadrilateralElement<2, 8>> quad8(
-    "ED2Q8");
+    "E2DQ8");
 
 // Quadrilateral 9-noded element
 static Register<mpm::Element<2>, mpm::QuadrilateralElement<2, 9>> quad9(
-    "ED2Q9");
+    "E2DQ9");
 
 // Hexahedron 8-noded element
-static Register<mpm::Element<3>, mpm::HexahedronElement<3, 8>> hex8("ED3H8");
+static Register<mpm::Element<3>, mpm::HexahedronElement<3, 8>> hex8("E3DH8");
 
 // Hexahedron 20-noded element
-static Register<mpm::Element<3>, mpm::HexahedronElement<3, 20>> hex20("ED3H20");
+static Register<mpm::Element<3>, mpm::HexahedronElement<3, 20>> hex20("E3DH20");

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -27,7 +27,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
   // Shape function
   // 4-noded quadrilateral shape functions
   std::shared_ptr<mpm::Element<Dim>> element =
-      Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+      Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
   Eigen::Vector2d coords;
   coords.setZero();
@@ -242,7 +242,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
         // 4-noded quadrilateral shape functions
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+            Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
         mpm::Index id = 0;
         auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
@@ -316,7 +316,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
         // 4-noded quadrilateral shape functions
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+            Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
         mpm::Index id = 0;
         auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
@@ -361,7 +361,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     SECTION("Check 4-noded Quadrilateral") {
       // 4-noded quadrilateral shape functions
       std::shared_ptr<mpm::Element<Dim>> element =
-          Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+          Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
       auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
       REQUIRE(cell->nfunctions() == 4);
 
@@ -373,7 +373,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
       // 8-noded quadrilateral shape functions
       const unsigned nnodes = 8;
       std::shared_ptr<mpm::Element<Dim>> element =
-          Factory<mpm::Element<Dim>>::instance()->create("ED2Q8");
+          Factory<mpm::Element<Dim>>::instance()->create("E2DQ8");
       auto cell = std::make_shared<mpm::Cell<Dim>>(id, nnodes, element);
       REQUIRE(cell->nfunctions() == 8);
     }
@@ -382,7 +382,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
       // 9-noded quadrilateral shape functions
       const unsigned nnodes = 9;
       std::shared_ptr<mpm::Element<Dim>> element =
-          Factory<mpm::Element<Dim>>::instance()->create("ED2Q9");
+          Factory<mpm::Element<Dim>>::instance()->create("E2DQ9");
       auto cell = std::make_shared<mpm::Cell<Dim>>(id, nnodes, element);
       REQUIRE(cell->nfunctions() == 9);
     }
@@ -456,7 +456,7 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
     // 4-noded quadrilateral shape functions
     std::shared_ptr<mpm::Element<Dim>> element =
-        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+        Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
     // Local coordinate of a particle
     Eigen::Vector2d xi = Eigen::Vector2d::Zero();
@@ -796,7 +796,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
   // 8-noded hexahedron shape functions
   std::shared_ptr<mpm::Element<Dim>> element =
-      Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+      Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
   //! Check Cell IDs
   SECTION("Check cell ids") {
@@ -1023,7 +1023,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
         // 8-noded hexahedron shape functions
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+            Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
         mpm::Index id = 0;
         auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
@@ -1114,7 +1114,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
         // 8-noded hexahedron shape functions
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+            Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
         // Cell 1
         mpm::Index id1 = 0;
@@ -1243,7 +1243,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
     SECTION("Check 8-noded Hexahedron") {
       // 8-noded hexahedron shape functions
       std::shared_ptr<mpm::Element<Dim>> element =
-          Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+          Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
       auto cell = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
       REQUIRE(cell->nfunctions() == 8);
@@ -1257,7 +1257,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
       // 20-noded hexahedron shape functions
       const unsigned nnodes = 20;
       std::shared_ptr<mpm::Element<Dim>> element =
-          Factory<mpm::Element<Dim>>::instance()->create("ED3H20");
+          Factory<mpm::Element<Dim>>::instance()->create("E3DH20");
 
       auto cell = std::make_shared<mpm::Cell<Dim>>(id, nnodes, element);
       REQUIRE(cell->nfunctions() == 20);
@@ -1361,7 +1361,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
     // 8-noded hexahedron shape functions
     std::shared_ptr<mpm::Element<Dim>> element =
-        Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+        Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
     //! Check Cell IDs
     mpm::Index id = 0;
@@ -1432,7 +1432,7 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
     // 8-noded hexahedron shape functions
     std::shared_ptr<mpm::Element<Dim>> element =
-        Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+        Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
     //! Check Cell IDs
     mpm::Index id = 0;

--- a/tests/io_test.cc
+++ b/tests/io_test.cc
@@ -24,7 +24,7 @@ TEST_CASE("IO is checked for input parsing", "[IO][JSON]") {
           {"traction", "traction.txt"}}},
         {"mesh",
          {{"mesh_reader", "Ascii3D"},
-          {"cell_type", "ED3H8"},
+          {"cell_type", "E3DH8"},
           {"particle_type", "P3D"}}},
         {"materials",
          {{{"id", 0},

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
     std::shared_ptr<mpm::Element<Dim>> element =
-        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+        Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
     auto cell = std::make_shared<mpm::Cell<Dim>>(cell_id, Nnodes, element);
 
@@ -215,7 +215,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
     std::shared_ptr<mpm::Element<Dim>> shapefn =
-        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+        Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
     node0->assign_velocity_constraint(0, 0.02);
     node0->assign_velocity_constraint(1, 0.03);
@@ -313,7 +313,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
 
     std::shared_ptr<mpm::Element<Dim>> shapefn =
-        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+        Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
     node0->assign_velocity_constraint(0, 2);
     node0->assign_velocity_constraint(1, 3);
@@ -482,7 +482,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(7, coords);
 
     std::shared_ptr<mpm::Element<Dim>> shapefn =
-        Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+        Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
     auto cell = std::make_shared<mpm::Cell<Dim>>(cell_id, Nnodes, shapefn);
 
@@ -591,7 +591,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(7, coords);
 
     std::shared_ptr<mpm::Element<Dim>> shapefn =
-        Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+        Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
     node0->assign_velocity_constraint(0, 0.02);
     node0->assign_velocity_constraint(1, 0.03);
@@ -705,7 +705,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
         std::make_shared<mpm::Node<Dim, Dof, Nphases>>(7, coords);
 
     std::shared_ptr<mpm::Element<Dim>> shapefn =
-        Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+        Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
     node0->assign_velocity_constraint(0, 2);
     node0->assign_velocity_constraint(1, 3);

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -25,7 +25,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
 
   // 4-noded quadrilateral element
   std::shared_ptr<mpm::Element<Dim>> element =
-      Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+      Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
   //! Check Mesh IDs
   SECTION("Check mesh ids") {
@@ -448,7 +448,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                                                    {1, 4, 5, 2}};
         // Assign 4-noded quadrilateral element to cell
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+            Factory<mpm::Element<Dim>>::instance()->create("E2DQ4");
 
         // Global cell index
         mpm::Index gcid = 0;
@@ -660,7 +660,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
 
   // 8-noded hexahedron element
   std::shared_ptr<mpm::Element<Dim>> element =
-      Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+      Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
   //! Check Mesh IDs
   SECTION("Check mesh ids") {
@@ -1081,7 +1081,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                                                    {1, 8, 9, 2, 5, 10, 11, 6}};
         // Assign 8-noded hexahedron element to cell
         std::shared_ptr<mpm::Element<Dim>> element =
-            Factory<mpm::Element<Dim>>::instance()->create("ED3H8");
+            Factory<mpm::Element<Dim>>::instance()->create("E3DH8");
 
         // Global cell index
         mpm::Index gcid = 0;

--- a/tests/write_mesh_particles.cc
+++ b/tests/write_mesh_particles.cc
@@ -9,7 +9,7 @@ bool write_json(unsigned dim, bool resume, const std::string& file_name) {
   std::string dimension = "2d";
   auto particle_type = "P2D";
   auto node_type = "N2D";
-  auto cell_type = "ED2Q4";
+  auto cell_type = "E2DQ4";
   auto mesh_reader = "Ascii2D";
   std::string material = "LinearElastic2D";
   std::vector<double> gravity{{0., -9.81}};
@@ -19,7 +19,7 @@ bool write_json(unsigned dim, bool resume, const std::string& file_name) {
     dimension = "3d";
     particle_type = "P3D";
     node_type = "N3D";
-    cell_type = "ED3H8";
+    cell_type = "E3DH8";
     mesh_reader = "Ascii3D";
     material = "LinearElastic3D";
     gravity.clear();

--- a/tests/write_mesh_particles_unitcell.cc
+++ b/tests/write_mesh_particles_unitcell.cc
@@ -9,7 +9,7 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
   std::string dimension = "2d";
   auto particle_type = "P2D";
   auto node_type = "N2D";
-  auto cell_type = "ED2Q4";
+  auto cell_type = "E2DQ4";
   auto mesh_reader = "Ascii2D";
   std::string material = "LinearElastic2D";
   std::vector<double> gravity{{0., -9.81}};
@@ -19,7 +19,7 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
     dimension = "3d";
     particle_type = "P3D";
     node_type = "N3D";
-    cell_type = "ED3H8";
+    cell_type = "E3DH8";
     mesh_reader = "Ascii3D";
     material = "LinearElastic3D";
     gravity.clear();


### PR DESCRIPTION
Since `node` uses registration name of `N2D` and `N3D` and `particle` uses `P2D` and `P3D`, it makes more sense for `elements` to use `E2D**` and `E3D**` instead of `ED2**` and `ED3**`

Thus I have changed them accordingly