### PR TITLE
:rocket: Enable Eigen OpenMP parallelisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,15 @@ if (HDF5_FOUND)
   add_definitions(${HDF5_DEFINITIONS})
 endif()
 
+# OpenMP
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  endif()
+endif()
+
 # TBB
 find_package(TBB REQUIRED)
 add_definitions(${TBB_DEFINITIONS})


### PR DESCRIPTION
Compiling with `-fopenmp` on a C++11 compatible compiler will trigger parallel version of Eigen