### PR TITLE
Conserve mass but change volume

### DIFF
--- a/include/particle.h
+++ b/include/particle.h
@@ -235,6 +235,8 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::VectorXd shapefn_;
   //! B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix_;
+  //! Density correction because of volume change
+  double density_correction_;
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Particle class

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -211,8 +211,14 @@ bool mpm::Particle<Tdim, Tnphases>::compute_volume() {
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
-      // Volume of the cell / # of particles
-      this->assign_volume(cell_->volume() / cell_->nparticles());
+      // Check if volume has been initialized
+      if (this->volume_ != std::numeric_limits<double>::max()) {
+        // new volume = current volume * (1 + dvolumetric strain)
+        this->assign_volume(this->volume_ * (1 + (this->dstrain_.head(3)).sum()));
+      } else {
+        // Volume of the cell / # of particles
+        this->assign_volume(cell_->volume() / cell_->nparticles());   
+      } 
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -208,17 +208,24 @@ void mpm::Particle<Tdim, Tnphases>::assign_volume(double volume) {
 template <unsigned Tdim, unsigned Tnphases>
 bool mpm::Particle<Tdim, Tnphases>::compute_volume() {
   bool status = true;
+  // Assume one phase only for now
+  const unsigned phase = 0;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Check if volume has been initialized
       if (this->volume_ != std::numeric_limits<double>::max()) {
         // new volume = current volume * (1 + dvolumetric strain)
-        this->assign_volume(this->volume_ * (1 + (this->dstrain_.head(3)).sum()));
+        this->assign_volume(this->volume_ *
+                            (1 + (this->dstrain_.head(3)).sum()));
+        // density correction = current density / density from material
+        density_correction_ =
+            mass_(phase) / volume_ / material_->property("density");
       } else {
         // Volume of the cell / # of particles
-        this->assign_volume(cell_->volume() / cell_->nparticles());   
-      } 
+        this->assign_volume(cell_->volume() / cell_->nparticles());
+        density_correction_ = 1;
+      }
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "
@@ -239,7 +246,8 @@ bool mpm::Particle<Tdim, Tnphases>::compute_mass(unsigned phase) {
     // Check if particle volume is set and material ptr is valid
     if (volume_ != std::numeric_limits<double>::max() && material_ != nullptr) {
       // Mass = volume of particle * density
-      this->mass_(phase) = volume_ * material_->property("density");
+      this->mass_(phase) =
+          volume_ * material_->property("density") * density_correction_;
     } else {
       throw std::runtime_error(
           "Cell is not initialised! or material is invalid"


### PR DESCRIPTION
- [x] Change volume computation, using volumetric strain
- [x] I don't want to change `material`, so I add a private variable in `particle` called `density_correction_` so that `density_correction_ * density_from_material = density_updated`. 
- [x] Update the compute mass functions accordingly
- [ ] Update test functions 

This has been tested in 2d, with the material points crossing the cell. 