### PR TITLE
:fire: Remove analysis flag from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,19 @@ To compile without tests run: `mkdir build && cd build && cmake -DCMAKE_BUILD_TY
 The CB-Geo MPM code uses a `JSON` file for input configuration. To run the mpm code:
 
 ```
-./mpm  -a <analysis> [-i <input_file>] -f <working_dir> [--] [--version]
+./mpm  -f <working_dir> [-i <input_file>] [--] [--version]
        [-h]
+```
+
+For example:
+
+```
+./mpm -f ./mpm/3d-landslide/ -i mpm-usf-3d.json
 ```
 
 Where:
 
 ```
-   -a <analysis>,  --analysis <analysis>
-     (required)  MPM analysis 
-     (MPMExplicitUSF3D / MPMExplicitUSF2D / MPMExplicitUSL3D / MPMExplicitUSL2D)
 
    -i <input_file>,  --input_file <input_file>
      Input JSON file [mpm.json]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The CB-Geo MPM code uses a `JSON` file for input configuration. To run the mpm c
 For example:
 
 ```
-./mpm -f ./mpm/3d-landslide/ -i mpm-usf-3d.json
+./mpm -f /path/to/input-dir/ -i mpm-usf-3d.json
 ```
 
 Where:

--- a/include/io.h
+++ b/include/io.h
@@ -34,7 +34,9 @@ class IO {
   bool check_file(const std::string& file_name);
 
   //! Return analysis
-  std::string analysis_type() const { return analysis_; }
+  std::string analysis_type() const {
+    return json_["analysis"]["type"].template get<std::string>();
+  }
 
   //! Return json analysis object
   Json analysis() const { return json_["analysis"]; }
@@ -67,8 +69,6 @@ class IO {
   std::string input_file_{"mpm.json"};
   //! Input JSON object
   Json json_;
-  //! Analysis
-  std::string analysis_;
   //! Logger
   std::shared_ptr<spdlog::logger> console_;
 };

--- a/src/io.cc
+++ b/src/io.cc
@@ -19,12 +19,6 @@ mpm::IO::IO(int argc, char** argv) {
                                            "mpm.json", "input_file");
     cmd.add(input_arg);
 
-    // Analysis
-    TCLAP::ValueArg<std::string> analysis_arg(
-        "a", "analysis", "MPM analysis", true, "MPMExplicit3D", "analysis");
-
-    cmd.add(analysis_arg);
-
     // Parse arguments
     cmd.parse(argc, argv);
 
@@ -34,8 +28,6 @@ mpm::IO::IO(int argc, char** argv) {
     // Set input file if the optional argument is not empty
     input_file_ = input_arg.getValue();
 
-    // Set Analysis Type
-    analysis_ = analysis_arg.getValue();
   } catch (TCLAP::ArgException& except) {  // catch any exceptions
     console_->error("error: {}  for arg {}", except.error(), except.argId());
   }

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -5,7 +5,8 @@
 namespace mpm_test {
 
 // Write JSON Configuration file
-bool write_json(unsigned dim, bool resume, const std::string& file_name);
+bool write_json(unsigned dim, bool resume, const std::string& analysis,
+                const std::string& file_name);
 
 // Write Mesh file in 2D
 bool write_mesh_2d();

--- a/tests/include/write_mesh_particles_unitcell.h
+++ b/tests/include/write_mesh_particles_unitcell.h
@@ -5,7 +5,8 @@
 namespace mpm_test {
 
 // Write JSON Configuration file
-bool write_json_unitcell(unsigned dim, const std::string& file_name);
+bool write_json_unitcell(unsigned dim, const std::string& analysis,
+                         const std::string& file_name);
 
 // Write Mesh file in 2D
 bool write_mesh_2d_unitcell();

--- a/tests/io_test.cc
+++ b/tests/io_test.cc
@@ -38,7 +38,8 @@ TEST_CASE("IO is checked for input parsing", "[IO][JSON]") {
            {"youngs_modulus", 1.5E+6},
            {"poisson_ratio", 0.25}}}},
         {"analysis",
-         {{"dt", 0.001},
+         {{"type", "MPMExplicitUSF3D"},
+          {"dt", 0.001},
           {"nsteps", 1000},
           {"gravity", true},
           {"boundary_friction", 0.5},
@@ -53,10 +54,9 @@ TEST_CASE("IO is checked for input parsing", "[IO][JSON]") {
     file.close();
 
     // Assign argc and argv to nput arguments of MPM
-    int argc = 7;
+    int argc = 5;
     // clang-format off
     char* argv[] = {(char*)"./mpm",
-                    (char*)"-a",  (char*)"MPMExplicit3D",
                     (char*)"-f",  (char*)"./",
                     (char*)"-i",  (char*)"mpm.json"};
     // clang-format on
@@ -65,7 +65,7 @@ TEST_CASE("IO is checked for input parsing", "[IO][JSON]") {
     auto io = std::make_unique<mpm::IO>(argc, argv);
 
     // Check analysis type
-    REQUIRE(io->analysis_type() == "MPMExplicit3D");
+    REQUIRE(io->analysis_type() == "MPMExplicitUSF3D");
 
     // Check cmake JSON object
     REQUIRE(io->file_name("config") == "./mpm.json");

--- a/tests/mpm_explicit_usf_test.cc
+++ b/tests/mpm_explicit_usf_test.cc
@@ -15,8 +15,9 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
+  const std::string analysis = "MPMExplicitUSF2D";
   bool resume = false;
-  bool status = mpm_test::write_json(2, resume, fname);
+  bool status = mpm_test::write_json(2, resume, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -28,10 +29,9 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSF2D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usf-2d.json"};
   // clang-format on
@@ -69,8 +69,9 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usf";
+    const std::string analysis = "MPMExplicitUSF2D";
     bool resume = true;
-    bool status = mpm_test::write_json(2, resume, fname);
+    bool status = mpm_test::write_json(2, resume, analysis, fname);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);
@@ -92,8 +93,9 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
+  const std::string analysis = "MPMExplicitUSF3D";
   const bool resume = false;
-  bool status = mpm_test::write_json(3, resume, fname);
+  bool status = mpm_test::write_json(3, resume, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -105,10 +107,9 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSF3D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usf-3d.json"};
   // clang-format on
@@ -146,8 +147,9 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usf";
+    const std::string analysis = "MPMExplicitUSF3D";
     bool resume = true;
-    bool status = mpm_test::write_json(3, resume, fname);
+    bool status = mpm_test::write_json(3, resume, analysis, fname);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);

--- a/tests/mpm_explicit_usf_unitcell_test.cc
+++ b/tests/mpm_explicit_usf_unitcell_test.cc
@@ -15,7 +15,8 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  bool status = mpm_test::write_json_unitcell(2, fname);
+  const std::string analysis = "MPMExplicitUSF2D";
+  bool status = mpm_test::write_json_unitcell(2, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -27,10 +28,9 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked in unitcells",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSF2D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usf-2d-unitcell.json"};
   // clang-format on
@@ -72,7 +72,8 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  bool status = mpm_test::write_json_unitcell(3, fname);
+  const std::string analysis = "MPMExplicitUSF3D";
+  bool status = mpm_test::write_json_unitcell(3, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -84,10 +85,9 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked in unitcells",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSF3D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usf-3d-unitcell.json"};
   // clang-format on

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -15,8 +15,9 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
+  const std::string analysis = "MPMExplicitUSL2D";
   const bool resume = false;
-  bool status = mpm_test::write_json(2, resume, fname);
+  bool status = mpm_test::write_json(2, resume, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -28,10 +29,9 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSL2D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usl-2d.json"};
   // clang-format on
@@ -69,8 +69,9 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usl";
+    const std::string analysis = "MPMExplicitUSL2D";
     bool resume = true;
-    bool status = mpm_test::write_json(2, resume, fname);
+    bool status = mpm_test::write_json(2, resume, analysis, fname);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);
@@ -92,8 +93,9 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
+  const std::string analysis = "MPMExplicitUSL3D";
   const bool resume = false;
-  bool status = mpm_test::write_json(3, resume, fname);
+  bool status = mpm_test::write_json(3, resume, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -105,10 +107,9 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSL3D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usl-3d.json"};
   // clang-format on
@@ -146,8 +147,9 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usl";
+    const std::string analysis = "MPMExplicitUSL3D";
     bool resume = true;
-    bool status = mpm_test::write_json(3, resume, fname);
+    bool status = mpm_test::write_json(3, resume, analysis, fname);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);

--- a/tests/mpm_explicit_usl_unitcell_test.cc
+++ b/tests/mpm_explicit_usl_unitcell_test.cc
@@ -15,7 +15,8 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  bool status = mpm_test::write_json_unitcell(2, fname);
+  const std::string analysis = "MPMExplicitUSL2D";
+  bool status = mpm_test::write_json_unitcell(2, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -27,10 +28,9 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked in unitcells",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSL2D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usl-2d-unitcell.json"};
   // clang-format on
@@ -72,7 +72,8 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  bool status = mpm_test::write_json_unitcell(3, fname);
+  const std::string analysis = "MPMExplicitUSL3D";
+  bool status = mpm_test::write_json_unitcell(3, analysis, fname);
   REQUIRE(status == true);
 
   // Write Mesh
@@ -84,10 +85,9 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked in unitcells",
   REQUIRE(particle_status == true);
 
   // Assign argc and argv to input arguments of MPM
-  int argc = 7;
+  int argc = 5;
   // clang-format off
   char* argv[] = {(char*)"./mpm",
-                  (char*)"-a",  (char*)"MPMExplicitUSL3D",
                   (char*)"-f",  (char*)"./",
                   (char*)"-i",  (char*)"mpm-explicit-usl-3d-unitcell.json"};
   // clang-format on

--- a/tests/write_mesh_particles.cc
+++ b/tests/write_mesh_particles.cc
@@ -3,7 +3,8 @@
 namespace mpm_test {
 
 // Write JSON Configuration file
-bool write_json(unsigned dim, bool resume, const std::string& file_name) {
+bool write_json(unsigned dim, bool resume, const std::string& analysis,
+                const std::string& file_name) {
   // Make json object with input files
   // 2D
   std::string dimension = "2d";
@@ -50,7 +51,8 @@ bool write_json(unsigned dim, bool resume, const std::string& file_name) {
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},
       {"analysis",
-       {{"dt", 0.001},
+       {{"type", analysis},
+        {"dt", 0.001},
         {"uuid", file_name + "-" + dimension},
         {"nsteps", 10},
         {"gravity", gravity},

--- a/tests/write_mesh_particles_unitcell.cc
+++ b/tests/write_mesh_particles_unitcell.cc
@@ -3,7 +3,8 @@
 namespace mpm_test {
 
 // Write JSON Configuration file
-bool write_json_unitcell(unsigned dim, const std::string& file_name) {
+bool write_json_unitcell(unsigned dim, const std::string& analysis,
+                         const std::string& file_name) {
   // Make json object with input files
   // 2D
   std::string dimension = "2d";
@@ -53,7 +54,8 @@ bool write_json_unitcell(unsigned dim, const std::string& file_name) {
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},
       {"analysis",
-       {{"dt", 0.001},
+       {{"type", analysis},
+        {"dt", 0.001},
         {"nsteps", 10},
         {"gravity", gravity},
         {"boundary_friction", 0.5},


### PR DESCRIPTION
Analysis, previously, was set using the command line flag `-a`, however this loses the information about what type of analysis was run. Hence, the decision to move this to the input JSON file.