### PR TITLE
:computer: Compute particle volume and mass at the start of the step

### DIFF
--- a/include/mpm_explicit_usf.tcc
+++ b/include/mpm_explicit_usf.tcc
@@ -35,6 +35,14 @@ bool mpm::MPMExplicitUSF<Tdim>::solve() {
       std::bind(&mpm::ParticleBase<Tdim>::assign_material,
                 std::placeholders::_1, material));
 
+  // Compute volume
+  meshes_.at(0)->iterate_over_particles(std::bind(
+      &mpm::ParticleBase<Tdim>::compute_volume, std::placeholders::_1));
+
+  // Compute mass
+  meshes_.at(0)->iterate_over_particles(std::bind(
+      &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1, phase));
+
   // Test if checkpoint resume is needed
   bool resume = false;
   if (analysis_.find("resume") != analysis_.end())
@@ -55,13 +63,6 @@ bool mpm::MPMExplicitUSF<Tdim>::solve() {
     meshes_.at(0)->iterate_over_particles(std::bind(
         &mpm::ParticleBase<Tdim>::compute_shapefn, std::placeholders::_1));
 
-    // Compute volume
-    meshes_.at(0)->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_volume, std::placeholders::_1));
-
-    // Compute mass
-    meshes_.at(0)->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1, phase));
     // Assign mass and momentum to nodes
     meshes_.at(0)->iterate_over_particles(
         std::bind(&mpm::ParticleBase<Tdim>::map_mass_momentum_to_nodes,

--- a/include/mpm_explicit_usl.tcc
+++ b/include/mpm_explicit_usl.tcc
@@ -35,6 +35,14 @@ bool mpm::MPMExplicitUSL<Tdim>::solve() {
       std::bind(&mpm::ParticleBase<Tdim>::assign_material,
                 std::placeholders::_1, material));
 
+  // Compute volume
+  meshes_.at(0)->iterate_over_particles(std::bind(
+      &mpm::ParticleBase<Tdim>::compute_volume, std::placeholders::_1));
+
+  // Compute mass
+  meshes_.at(0)->iterate_over_particles(std::bind(
+      &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1, phase));
+
   // Test if checkpoint resume is needed
   bool resume = false;
   if (analysis_.find("resume") != analysis_.end())
@@ -54,13 +62,6 @@ bool mpm::MPMExplicitUSL<Tdim>::solve() {
     meshes_.at(0)->iterate_over_particles(std::bind(
         &mpm::ParticleBase<Tdim>::compute_shapefn, std::placeholders::_1));
 
-    // Compute volume
-    meshes_.at(0)->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_volume, std::placeholders::_1));
-
-    // Compute mass
-    meshes_.at(0)->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1, phase));
     // Assign mass and momentum to nodes
     meshes_.at(0)->iterate_over_particles(
         std::bind(&mpm::ParticleBase<Tdim>::map_mass_momentum_to_nodes,


### PR DESCRIPTION
* Mass conservation is ensured
* Volume is not re-calculate based on the cell volume at each step. Volume and mass of a particle are computed at the initialisation step.