### PR TITLE
:checkered_flag: Update volume based on volumetric strain fixes #176

### DIFF
--- a/include/mpm_explicit_usf.tcc
+++ b/include/mpm_explicit_usf.tcc
@@ -105,6 +105,11 @@ bool mpm::MPMExplicitUSF<Tdim>::solve() {
         std::bind(&mpm::ParticleBase<Tdim>::compute_updated_position,
                   std::placeholders::_1, phase, this->dt_));
 
+    // Iterate over each particle to update particle volume
+    meshes_.at(0)->iterate_over_particles(
+        std::bind(&mpm::ParticleBase<Tdim>::update_volume_strainrate,
+                  std::placeholders::_1, phase, this->dt_));
+
     // Locate particles
     auto unlocatable_particles = meshes_.at(0)->locate_particles_mesh();
 

--- a/include/mpm_explicit_usl.tcc
+++ b/include/mpm_explicit_usl.tcc
@@ -104,6 +104,11 @@ bool mpm::MPMExplicitUSL<Tdim>::solve() {
         std::bind(&mpm::ParticleBase<Tdim>::compute_stress,
                   std::placeholders::_1, phase));
 
+    // Iterate over each particle to update particle volume
+    meshes_.at(0)->iterate_over_particles(
+        std::bind(&mpm::ParticleBase<Tdim>::update_volume_strainrate,
+                  std::placeholders::_1, phase, this->dt_));
+
     // Locate particles
     auto unlocatable_particles = meshes_.at(0)->locate_particles_mesh();
 

--- a/include/particle.h
+++ b/include/particle.h
@@ -90,6 +90,11 @@ class Particle : public ParticleBase<Tdim> {
   //! \param[in] phase Index corresponding to the phase
   bool compute_volume(unsigned phase) override;
 
+  //! Update volume based on centre volumetric strain rate
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] dt Analysis time step
+  bool update_volume_strainrate(unsigned phase, double dt) override;
+
   //! Compute mass as volume * density
   //! \param[in] phase Index corresponding to the phase
   bool compute_mass(unsigned phase) override;
@@ -227,6 +232,8 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::Matrix<double, Tnphases, 1> volumetric_strain_centroid_;
   //! Strain rate
   Eigen::Matrix<double, 6, Tnphases> strain_rate_;
+  //! Strain rate centroid
+  Eigen::Matrix<double, 6, Tnphases> strain_rate_centroid_;
   //! dstrains
   Eigen::Matrix<double, 6, Tnphases> dstrain_;
   //! Velocity

--- a/include/particle.h
+++ b/include/particle.h
@@ -232,8 +232,6 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::Matrix<double, Tnphases, 1> volumetric_strain_centroid_;
   //! Strain rate
   Eigen::Matrix<double, 6, Tnphases> strain_rate_;
-  //! Strain rate centroid
-  Eigen::Matrix<double, 6, Tnphases> strain_rate_centroid_;
   //! dstrains
   Eigen::Matrix<double, 6, Tnphases> dstrain_;
   //! Velocity

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -92,6 +92,9 @@ class ParticleBase {
   //! Compute volume of particle
   virtual bool compute_volume(unsigned phase) = 0;
 
+  //! Update volume based on centre volumetric strain rate
+  virtual bool update_volume_strainrate(unsigned phase, double dt) = 0;
+
   //! Compute mass of particle
   virtual bool compute_mass(unsigned phase) = 0;
 

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -471,7 +471,9 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // Compute updated particle location from nodal velocity should fail
     REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
     // Compute volume
-    REQUIRE(particle->compute_volume(Phase) == false);
+    REQUIRE(particle->compute_volume(phase) == false);
+    // Update volume should fail
+    REQUIRE(particle->update_volume_strainrate(phase, dt) == false);
 
     REQUIRE(particle->assign_cell(cell) == true);
     REQUIRE(cell->status() == true);
@@ -627,6 +629,11 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     const double volumetric_strain = 0.8;
     REQUIRE(particle->volumetric_strain_centroid(phase) ==
             Approx(volumetric_strain).epsilon(Tolerance));
+
+    // Update volume strain rate
+    REQUIRE(particle->volume(phase) == Approx(1.0).epsilon(Tolerance));
+    REQUIRE(particle->update_volume_strainrate(phase, dt) == true);
+    REQUIRE(particle->volume(phase) == Approx(1.8).epsilon(Tolerance));
 
     // Compute stress
     REQUIRE(particle->compute_stress(phase) == true);
@@ -1293,7 +1300,9 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Compute updated particle location from nodal velocity should fail
     REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
     // Compute volume
-    REQUIRE(particle->compute_volume(Phase) == false);
+    REQUIRE(particle->compute_volume(phase) == false);
+    // Update volume should fail
+    REQUIRE(particle->update_volume_strainrate(phase, dt) == false);
 
     REQUIRE(particle->assign_cell(cell) == true);
     REQUIRE(cell->status() == true);
@@ -1469,6 +1478,11 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     const double volumetric_strain = 4.;
     REQUIRE(particle->volumetric_strain_centroid(phase) ==
             Approx(volumetric_strain).epsilon(Tolerance));
+
+    // Update volume strain rate
+    REQUIRE(particle->volume(phase) == Approx(8.0).epsilon(Tolerance));
+    REQUIRE(particle->update_volume_strainrate(phase, dt) == true);
+    REQUIRE(particle->volume(phase) == Approx(40.0).epsilon(Tolerance));
 
     // Compute stress
     REQUIRE(particle->compute_stress(phase) == true);


### PR DESCRIPTION
Update particle volume with strain rate centroid. Density is used only to calculate the particle mass at the start of the time-step. Hence, density is neither stored nor updated in the algorithm. If required, it could be added to `update_volume_strainrate`