### PR TITLE
:checkered_flag: Default shapefn/grad calls with defromation gradient and particle size,  fixes #179

### DIFF
--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -638,7 +638,8 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::transform_real_to_unit_cell(
     if (!guess_nan) xi = affine_guess;
 
     // Shape function
-    const auto sf = element_->shapefn(xi);
+    const auto sf = element_->shapefn(xi, Eigen::Matrix<double, 2, 1>::Zero(),
+                                      Eigen::Matrix<double, 2, 1>::Zero());
 
     // f(x) = p(x) - p, where p is the real point
     Eigen::Matrix<double, 2, 1> fx = (nodal_coords * sf) - point;
@@ -655,10 +656,13 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::transform_real_to_unit_cell(
   for (unsigned iter = 0; iter < max_iterations; ++iter) {
 
     // Calculate Jacobian
-    Eigen::Matrix<double, 2, 2> jacobian = element_->jacobian(xi, unit_cell);
+    Eigen::Matrix<double, 2, 2> jacobian =
+        element_->jacobian(xi, unit_cell, Eigen::Matrix<double, 2, 1>::Zero(),
+                           Eigen::Matrix<double, 2, 1>::Zero());
 
     // Shape function
-    const auto sf = element_->shapefn(xi);
+    const auto sf = element_->shapefn(xi, Eigen::Matrix<double, 2, 1>::Zero(),
+                                      Eigen::Matrix<double, 2, 1>::Zero());
 
     // Residual (f(x))
     // f(x) = p(x) - p, where p is the real point
@@ -726,7 +730,8 @@ inline Eigen::Matrix<double, 3, 1> mpm::Cell<3>::transform_real_to_unit_cell(
     if (!guess_nan) xi = affine_guess;
 
     // Shape function
-    const auto sf = element_->shapefn(xi);
+    const auto sf = element_->shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                                      Eigen::Matrix<double, 3, 1>::Zero());
 
     // f(x) = p(x) - p, where p is the real point
     Eigen::Matrix<double, 3, 1> fx = (nodal_coords * sf) - point;
@@ -742,10 +747,13 @@ inline Eigen::Matrix<double, 3, 1> mpm::Cell<3>::transform_real_to_unit_cell(
   // p(x) is the computed point.
   for (unsigned iter = 0; iter < max_iterations; ++iter) {
     // Calculate Jacobian
-    Eigen::Matrix<double, 3, 3> jacobian = element_->jacobian(xi, unit_cell);
+    Eigen::Matrix<double, 3, 3> jacobian =
+        element_->jacobian(xi, unit_cell, Eigen::Matrix<double, 3, 1>::Zero(),
+                           Eigen::Matrix<double, 3, 1>::Zero());
 
     // Shape function
-    const auto sf = element_->shapefn(xi);
+    const auto sf = element_->shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                                      Eigen::Matrix<double, 3, 1>::Zero());
 
     // Residual f(x)
     Eigen::Matrix<double, 3, 1> residual;
@@ -850,7 +858,9 @@ Eigen::VectorXd mpm::Cell<Tdim>::compute_strain_rate_centroid(unsigned phase) {
   xi_centroid.setZero();
 
   // Get B-Matrix at the centroid
-  auto bmatrix = element_->bmatrix(xi_centroid, this->nodal_coordinates());
+  auto bmatrix = element_->bmatrix(xi_centroid, this->nodal_coordinates(),
+                                   Eigen::Matrix<double, Tdim, 1>::Zero(),
+                                   Eigen::Matrix<double, Tdim, 1>::Zero());
 
   // Define strain rate at centroid
   Eigen::VectorXd strain_rate_centroid;

--- a/include/element.h
+++ b/include/element.h
@@ -36,19 +36,11 @@ class Element {
 
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
-  virtual Eigen::VectorXd shapefn(const VectorDim& xi) const = 0;
-
-  //! Evaluate shape functions at given local coordinates
-  //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   virtual Eigen::VectorXd shapefn(
       const VectorDim& xi, const VectorDim& particle_size,
       const VectorDim& deformation_gradient) const = 0;
-
-  //! Evaluate gradient of shape functions
-  //! \param[in] xi given local coordinates
-  virtual Eigen::MatrixXd grad_shapefn(const VectorDim& xi) const = 0;
 
   //! Evaluate gradient of shape functions
   //! \param[in] xi given local coordinates

--- a/include/element.h
+++ b/include/element.h
@@ -53,13 +53,6 @@ class Element {
   //! Compute Jacobian
   //! \param[in] xi given local coordinates
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval jacobian Jacobian matrix
-  virtual Eigen::Matrix<double, Tdim, Tdim> jacobian(
-      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const = 0;
-
-  //! Compute Jacobian
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval jacobian Jacobian matrix
@@ -67,18 +60,6 @@ class Element {
       const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
       const VectorDim& particle_size,
       const VectorDim& deformation_gradient) const = 0;
-
-  //! Evaluate and return the B-matrix
-  //! \param[in] xi given local coordinates
-  //! \retval bmatrix B matrix
-  virtual std::vector<Eigen::MatrixXd> bmatrix(const VectorDim& xi) const = 0;
-
-  //! Evaluate the B matrix at given local coordinates for a real cell
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval bmatrix B matrix
-  virtual std::vector<Eigen::MatrixXd> bmatrix(
-      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const = 0;
 
   //! Evaluate the B matrix at given local coordinates for a real cell
   //! \param[in] xi given local coordinates

--- a/include/hexahedron_element.h
+++ b/include/hexahedron_element.h
@@ -143,14 +143,6 @@ class HexahedronElement : public Element<Tdim> {
   //! Compute Jacobian
   //! \param[in] xi given local coordinates
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval jacobian Jacobian matrix
-  Eigen::Matrix<double, Tdim, Tdim> jacobian(
-      const Eigen::Matrix<double, 3, 1>& xi,
-      const Eigen::MatrixXd& nodal_coordinates) const override;
-
-  //! Compute Jacobian
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval jacobian Jacobian matrix
@@ -159,19 +151,6 @@ class HexahedronElement : public Element<Tdim> {
       const Eigen::MatrixXd& nodal_coordinates,
       const Eigen::Matrix<double, 3, 1>& particle_size,
       const Eigen::Matrix<double, 3, 1>& deformation_gradient) const override;
-
-  //! Evaluate B matrix at given local coordinates
-  //! \param[in] xi given local coordinates
-  //! \retval bmatrix B matrix
-  std::vector<Eigen::MatrixXd> bmatrix(const VectorDim& xi) const override;
-
-  //! Evaluate the B matrix at given local coordinates for a real cell
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval bmatrix B matrix
-  std::vector<Eigen::MatrixXd> bmatrix(
-      const VectorDim& xi,
-      const Eigen::MatrixXd& nodal_coordinates) const override;
 
   //! Evaluate the B matrix at given local coordinates for a real cell
   //! \param[in] xi given local coordinates

--- a/include/hexahedron_element.h
+++ b/include/hexahedron_element.h
@@ -125,21 +125,11 @@ class HexahedronElement : public Element<Tdim> {
 
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
-  //! \retval shapefn Shape function of a given cell
-  Eigen::VectorXd shapefn(const VectorDim& xi) const override;
-
-  //! Evaluate shape functions at given local coordinates
-  //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval shapefn Shape function of a given cell
   Eigen::VectorXd shapefn(const VectorDim& xi, const VectorDim& particle_size,
                           const VectorDim& deformation_gradient) const override;
-
-  //! Evaluate gradient of shape functions
-  //! \param[in] xi given local coordinates
-  //! \retval grad_shapefn Gradient of shape function of a given cell
-  Eigen::MatrixXd grad_shapefn(const VectorDim& xi) const override;
 
   //! Evaluate gradient of shape functions
   //! \param[in] xi given local coordinates

--- a/include/hexahedron_element.tcc
+++ b/include/hexahedron_element.tcc
@@ -12,12 +12,15 @@
 //!       0_ _ _ _ _ _ 0
 //!     4               5
 
-//! Return shape function of a 8-noded hexahedron
-//! \param[in] xi Coordinates of point of interest
-//! \retval shapefn Shape function of a given cell
+//! Return shape function of a 8-noded hexahedron, with particle size and
+//! deformation gradient
+//! \param[in] xi Coordinates of point of interest \retval
+//! shapefn Shape function of a given cell
 template <>
 inline Eigen::VectorXd mpm::HexahedronElement<3, 8>::shapefn(
-    const Eigen::Matrix<double, 3, 1>& xi) const {
+    const Eigen::Matrix<double, 3, 1>& xi,
+    const Eigen::Matrix<double, 3, 1>& particle_size,
+    const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   // 8-noded
   Eigen::Matrix<double, 8, 1> shapefn;
   shapefn(0) = 0.125 * (1 - xi(0)) * (1 - xi(1)) * (1 - xi(2));
@@ -31,12 +34,15 @@ inline Eigen::VectorXd mpm::HexahedronElement<3, 8>::shapefn(
   return shapefn;
 }
 
-//! Return gradient of shape functions of a 8-noded hexahedron
+//! Return gradient of shape functions of a 8-noded hexahedron, with particle
+//! size and deformation gradient
 //! \param[in] xi Coordinates of point of interest
 //! \retval grad_shapefn Gradient of shape function of a given cell
 template <>
 inline Eigen::MatrixXd mpm::HexahedronElement<3, 8>::grad_shapefn(
-    const Eigen::Matrix<double, 3, 1>& xi) const {
+    const Eigen::Matrix<double, 3, 1>& xi,
+    const Eigen::Matrix<double, 3, 1>& particle_size,
+    const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 8, 3> grad_shapefn;
   grad_shapefn(0, 0) = -0.125 * (1 - xi(1)) * (1 - xi(2));
   grad_shapefn(1, 0) = 0.125 * (1 - xi(1)) * (1 - xi(2));
@@ -102,12 +108,15 @@ inline Eigen::MatrixXd mpm::HexahedronElement<3, 8>::unit_cell_coordinates()
 //!       0_ _ _ 0 _ _ _ 0
 //!     4        16         5
 
-//! Return shape function of a 20-noded hexahedron
+//! Return the shape function of a 20-noded hexahedron, with particle
+//! size and deformation gradient
 //! \param[in] xi Coordinates of point of interest
 //! \retval shapefn Shape function of a given cell
 template <>
 inline Eigen::VectorXd mpm::HexahedronElement<3, 20>::shapefn(
-    const Eigen::Matrix<double, 3, 1>& xi) const {
+    const Eigen::Matrix<double, 3, 1>& xi,
+    const Eigen::Matrix<double, 3, 1>& particle_size,
+    const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 20, 1> shapefn;
   shapefn(0) = -0.125 * (1 - xi(0)) * (1 - xi(1)) * (1 - xi(2)) *
                (2 + xi(0) + xi(1) + xi(2));
@@ -141,12 +150,15 @@ inline Eigen::VectorXd mpm::HexahedronElement<3, 20>::shapefn(
   return shapefn;
 }
 
-//! Return gradient of shape functions of a 20-noded hexahedron
+//! Return gradient of shape functions of a 20-noded hexahedron, with particle
+//! size and deformation gradient
 //! \param[in] xi Coordinates of point of interest
 //! \retval grad_shapefn Gradient of shape function of a given cell
 template <>
 inline Eigen::MatrixXd mpm::HexahedronElement<3, 20>::grad_shapefn(
-    const Eigen::Matrix<double, 3, 1>& xi) const {
+    const Eigen::Matrix<double, 3, 1>& xi,
+    const Eigen::Matrix<double, 3, 1>& particle_size,
+    const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 20, 3> grad_shapefn;
 
   grad_shapefn(0, 0) =
@@ -238,26 +250,6 @@ inline Eigen::MatrixXd mpm::HexahedronElement<3, 20>::grad_shapefn(
   return grad_shapefn;
 }
 
-//! Return shape functions of a Hexahedron Element at a given local
-//! coordinate, with particle size and deformation gradient
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::VectorXd mpm::HexahedronElement<Tdim, Tnfunctions>::shapefn(
-    const Eigen::Matrix<double, Tdim, 1>& xi,
-    const Eigen::Matrix<double, Tdim, 1>& particle_size,
-    const Eigen::Matrix<double, Tdim, 1>& deformation_gradient) const {
-  return this->mpm::HexahedronElement<Tdim, Tnfunctions>::shapefn(xi);
-}
-
-//! Return gradient shape functions of a Hexahedron Element at a given local
-//! coordinate, with particle size and deformation gradient
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::MatrixXd mpm::HexahedronElement<Tdim, Tnfunctions>::grad_shapefn(
-    const Eigen::Matrix<double, Tdim, 1>& xi,
-    const Eigen::Matrix<double, Tdim, 1>& particle_size,
-    const Eigen::Matrix<double, Tdim, 1>& deformation_gradient) const {
-  return this->mpm::HexahedronElement<Tdim, Tnfunctions>::grad_shapefn(xi);
-}
-
 //! Compute Jacobian
 template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::Matrix<double, Tdim, Tdim>
@@ -265,7 +257,9 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const Eigen::Matrix<double, 3, 1>& xi,
         const Eigen::MatrixXd& nodal_coordinates) const {
   // Get gradient shape functions
-  const Eigen::MatrixXd grad_shapefn = this->grad_shapefn(xi);
+  const Eigen::MatrixXd grad_shapefn =
+      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                         Eigen::Matrix<double, 3, 1>::Zero());
   try {
     // Check if dimensions are correct
     if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
@@ -300,7 +294,9 @@ inline std::vector<Eigen::MatrixXd>
     mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
         const VectorDim& xi) const {
   // Get gradient shape functions
-  Eigen::MatrixXd grad_shapefn = this->grad_shapefn(xi);
+  Eigen::MatrixXd grad_shapefn =
+      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                         Eigen::Matrix<double, 3, 1>::Zero());
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;
@@ -328,7 +324,9 @@ inline std::vector<Eigen::MatrixXd>
     mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
         const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
   // Get gradient shape functions
-  Eigen::MatrixXd grad_sf = this->grad_shapefn(xi);
+  Eigen::MatrixXd grad_sf =
+      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                         Eigen::Matrix<double, 3, 1>::Zero());
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;
@@ -388,7 +386,9 @@ inline Eigen::MatrixXd mpm::HexahedronElement<Tdim, Tnfunctions>::mass_matrix(
   Eigen::Matrix<double, Tnfunctions, Tnfunctions> mass_matrix;
   mass_matrix.setZero();
   for (const auto& xi : xi_s) {
-    const Eigen::Matrix<double, Tnfunctions, 1> shape_fn = this->shapefn(xi);
+    const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
+        this->shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                      Eigen::Matrix<double, 3, 1>::Zero());
     mass_matrix += (shape_fn * shape_fn.transpose());
   }
   return mass_matrix;
@@ -416,7 +416,9 @@ inline Eigen::MatrixXd
   laplace_matrix.setZero();
   for (const auto& xi : xi_s) {
     // Get gradient shape functions
-    const Eigen::MatrixXd grad_sf = this->grad_shapefn(xi);
+    const Eigen::MatrixXd grad_sf =
+        this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
+                           Eigen::Matrix<double, 3, 1>::Zero());
 
     // Jacobian dx_i/dxi_j
     const Eigen::Matrix<double, Tdim, Tdim> jacobian =

--- a/include/hexahedron_element.tcc
+++ b/include/hexahedron_element.tcc
@@ -255,7 +255,9 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::Matrix<double, Tdim, Tdim>
     mpm::HexahedronElement<Tdim, Tnfunctions>::jacobian(
         const Eigen::Matrix<double, 3, 1>& xi,
-        const Eigen::MatrixXd& nodal_coordinates) const {
+        const Eigen::MatrixXd& nodal_coordinates,
+        const Eigen::Matrix<double, 3, 1>& particle_size,
+        const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
       this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
@@ -276,53 +278,13 @@ inline Eigen::Matrix<double, Tdim, Tdim>
   return (grad_shapefn.transpose() * nodal_coordinates);
 }
 
-//! Compute Jacobian
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::Matrix<double, Tdim, Tdim>
-    mpm::HexahedronElement<Tdim, Tnfunctions>::jacobian(
-        const Eigen::Matrix<double, 3, 1>& xi,
-        const Eigen::MatrixXd& nodal_coordinates,
-        const Eigen::Matrix<double, 3, 1>& particle_size,
-        const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
-  return this->mpm::HexahedronElement<Tdim, Tnfunctions>::jacobian(
-      xi, nodal_coordinates);
-}
-
-//! Return B-matrix of a Hexahedron Element
+//! Compute Bmatrix
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::vector<Eigen::MatrixXd>
     mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi) const {
-  // Get gradient shape functions
-  Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
-                         Eigen::Matrix<double, 3, 1>::Zero());
-
-  // B-Matrix
-  std::vector<Eigen::MatrixXd> bmatrix;
-  bmatrix.reserve(Tnfunctions);
-
-  for (unsigned i = 0; i < Tnfunctions; ++i) {
-    // clang-format off
-    Eigen::Matrix<double, 6, Tdim> bi;
-    bi(0, 0) = grad_shapefn(i, 0); bi(0, 1) = 0.;                 bi(0, 2) = 0.;
-    bi(1, 0) = 0.;                 bi(1, 1) = grad_shapefn(i, 1); bi(1, 2) = 0.;
-    bi(2, 0) = 0.;                 bi(2, 1) = 0.;                 bi(2, 2) = grad_shapefn(i, 2);
-    bi(3, 0) = grad_shapefn(i, 1); bi(3, 1) = grad_shapefn(i, 0); bi(3, 2) = 0.;
-    bi(4, 0) = 0.;                 bi(4, 1) = grad_shapefn(i, 2); bi(4, 2) = grad_shapefn(i, 1);
-    bi(5, 0) = grad_shapefn(i, 2); bi(5, 1) = 0.;                 bi(5, 2) = grad_shapefn(i, 0);
-    // clang-format on
-    bmatrix.push_back(bi);
-  }
-  return bmatrix;
-}
-
-//! Return B-matrix of a Hexahedron Element at a given local
-//! coordinate for a real cell
-template <unsigned Tdim, unsigned Tnfunctions>
-inline std::vector<Eigen::MatrixXd>
-    mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   Eigen::MatrixXd grad_sf =
       this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
@@ -365,17 +327,6 @@ inline std::vector<Eigen::MatrixXd>
     bmatrix.push_back(bi);
   }
   return bmatrix;
-}
-
-//! Compute Bmatrix
-template <unsigned Tdim, unsigned Tnfunctions>
-inline std::vector<Eigen::MatrixXd>
-    mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
-        const VectorDim& particle_size,
-        const VectorDim& deformation_gradient) const {
-  return this->mpm::HexahedronElement<Tdim, Tnfunctions>::bmatrix(
-      xi, nodal_coordinates);
 }
 
 //! Return mass_matrix of a Hexahedron Element

--- a/include/hexahedron_element.tcc
+++ b/include/hexahedron_element.tcc
@@ -260,8 +260,7 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const Eigen::Matrix<double, 3, 1>& deformation_gradient) const {
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
-                         Eigen::Matrix<double, 3, 1>::Zero());
+      this->grad_shapefn(xi, particle_size, deformation_gradient);
   try {
     // Check if dimensions are correct
     if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
@@ -287,8 +286,7 @@ inline std::vector<Eigen::MatrixXd>
         const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   Eigen::MatrixXd grad_sf =
-      this->grad_shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
-                         Eigen::Matrix<double, 3, 1>::Zero());
+      this->grad_shapefn(xi, particle_size, deformation_gradient);
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -182,9 +182,9 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
       shapefn_ = element->shapefn(this->xi_, this->size_,
                                   Eigen::Matrix<double, Tdim, 1>::Zero());
       // Compute bmatrix of the particle for reference cell
-      bmatrix_ = element->bmatrix(this->xi_, cell_->nodal_coordinates(),
-                                  Eigen::Matrix<double, Tdim, 1>::Zero(),
-                                  Eigen::Matrix<double, Tdim, 1>::Zero());
+      bmatrix_ =
+          element->bmatrix(this->xi_, cell_->nodal_coordinates(), this->size_,
+                           Eigen::Matrix<double, Tdim, 1>::Zero());
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -179,9 +179,8 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
       const auto element = cell_->element_ptr();
 
       // Compute shape function of the particle
-      shapefn_ =
-          element->shapefn(this->xi_, Eigen::Matrix<double, Tdim, 1>::Zero(),
-                           Eigen::Matrix<double, Tdim, 1>::Zero());
+      shapefn_ = element->shapefn(this->xi_, this->size_,
+                                  Eigen::Matrix<double, Tdim, 1>::Zero());
       // Compute bmatrix of the particle for reference cell
       bmatrix_ = element->bmatrix(this->xi_, cell_->nodal_coordinates(),
                                   Eigen::Matrix<double, Tdim, 1>::Zero(),

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -179,9 +179,13 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
       const auto element = cell_->element_ptr();
 
       // Compute shape function of the particle
-      shapefn_ = element->shapefn(this->xi_);
+      shapefn_ =
+          element->shapefn(this->xi_, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                           Eigen::Matrix<double, Tdim, 1>::Zero());
       // Compute bmatrix of the particle for reference cell
-      bmatrix_ = element->bmatrix(this->xi_, cell_->nodal_coordinates());
+      bmatrix_ = element->bmatrix(this->xi_, cell_->nodal_coordinates(),
+                                  Eigen::Matrix<double, Tdim, 1>::Zero(),
+                                  Eigen::Matrix<double, Tdim, 1>::Zero());
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "

--- a/include/quadrilateral_element.h
+++ b/include/quadrilateral_element.h
@@ -89,21 +89,11 @@ class QuadrilateralElement : public Element<Tdim> {
 
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
-  //! \retval shapefn Shape function of a given cell
-  Eigen::VectorXd shapefn(const VectorDim& xi) const override;
-
-  //! Evaluate shape functions at given local coordinates
-  //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval shapefn Shape function of a given cell
   Eigen::VectorXd shapefn(const VectorDim& xi, const VectorDim& particle_size,
                           const VectorDim& deformation_gradient) const override;
-
-  //! Evaluate gradient of shape functions
-  //! \param[in] xi given local coordinates
-  //! \retval grad_shapefn Gradient of shape function of a given cell
-  Eigen::MatrixXd grad_shapefn(const VectorDim& xi) const override;
 
   //! Evaluate gradient of shape functions
   //! \param[in] xi given local coordinates

--- a/include/quadrilateral_element.h
+++ b/include/quadrilateral_element.h
@@ -107,14 +107,6 @@ class QuadrilateralElement : public Element<Tdim> {
   //! Compute Jacobian
   //! \param[in] xi given local coordinates
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval jacobian Jacobian matrix
-  Eigen::Matrix<double, Tdim, Tdim> jacobian(
-      const VectorDim& xi,
-      const Eigen::MatrixXd& nodal_coordinates) const override;
-
-  //! Compute Jacobian
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
   //! \param[in] particle_size Particle size
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval jacobian Jacobian matrix
@@ -122,19 +114,6 @@ class QuadrilateralElement : public Element<Tdim> {
       const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
       const VectorDim& particle_size,
       const VectorDim& deformation_gradient) const override;
-
-  //! Evaluate the B matrix at given local coordinates
-  //! \param[in] xi given local coordinates
-  //! \retval bmatrix B matrix
-  std::vector<Eigen::MatrixXd> bmatrix(const VectorDim& xi) const override;
-
-  //! Evaluate the B matrix at given local coordinates for a real cell
-  //! \param[in] xi given local coordinates
-  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
-  //! \retval bmatrix B matrix
-  std::vector<Eigen::MatrixXd> bmatrix(
-      const VectorDim& xi,
-      const Eigen::MatrixXd& nodal_coordinates) const override;
 
   //! Evaluate the B matrix at given local coordinates for a real cell
   //! \param[in] xi given local coordinates

--- a/include/quadrilateral_element.tcc
+++ b/include/quadrilateral_element.tcc
@@ -247,8 +247,7 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
-                         Eigen::Matrix<double, Tdim, 1>::Zero());
+      this->grad_shapefn(xi, particle_size, deformation_gradient);
 
   try {
     // Check if matrices dimensions are correct
@@ -276,8 +275,7 @@ inline std::vector<Eigen::MatrixXd>
         const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   Eigen::MatrixXd grad_sf =
-      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
-                         Eigen::Matrix<double, Tdim, 1>::Zero());
+      this->grad_shapefn(xi, particle_size, deformation_gradient);
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;

--- a/include/quadrilateral_element.tcc
+++ b/include/quadrilateral_element.tcc
@@ -7,10 +7,12 @@
 //! 0 0----------0 1
 
 //! Return shape functions of a 4-node Quadrilateral Element at a given local
-//! coordinate
+//! coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::VectorXd mpm::QuadrilateralElement<2, 4>::shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 4, 1> shapefn;
   shapefn(0) = 0.25 * (1 - xi(0)) * (1 - xi(1));
   shapefn(1) = 0.25 * (1 + xi(0)) * (1 - xi(1));
@@ -20,10 +22,12 @@ inline Eigen::VectorXd mpm::QuadrilateralElement<2, 4>::shapefn(
 }
 
 //! Return gradient of shape functions of a 4-node Quadrilateral Element at a
-//! given local coordinate
+//! given local coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 4>::grad_shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 4, 2> grad_shapefn;
   grad_shapefn(0, 0) = -0.25 * (1 - xi(1));
   grad_shapefn(1, 0) = 0.25 * (1 - xi(1));
@@ -65,10 +69,12 @@ inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 4>::unit_cell_coordinates()
 //! 0       4       1
 
 //! Return shape functions of a 8-node Quadrilateral Element at a given local
-//! coordinate
+//! coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::VectorXd mpm::QuadrilateralElement<2, 8>::shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 8, 1> shapefn;
   shapefn(0) = -0.25 * (1. - xi(0)) * (1. - xi(1)) * (xi(0) + xi(1) + 1.);
   shapefn(1) = 0.25 * (1. + xi(0)) * (1. - xi(1)) * (xi(0) - xi(1) - 1.);
@@ -82,10 +88,12 @@ inline Eigen::VectorXd mpm::QuadrilateralElement<2, 8>::shapefn(
 }
 
 //! Return gradient of shape functions of a 8-node Quadrilateral Element at a
-//! given local coordinate
+//! given local coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 8>::grad_shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 8, 2> grad_shapefn;
   grad_shapefn(0, 0) = 0.25 * (2. * xi(0) + xi(1)) * (1. - xi(1));
   grad_shapefn(1, 0) = 0.25 * (2. * xi(0) - xi(1)) * (1. - xi(1));
@@ -138,10 +146,12 @@ inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 8>::unit_cell_coordinates()
 //!  0      4       1
 
 //! Return shape functions of a 9-node Quadrilateral Element at a given local
-//! coordinate
+//! coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::VectorXd mpm::QuadrilateralElement<2, 9>::shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 9, 1> shapefn;
 
   shapefn(0) = 0.25 * xi(0) * xi(1) * (xi(0) - 1.) * (xi(1) - 1.);
@@ -158,10 +168,12 @@ inline Eigen::VectorXd mpm::QuadrilateralElement<2, 9>::shapefn(
 }
 
 //! Return gradient of shape functions of a 9-node Quadrilateral Element at a
-//! given local coordinate
+//! given local coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 9>::grad_shapefn(
-    const Eigen::Matrix<double, 2, 1>& xi) const {
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 9, 2> grad_shapefn;
   // 9-noded
   grad_shapefn(0, 0) = 0.25 * xi(1) * (xi(1) - 1.) * (2 * xi(0) - 1.);
@@ -226,32 +238,15 @@ inline mpm::ElementDegree mpm::QuadrilateralElement<2, 9>::degree() const {
   return mpm::ElementDegree::Quadratic;
 }
 
-//! Return shape functions of a Quadrilateral Element at a given local
-//! coordinate, with particle size and deformation gradient
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::VectorXd mpm::QuadrilateralElement<Tdim, Tnfunctions>::shapefn(
-    const VectorDim& xi, const VectorDim& particle_size,
-    const VectorDim& deformation_gradient) const {
-  return this->mpm::QuadrilateralElement<Tdim, Tnfunctions>::shapefn(xi);
-}
-
-//! Return gradient shape functions of a Quadrilateral Element at a given local
-//! coordinate, with particle size and deformation gradient
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::MatrixXd
-    mpm::QuadrilateralElement<Tdim, Tnfunctions>::grad_shapefn(
-        const VectorDim& xi, const VectorDim& particle_size,
-        const VectorDim& deformation_gradient) const {
-  return this->mpm::QuadrilateralElement<Tdim, Tnfunctions>::grad_shapefn(xi);
-}
-
 //! Compute Jacobian
 template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::Matrix<double, Tdim, Tdim>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::jacobian(
         const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
   // Get gradient shape functions
-  const Eigen::MatrixXd grad_shapefn = this->grad_shapefn(xi);
+  const Eigen::MatrixXd grad_shapefn =
+      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                         Eigen::Matrix<double, Tdim, 1>::Zero());
 
   try {
     // Check if matrices dimensions are correct
@@ -287,7 +282,9 @@ inline std::vector<Eigen::MatrixXd>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
         const VectorDim& xi) const {
   // Get gradient shape functions
-  Eigen::MatrixXd grad_shapefn = this->grad_shapefn(xi);
+  Eigen::MatrixXd grad_shapefn =
+      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                         Eigen::Matrix<double, Tdim, 1>::Zero());
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;
@@ -312,7 +309,9 @@ inline std::vector<Eigen::MatrixXd>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
         const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
   // Get gradient shape functions
-  Eigen::MatrixXd grad_sf = this->grad_shapefn(xi);
+  Eigen::MatrixXd grad_sf =
+      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                         Eigen::Matrix<double, Tdim, 1>::Zero());
 
   // B-Matrix
   std::vector<Eigen::MatrixXd> bmatrix;
@@ -371,7 +370,9 @@ inline Eigen::MatrixXd
   Eigen::Matrix<double, Tnfunctions, Tnfunctions> mass_matrix;
   mass_matrix.setZero();
   for (const auto& xi : xi_s) {
-    const Eigen::Matrix<double, Tnfunctions, 1> shape_fn = this->shapefn(xi);
+    const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
+        this->shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                      Eigen::Matrix<double, Tdim, 1>::Zero());
     mass_matrix += (shape_fn * shape_fn.transpose());
   }
   return mass_matrix;
@@ -399,7 +400,9 @@ inline Eigen::MatrixXd
   laplace_matrix.setZero();
   for (const auto& xi : xi_s) {
     // Get gradient shape functions
-    const Eigen::MatrixXd grad_sf = this->grad_shapefn(xi);
+    const Eigen::MatrixXd grad_sf =
+        this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                           Eigen::Matrix<double, Tdim, 1>::Zero());
 
     // Jacobian dx_i/dxi_j
     const Eigen::Matrix<double, Tdim, Tdim> jacobian =

--- a/include/quadrilateral_element.tcc
+++ b/include/quadrilateral_element.tcc
@@ -238,11 +238,13 @@ inline mpm::ElementDegree mpm::QuadrilateralElement<2, 9>::degree() const {
   return mpm::ElementDegree::Quadratic;
 }
 
-//! Compute Jacobian
+//! Compute Jacobian with particle size and deformation gradient
 template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::Matrix<double, Tdim, Tdim>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::jacobian(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
       this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
@@ -264,50 +266,14 @@ inline Eigen::Matrix<double, Tdim, Tdim>
   return (grad_shapefn.transpose() * nodal_coordinates);
 }
 
-//! Compute Jacobian with particle size and deformation gradient
-template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::Matrix<double, Tdim, Tdim>
-    mpm::QuadrilateralElement<Tdim, Tnfunctions>::jacobian(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
-        const VectorDim& particle_size,
-        const VectorDim& deformation_gradient) const {
-  return this->mpm::QuadrilateralElement<Tdim, Tnfunctions>::jacobian(
-      xi, nodal_coordinates);
-}
-
-//! Return the B-matrix of a Quadrilateral Element at a given local
-//! coordinate
-template <unsigned Tdim, unsigned Tnfunctions>
-inline std::vector<Eigen::MatrixXd>
-    mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi) const {
-  // Get gradient shape functions
-  Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
-                         Eigen::Matrix<double, Tdim, 1>::Zero());
-
-  // B-Matrix
-  std::vector<Eigen::MatrixXd> bmatrix;
-  bmatrix.reserve(Tnfunctions);
-
-  for (unsigned i = 0; i < Tnfunctions; ++i) {
-    Eigen::Matrix<double, 3, Tdim> bi;
-    // clang-format off
-    bi(0, 0) = grad_shapefn(i, 0); bi(0, 1) = 0.;
-    bi(1, 0) = 0.;                 bi(1, 1) = grad_shapefn(i, 1);
-    bi(2, 0) = grad_shapefn(i, 1); bi(2, 1) = grad_shapefn(i, 0);
-    bmatrix.push_back(bi);
-    // clang-format on
-  }
-  return bmatrix;
-}
-
 //! Return the B-matrix of a Quadrilateral Element at a given local
 //! coordinate for a real cell
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::vector<Eigen::MatrixXd>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates) const {
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   Eigen::MatrixXd grad_sf =
       this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
@@ -347,18 +313,6 @@ inline std::vector<Eigen::MatrixXd>
     // clang-format on
   }
   return bmatrix;
-}
-
-//! Return the B-matrix of a Quadrilateral Element at a given local
-//! coordinate for a real cell
-template <unsigned Tdim, unsigned Tnfunctions>
-inline std::vector<Eigen::MatrixXd>
-    mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
-        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
-        const VectorDim& particle_size,
-        const VectorDim& deformation_gradient) const {
-  return this->mpm::QuadrilateralElement<Tdim, Tnfunctions>::bmatrix(
-      xi, nodal_coordinates);
 }
 
 //! Return mass_matrix of a Hexahedron Element

--- a/include/quadrilateral_gimp_element.h
+++ b/include/quadrilateral_gimp_element.h
@@ -96,6 +96,9 @@ class QuadrilateralGIMPElement : public QuadrilateralElement<2, 4> {
     return mpm::ShapefnType::GIMP;
   }
 
+  //! Return number of shape functions
+  unsigned nfunctions() const override { return Tnfunctions; }
+
  private:
   //! Return natural nodal coordinates
   Eigen::MatrixXd natural_nodal_coordinates() const;

--- a/include/quadrilateral_gimp_element.tcc
+++ b/include/quadrilateral_gimp_element.tcc
@@ -31,7 +31,7 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::VectorXd
     mpm::QuadrilateralGIMPElement<Tdim, Tnfunctions>::shapefn(
         const Eigen::Matrix<double, Tdim, 1>& xi,
-        const VectorDim& particle_size,
+        const Eigen::Matrix<double, Tdim, 1>& particle_size,
         const Eigen::Matrix<double, Tdim, 1>& deformation_gradient) const {
 
   //! length of element in local coordinate
@@ -94,7 +94,7 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::MatrixXd
     mpm::QuadrilateralGIMPElement<Tdim, Tnfunctions>::grad_shapefn(
         const Eigen::Matrix<double, Tdim, 1>& xi,
-        const VectorDim& particle_size,
+        const Eigen::Matrix<double, Tdim, 1>& particle_size,
         const Eigen::Matrix<double, Tdim, 1>& deformation_gradient) const {
 
   //! length of element in local coordinate

--- a/tests/cell_test.cc
+++ b/tests/cell_test.cc
@@ -472,8 +472,21 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     pgravity << 0., 9.814;
     // Phase
     unsigned phase = 0;
-    const auto shapefns_xi = element->shapefn(xi);
-    const auto bmatrix = element->bmatrix(xi);
+    // Nodal coordinates
+    Eigen::Matrix<double, 4, Dim> coords;
+    // clang-format off
+      coords << 0., 0.,
+                2., 0.,
+                2., 2.,
+                0., 2.;
+    // clang-format on
+
+    const auto shapefns_xi =
+        element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                         Eigen::Matrix<double, Dim, 1>::Zero());
+    const auto bmatrix =
+        element->bmatrix(xi, coords, Eigen::Matrix<double, Dim, 1>::Zero(),
+                         Eigen::Matrix<double, Dim, 1>::Zero());
 
     SECTION("Check particle mass mapping") {
       cell->map_particle_mass_to_nodes(shapefns_xi, phase, pmass);
@@ -674,7 +687,9 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
       // Check interpolate velocity (0.5, 0.5)
       xi << 0.5, 0.5;
-      auto shapefn_xi = element->shapefn(xi);
+      auto shapefn_xi =
+          element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                           Eigen::Matrix<double, Dim, 1>::Zero());
       velocity = cell->interpolate_nodal_velocity(shapefn_xi, phase);
 
       interpolated_velocity << 0.2875, 0.2875;
@@ -684,7 +699,8 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
       // Check interpolate velocity (-0.5, -0.5)
       xi << -0.5, -0.5;
-      shapefn_xi = element->shapefn(xi);
+      shapefn_xi = element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                                    Eigen::Matrix<double, Dim, 1>::Zero());
       velocity = cell->interpolate_nodal_velocity(shapefn_xi, phase);
 
       interpolated_velocity << 0.1875, 0.1875;
@@ -723,7 +739,9 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
       // Check interpolate acceleration (0.5, 0.5)
       xi << 0.5, 0.5;
-      auto shapefn_xi = element->shapefn(xi);
+      auto shapefn_xi =
+          element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                           Eigen::Matrix<double, Dim, 1>::Zero());
       check_acceleration =
           cell->interpolate_nodal_acceleration(shapefn_xi, phase);
 
@@ -734,7 +752,8 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
 
       // Check interpolate acceleration (-0.5, -0.5)
       xi << -0.5, -0.5;
-      shapefn_xi = element->shapefn(xi);
+      shapefn_xi = element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                                    Eigen::Matrix<double, Dim, 1>::Zero());
       check_acceleration =
           cell->interpolate_nodal_acceleration(shapefn_xi, phase);
 
@@ -1559,8 +1578,25 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
     // Phase
     unsigned phase = 0;
 
-    const auto shapefns_xi = element->shapefn(xi);
-    const auto bmatrix = element->bmatrix(xi);
+    // Nodal coords
+    Eigen::Matrix<double, 8, Dim> coords;
+    // clang-format off
+      coords << 0., 0., 0.,
+                2., 0., 0.,
+                2., 2., 0.,
+                0., 2., 0.,
+                0., 0., 2.,
+                2., 0., 2.,
+                2., 2., 2.,
+                0., 2., 2.;
+    // clang-format on
+
+    const auto shapefns_xi =
+        element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                         Eigen::Matrix<double, Dim, 1>::Zero());
+    const auto bmatrix =
+        element->bmatrix(xi, coords, Eigen::Matrix<double, Dim, 1>::Zero(),
+                         Eigen::Matrix<double, Dim, 1>::Zero());
 
     SECTION("Check particle mass mapping") {
       cell->map_particle_mass_to_nodes(shapefns_xi, phase, pmass);
@@ -1775,7 +1811,9 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
       // Check interpolate velocity (0.5, 0.5)
       xi << 0.5, 0.5, 0.5;
-      auto shapefn_xi = element->shapefn(xi);
+      auto shapefn_xi =
+          element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                           Eigen::Matrix<double, Dim, 1>::Zero());
       velocity = cell->interpolate_nodal_velocity(shapefn_xi, phase);
 
       interpolated_velocity << 0.5875, 0.5875, 0.5875;
@@ -1785,7 +1823,8 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
       // Check interpolate velocity (-0.5, -0.5)
       xi << -0.5, -0.5, -0.5;
-      shapefn_xi = element->shapefn(xi);
+      shapefn_xi = element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                                    Eigen::Matrix<double, Dim, 1>::Zero());
       velocity = cell->interpolate_nodal_velocity(shapefn_xi, phase);
 
       interpolated_velocity << 0.2875, 0.2875, 0.2875;
@@ -1826,7 +1865,9 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
       // Check interpolate acceleration (0.5, 0.5, 0.5)
       xi << 0.5, 0.5, 0.5;
-      auto shapefn_xi = element->shapefn(xi);
+      auto shapefn_xi =
+          element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                           Eigen::Matrix<double, Dim, 1>::Zero());
       check_acceleration =
           cell->interpolate_nodal_acceleration(shapefn_xi, phase);
 
@@ -1837,7 +1878,8 @@ TEST_CASE("Cell is checked for 3D case", "[cell][3D]") {
 
       // Check interpolate acceleration (-0.5, -0.5, -0.5)
       xi << -0.5, -0.5, -0.5;
-      shapefn_xi = element->shapefn(xi);
+      shapefn_xi = element->shapefn(xi, Eigen::Matrix<double, Dim, 1>::Zero(),
+                                    Eigen::Matrix<double, Dim, 1>::Zero());
       check_acceleration =
           cell->interpolate_nodal_acceleration(shapefn_xi, phase);
 

--- a/tests/hexahedron_element_test.cc
+++ b/tests/hexahedron_element_test.cc
@@ -23,7 +23,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
     SECTION("Eight noded hexahedron element for coordinates(0, 0, 0)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -38,7 +39,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(7) == Approx(0.125).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -74,7 +76,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
     SECTION("Eight noded hexahedron element for coordinates(-1, -1, -1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << -1., -1., -1.;
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
 
@@ -88,7 +91,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(7) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -124,7 +128,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
     SECTION("Eight noded hexahedron element for coordinates(1, 1, 1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 1., 1., 1.;
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -139,7 +144,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(7) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -252,7 +258,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       // clang-format on
 
       // Get Jacobian
-      auto jac = hex->jacobian(xi, coords);
+      auto jac = hex->jacobian(xi, coords, Eigen::Vector3d::Zero(),
+                               Eigen::Vector3d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -305,114 +312,6 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
     }
 
     // Coordinates is (0, 0, 0)
-    SECTION("Eight noded hexahedron B-matrix for coordinates(0, 0, 0)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords.setZero();
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0.5, 0.5, 0.5)
-    SECTION("Eight noded hexahedron B-matrix for coordinates(0.5, 0.5, 0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << 0.5, 0.5, 0.5;
-
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (-0.5, -0.5, -0.5)
-    SECTION(
-        "Eight noded hexahedron B-matrix for coordinates(-0.5, -0.5, -0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << -0.5, -0.5, -0.5;
-
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0, 0, 0)
     SECTION("Eight noded hexahedron B-matrix cell for coordinates(0, 0, 0)") {
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0., 0., 0.;
@@ -430,10 +329,12 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = hex->bmatrix(xi, coords);
+      auto bmatrix = hex->bmatrix(xi, coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(xi);
+      auto gradsf = hex->grad_shapefn(xi, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -479,10 +380,12 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = hex->bmatrix(xi, coords);
+      auto bmatrix = hex->bmatrix(xi, coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(xi);
+      auto gradsf = hex->grad_shapefn(xi, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -528,10 +431,12 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = hex->bmatrix(xi, coords);
+      auto bmatrix = hex->bmatrix(xi, coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(xi);
+      auto gradsf = hex->grad_shapefn(xi, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -627,8 +532,10 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
                 1., 1., 1.;
       // clang-format on
       // Get B-Matrix
-      auto bmatrix = hex->bmatrix(xi, coords);
-      auto jacobian = hex->jacobian(xi, coords);
+      auto bmatrix = hex->bmatrix(xi, coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
+      auto jacobian = hex->jacobian(xi, coords, Eigen::Vector3d::Zero(),
+                                    Eigen::Vector3d::Zero());
     }
 
     // Mass matrix of a cell
@@ -954,7 +861,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
     SECTION("Twenty noded hexahedron element for coordinates(0, 0, 0)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1004,7 +912,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(19) == Approx(0.25).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1150,7 +1059,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
         "-0.5, -0.5)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << -0.5, -0.5, -0.5;
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1200,7 +1110,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(19) == Approx(0.046875).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1345,7 +1256,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
         "0.5, 0.5)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 0.5, 0.5, 0.5;
-      auto shapefn = hex->shapefn(coords);
+      auto shapefn = hex->shapefn(coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1395,7 +1307,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       REQUIRE(shapefn(19) == Approx(0.421875).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
+      auto gradsf = hex->grad_shapefn(coords, Eigen::Vector3d::Zero(),
+                                      Eigen::Vector3d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1691,7 +1604,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       // clang-format on
 
       // Get Jacobian
-      auto jac = hex->jacobian(xi, coords);
+      auto jac = hex->jacobian(xi, coords, Eigen::Vector3d::Zero(),
+                               Eigen::Vector3d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -1756,113 +1670,6 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
           REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
     }
 
-    // Coordinates is (0, 0, 0)
-    SECTION("20-noded hexahedron B-matrix for coordinates(0, 0, 0)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords.setZero();
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0.5, 0.5, 0.5)
-    SECTION("20-noded hexahedron B-matrix for coordinates(0.5, 0.5, 0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << 0.5, 0.5, 0.5;
-
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (-0.5, -0.5, -0.5)
-    SECTION("20-noded hexahedron B-matrix for coordinates(-0.5, -0.5, -0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << -0.5, -0.5, -0.5;
-
-      // Get B-Matrix
-      auto bmatrix = hex->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = hex->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 2) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(3, 2) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 1) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(4, 2) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 0) == Approx(gradsf(i, 2)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(5, 2) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
     SECTION("20-noded hexahedron B-matrix and Jacobian failure") {
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0., 0., 0.;
@@ -1878,8 +1685,10 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
                 1., 1., 1.;
       // clang-format on
       // Get B-Matrix
-      auto bmatrix = hex->bmatrix(xi, coords);
-      auto jacobian = hex->jacobian(xi, coords);
+      auto bmatrix = hex->bmatrix(xi, coords, Eigen::Vector3d::Zero(),
+                                  Eigen::Vector3d::Zero());
+      auto jacobian = hex->jacobian(xi, coords, Eigen::Vector3d::Zero(),
+                                    Eigen::Vector3d::Zero());
     }
 
     // Mass matrix of a cell

--- a/tests/quadrilateral_element_test.cc
+++ b/tests/quadrilateral_element_test.cc
@@ -23,7 +23,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Four noded quadrilateral element for coordinates(0,0)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -34,7 +35,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(3) == Approx(0.25).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -52,7 +54,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Four noded quadrilateral element for coordinates(-1, -1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << -1., -1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -63,7 +66,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -81,7 +85,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Four noded quadrilateral element for coordinates(1,1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 1., 1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -92,7 +97,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -162,7 +168,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get Jacobian
-      auto jac = quad->jacobian(xi, coords);
+      auto jac = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -210,78 +217,6 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     }
 
     // Coordinates is (0,0)
-    SECTION("Four noded quadrilateral B-matrix for coordinates(0,0)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords.setZero();
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0.5,0.5)
-    SECTION("Four noded quadrilateral B-matrix for coordinates(0.5,0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << 0.5, 0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (-0.5,-0.5)
-    SECTION("Four noded quadrilateral B-matrix for coordinates(-0.5,-0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << -0.5, -0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0,0)
     SECTION("Four noded quadrilateral B-matrix cell for coordinates(0,0)") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
@@ -297,10 +232,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -332,10 +269,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -368,10 +307,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -439,8 +380,10 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
                 1., 1.;
       // clang-format on
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
-      auto jacobian = quad->jacobian(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+      auto jacobian = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                     Eigen::Vector2d::Zero());
     }
 
     // Mass matrix of a cell
@@ -639,7 +582,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Eight noded quadrilateral element for coordinates(0,0)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -654,7 +598,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(7) == Approx(0.5).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -681,7 +626,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Eight noded quadrilateral element for coordinates(-1,-1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << -1., -1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -696,7 +642,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(7) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -725,7 +672,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Eight noded quadrilateral element for coordinates(1, 1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 1., 1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -740,7 +688,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(7) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -836,7 +785,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get Jacobian
-      auto jac = quad->jacobian(xi, coords);
+      auto jac = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -889,78 +839,6 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     }
 
     // Coordinates is (0,0)
-    SECTION("Eight noded quadrilateral B-matrix for coordinates(0,0)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords.setZero();
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0.5,0.5)
-    SECTION("Eight noded quadrilateral B-matrix for coordinates(0.5,0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << 0.5, 0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (-0.5,-0.5)
-    SECTION("Eight noded quadrilateral B-matrix for coordinates(-0.5,-0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << -0.5, -0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0,0)
     SECTION("Eight noded quadrilateral B-matrix cell for coordinates(0,0)") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
@@ -980,10 +858,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -1020,10 +900,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -1060,10 +942,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -1134,8 +1018,10 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
                 1., 1.;
       // clang-format on
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
-      auto jacobian = quad->jacobian(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+      auto jacobian = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                     Eigen::Vector2d::Zero());
     }
 
     // Mass matrix of a cell
@@ -1373,7 +1259,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Nine noded quadrilateral element for coordinates(0,0)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1389,7 +1276,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(8) == Approx(1.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1418,7 +1306,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Nine noded quadrilateral element for coordinates(-1,-1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << -1., -1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1434,7 +1323,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(8) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1463,7 +1353,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
     SECTION("Nine noded quadrilateral element for coordinates(1, 1)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 1., 1.;
-      auto shapefn = quad->shapefn(coords);
+      auto shapefn = quad->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -1479,7 +1370,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(shapefn(8) == Approx(0.0).epsilon(Tolerance));
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
+      auto gradsf = quad->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -1551,54 +1443,6 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       REQUIRE(gradsf(6, 1) == Approx(0.5).epsilon(Tolerance));
       REQUIRE(gradsf(7, 1) == Approx(0.0).epsilon(Tolerance));
       REQUIRE(gradsf(8, 1) == Approx(0.0).epsilon(Tolerance));
-    }
-
-    // Coordinates is (0,0)
-    SECTION("Nine noded quadrilateral B-matrix for coordinates(0,0)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords.setZero();
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
-    // Coordinates is (0.5,0.5)
-    SECTION("Nine noded quadrilateral B-matrix for coordinates(0.5,0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << 0.5, 0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
     }
 
     // Mass matrix of a cell
@@ -1764,7 +1608,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get Jacobian
-      auto jac = quad->jacobian(xi, coords);
+      auto jac = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -1817,30 +1662,6 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
           REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
     }
 
-    // Coordinates is (-0.5,-0.5)
-    SECTION("Nine noded quadrilateral B-matrix for coordinates(-0.5,-0.5)") {
-      Eigen::Matrix<double, Dim, 1> coords;
-      coords << -0.5, -0.5;
-
-      // Get B-Matrix
-      auto bmatrix = quad->bmatrix(coords);
-
-      // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(coords);
-
-      // Check size of B-matrix
-      REQUIRE(bmatrix.size() == nfunctions);
-
-      for (unsigned i = 0; i < nfunctions; ++i) {
-        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
-        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
-      }
-    }
-
     // Coordinates is (0,0)
     SECTION("Nine noded quadrilateral B-matrix cell for coordinates(0,0)") {
       // Reference coordinates
@@ -1862,10 +1683,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -1902,10 +1725,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -1943,10 +1768,12 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
       // clang-format on
 
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
-      auto gradsf = quad->grad_shapefn(xi);
+      auto gradsf = quad->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
       gradsf *= 2.;
 
       // Check size of B-matrix
@@ -2017,8 +1844,10 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
                 1., 1.;
       // clang-format on
       // Get B-Matrix
-      auto bmatrix = quad->bmatrix(xi, coords);
-      auto jacobian = quad->jacobian(xi, coords);
+      auto bmatrix = quad->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+      auto jacobian = quad->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                     Eigen::Vector2d::Zero());
     }
 
     SECTION("Nine noded quadrilateral coordinates of unit cell") {


### PR DESCRIPTION
* Remove multiple if conditions to check which shapefn should be used, reduce redundant code.