### PR TITLE
:rocket: Efficient location of point in cell based on the distance from cell centroid

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -247,6 +247,11 @@ class Cell {
   void compute_normals();
 
  private:
+  //! Approximately check if a point is in a cell
+  //! \param[in] point Coordinates of point
+  bool approx_point_in_cell(const Eigen::Matrix<double, Tdim, 1>& point);
+
+ private:
   //! Mutex
   std::mutex cell_mutex_;
   //! cell id

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -57,7 +57,7 @@ bool mpm::Cell<Tdim>::is_initialised() const {
           // Check if volume of a cell is initialised
           (std::fabs(this->volume_ - std::numeric_limits<double>::max()) >
            1.0E-10) &&
-          // Check if mean lenght of a cell is initialised
+          // Check if mean length of a cell is initialised
           (std::fabs(this->mean_length_ - std::numeric_limits<double>::max()) >
            1.0E-10));
 }
@@ -358,10 +358,24 @@ inline bool mpm::Cell<3>::point_in_cartesian_cell(
     return false;
 }
 
-//! Check if a point is in a 3D cell by affine transformation and newton-raphson
+//! Check approximately if a point is in a cell by using cell length
+template <unsigned Tdim>
+inline bool mpm::Cell<Tdim>::approx_point_in_cell(
+    const Eigen::Matrix<double, Tdim, 1>& point) {
+  const double length = (point - this->centroid_).norm();
+  if (length < (this->mean_length_ * 2.))
+    return true;
+  else
+    return false;
+}
+
+//! Check if a point is in a cell by affine transformation and newton-raphson
 template <unsigned Tdim>
 inline bool mpm::Cell<Tdim>::is_point_in_cell(
     const Eigen::Matrix<double, Tdim, 1>& point) {
+
+  // Check if point is approximately in the cell
+  if (!this->approx_point_in_cell(point)) return false;
 
   // Check if cell is cartesian, if so use cartesian checker
   if (!isoparametric_) return mpm::Cell<Tdim>::point_in_cartesian_cell(point);


### PR DESCRIPTION
Doing an approximate quick check if a point can be found in a cell, reduces the calculation time significantly. For 150k particles, it reduces from ~180s (isoparametric) and ~50s (Cartesian) to roughly 7s! :rocket: 