### PR TITLE
:computer: Refactor assign tractions on particles

### DIFF
--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -477,7 +477,7 @@ template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::assign_particles_tractions(
     const std::vector<std::tuple<mpm::Index, unsigned, double>>&
         particle_tractions) {
-  bool status = false;
+  bool status = true;
   // TODO: Remove phase
   const unsigned phase = 0;
   try {
@@ -495,8 +495,7 @@ bool mpm::Mesh<Tdim>::assign_particles_tractions(
       if (map_particles_.find(pid) != map_particles_.end())
         status = map_particles_[pid]->assign_traction(phase, dir, traction);
 
-      if (!status)
-        throw std::runtime_error("Particle not found / traction is invalid");
+      if (!status) throw std::runtime_error("Traction is invalid for particle");
     }
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());

--- a/include/mpm_explicit.tcc
+++ b/include/mpm_explicit.tcc
@@ -317,7 +317,8 @@ bool mpm::MPMExplicit<Tdim>::initialise_particles() {
     }
 
     auto particles_traction_end = std::chrono::steady_clock::now();
-    console_->info("Rank {} Read particle traction: {} ms", mpi_rank,
+    console_->info("Rank {} Read particle traction and stresses: {} ms",
+                   mpi_rank,
                    std::chrono::duration_cast<std::chrono::milliseconds>(
                        particles_traction_end - particles_traction_begin)
                        .count());


### PR DESCRIPTION
* Do not throw an error, when a particle is not found, as this is likely to happen when running the code on multiple nodes. The code still throws an error when an assignment fails