### PR TITLE
Add inclined velocity constraints and rotation matrix to nodes

### DIFF
--- a/include/geometry.tcc
+++ b/include/geometry.tcc
@@ -1,4 +1,4 @@
-//! Compute the inverse of a 2d rotation matrix for an orthogonal axis
+//! Compute the 2d rotation matrix for an orthogonal axis
 //! coordinate system
 template <>
 inline Eigen::Matrix<double, 2, 2> mpm::Geometry<2>::rotation_matrix(
@@ -11,15 +11,15 @@ inline Eigen::Matrix<double, 2, 2> mpm::Geometry<2>::rotation_matrix(
 
   // clang-format off
   const Eigen::Matrix<double, 2, 2> rotation_matrix = 
-    (Eigen::Matrix<double, 2, 2>() << cos_alpha_cos_beta - sin_alpha_sin_beta,  -cos_alpha_sin_beta - cos_alpha_cos_beta,
+    (Eigen::Matrix<double, 2, 2>() << cos_alpha_cos_beta - sin_alpha_sin_beta,  -cos_alpha_sin_beta - sin_alpha_cos_beta,
                                       sin_alpha_cos_beta + cos_alpha_sin_beta,  -sin_alpha_sin_beta + cos_alpha_cos_beta).finished();                                 
   // clang-format on            
 
-  // inverted rotation matrix
+  // rotation matrix
   return rotation_matrix;
 }
 
-//! Compute the inverse of a 3d rotation matrix for an orthogonal axis coordinate system
+//! Compute the 3d rotation matrix for an orthogonal axis coordinate system
 template <>
 inline Eigen::Matrix<double, 3, 3> mpm::Geometry<3>::rotation_matrix(const 
     Eigen::Matrix<double, 3, 1>& angles) const {
@@ -50,7 +50,7 @@ inline Eigen::Matrix<double, 3, 3> mpm::Geometry<3>::rotation_matrix(const
                                       cos_gamma).finished();
   // clang-format on
 
-  // inverted rotation matrix
+  // rotation matrix
   return rotation_matrix;
 }
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -218,8 +218,7 @@ class Mesh {
   //! \param[in] inclined_velocity_constraints Constraint at node id and euler
   //! angles
   bool assign_rotation_matrices(
-      const std::vector<
-          std::map<mpm::Index, unsigned, Eigen::Matrix<double, Tdim, 1>>>&
+      const std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>&
           euler_angles);
 
   //! Assign velocity constraints to cells
@@ -324,6 +323,8 @@ class Mesh {
   Map<Cell<Tdim>> map_cells_;
   //! Container of cells
   Container<Cell<Tdim>> cells_;
+  //! Geometry to call functions within it
+  std::unique_ptr<mpm::Geometry<Tdim>> geometry_;
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Mesh class

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -21,6 +21,7 @@
 #include "cell.h"
 #include "container.h"
 #include "factory.h"
+#include "geometry.h"
 #include "hdf5.h"
 #include "logger.h"
 #include "material/material.h"
@@ -205,6 +206,21 @@ class Mesh {
   bool assign_velocity_constraints(
       const std::vector<std::tuple<mpm::Index, unsigned, double>>&
           velocity_constraints);
+
+  //! Assign inclined velocity constraints to nodes
+  //! \param[in] inclined_velocity_constraints Constraint at node id, dir, and
+  //! velocity
+  bool assign_inclined_velocity_constraints(
+      const std::vector<std::tuple<mpm::Index, unsigned, double>>&
+          inclined_velocity_constraints);
+
+  //! Assign rotation matrix
+  //! \param[in] inclined_velocity_constraints Constraint at node id and euler
+  //! angles
+  bool assign_rotation_matrices(
+      const std::vector<
+          std::map<mpm::Index, unsigned, Eigen::Matrix<double, Tdim, 1>>>&
+          euler_angles);
 
   //! Assign velocity constraints to cells
   //! \param[in] velocity_constraints Constraint at cell id, face id, dir, and

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -8,6 +8,9 @@ mpm::Mesh<Tdim>::Mesh(unsigned id, bool isoparametric)
   std::string logger = "mesh::" + std::to_string(id);
   console_ = std::make_unique<spdlog::logger>(logger, mpm::stdout_sink);
 
+  //! Geometry
+  geometry_ = std::make_unique<mpm::Geometry<Tdim>>();
+
   particles_.clear();
 }
 
@@ -525,8 +528,8 @@ bool mpm::Mesh<Tdim>::assign_inclined_velocity_constraints(
 //! Assign rotation matrix to nodes
 template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::assign_rotation_matrices(
-    const std::vector<std::map<mpm::Index, unsigned,
-                               Eigen::Matrix<double, Tdim, 1>>>& euler_angles) {
+    const std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>&
+        euler_angles) {
   bool status = false;
   try {
     if (!nodes_.size())
@@ -542,7 +545,7 @@ bool mpm::Mesh<Tdim>::assign_rotation_matrices(
 
       // Compute rotation matrix
       Eigen::Matrix<double, Tdim, Tdim> rotation_matrix =
-          rotation_matrix(angles);
+          geometry_->rotation_matrix(angles);
 
       // Apply constraint
       status = map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);

--- a/include/mpm_explicit.tcc
+++ b/include/mpm_explicit.tcc
@@ -157,6 +157,25 @@ bool mpm::MPMExplicit<Tdim>::initialise_mesh() {
             "Velocity constraints are not properly assigned");
     }
 
+    // Read and assign inclined velocity constraints
+    if (!io_->file_name("inclined_velocity_constraints").empty()) {
+      bool inclined_velocity_constraints =
+          mesh_->assign_inclined_velocity_constraints(
+              mesh_reader->read_inclined_velocity_constraints(
+                  io_->file_name("inclined_velocity_constraints")));
+      if (!inclined_velocity_constraints)
+        throw std::runtime_error(
+            "Inclined velocity constraints are not properly assigned");
+    }
+
+    // Read nodal euler angles and assign rotation matrices
+    if (!io_->file_name("nodal_euler_angles").empty()) {
+      bool rotation_matrices = mesh_->assign_rotation_matrices(
+          mesh_reader->read_euler_angles(io_->file_name("nodal_euler_angles")));
+      if (!rotation_matrices)
+        throw std::runtime_error("Euler angles are not properly assigned");
+    }
+
     // Set nodal traction as false if file is empty
     if (io_->file_name("nodal_tractions").empty()) nodal_tractions_ = false;
 

--- a/include/node.h
+++ b/include/node.h
@@ -174,11 +174,13 @@ class Node : public NodeBase<Tdim> {
   //! Directions can take values between 0 and Dim * Nphases
   //! \param[in] dir Direction of velocity constraint
   //! \param[in] velocity Applied velocity constraint
-  bool assign_inclined_velocity_constraint(unsigned dir, double velocity) override;
+  bool assign_inclined_velocity_constraint(unsigned dir,
+                                           double velocity) override;
 
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
-  bool assign_rotation_matrix(Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
+  bool assign_rotation_matrix(
+      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
     rotation_matrix_ = rotation_matrix;
   }
 

--- a/include/node.h
+++ b/include/node.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <vector>
 
+#include "geometry.h"
 #include "logger.h"
 #include "node_base.h"
 
@@ -169,8 +170,23 @@ class Node : public NodeBase<Tdim> {
   //! \param[in] velocity Applied velocity constraint
   bool assign_velocity_constraint(unsigned dir, double velocity) override;
 
+  //! Assign inclined velocity constraint
+  //! Directions can take values between 0 and Dim * Nphases
+  //! \param[in] dir Direction of velocity constraint
+  //! \param[in] velocity Applied velocity constraint
+  bool assign_inclined_velocity_constraint(unsigned dir, double velocity) override;
+
+  //! Assign rotation matrix
+  //! \param[in] rotation_matrix Rotation matrix of the node
+  bool assign_rotation_matrix(Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
+    rotation_matrix_ = rotation_matrix;
+  }
+
   //! Apply velocity constraints
   void apply_velocity_constraints() override;
+
+  //! Apply inclined velocity constraints
+  void apply_inclined_velocity_constraints() override;
 
  private:
   //! Mutex
@@ -199,6 +215,10 @@ class Node : public NodeBase<Tdim> {
   Eigen::Matrix<double, Tdim, Tnphases> acceleration_;
   //! Velocity constraints
   std::map<unsigned, double> velocity_constraints_;
+  //! Rotation matrix for inclined velocity constraints
+  Eigen::Matrix<double, Tdim, Tdim> rotation_matrix_;
+  //! Inclided velocity constraints
+  std::map<unsigned, double> inclined_velocity_constraints_;
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Node class

--- a/include/node.h
+++ b/include/node.h
@@ -6,7 +6,6 @@
 #include <mutex>
 #include <vector>
 
-#include "geometry.h"
 #include "logger.h"
 #include "node_base.h"
 

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -270,8 +270,9 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::assign_inclined_velocity_constraint(
   try {
     //! Constrain directions can take values between 0 and Dim * Nphases
     if (dir >= 0 && dir < (Tdim * Tnphases))
-      this->inclined_velocity_constraints_.insert(std::make_pair<unsigned, double>(
-          static_cast<unsigned>(dir), static_cast<double>(velocity)));
+      this->inclined_velocity_constraints_.insert(
+          std::make_pair<unsigned, double>(static_cast<unsigned>(dir),
+                                           static_cast<double>(velocity)));
     else
       throw std::runtime_error("Constraint direction is out of bounds");
 
@@ -286,7 +287,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::assign_inclined_velocity_constraint(
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof, Tnphases>::apply_velocity_constraints() {
   // Apply inclided velocity constraints
-  this->apply_inclined_velocity_constraints();
+  // this->apply_inclined_velocity_constraints();
 
   // Apply cartesian constraints
   // Set velocity constraint
@@ -314,8 +315,10 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_inclined_velocity_constraints() {
     // Phase: Integer value of division (dir / Tdim)
     const auto phase = static_cast<unsigned>(dir / Tdim);
     // Transform to local coordinate
-    Eigen::Matrix<double, Tdim, Tnphases> local_velocity = rotation_matrix_ * this->velocity_;
-    Eigen::Matrix<double, Tdim, Tnphases> local_acceleration = rotation_matrix_ * this->acceleration_;
+    Eigen::Matrix<double, Tdim, Tnphases> local_velocity =
+        rotation_matrix_ * this->velocity_;
+    Eigen::Matrix<double, Tdim, Tnphases> local_acceleration =
+        rotation_matrix_ * this->acceleration_;
     // Apply boundary condition in local coordinate
     local_velocity(direction, phase) = constraint.second;
     local_acceleration(direction, phase) = 0.;

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -149,8 +149,21 @@ class NodeBase {
   //! \param[in] velocity Applied velocity constraint
   virtual bool assign_velocity_constraint(unsigned dir, double velocity) = 0;
 
+  //! Assign inclined velocity constraint
+  //! Directions can take values between 0 and Dim * Nphases
+  //! \param[in] dir Direction of velocity constraint
+  //! \param[in] velocity Applied velocity constraint
+  virtual bool assign_inclined_velocity_constraint(unsigned dir, double velocity) = 0;
+
+  //! Assign rotation matrix
+  //! \param[in] rotation_matrix Rotation matrix of the node
+  virtual bool assign_rotation_matrix(Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
+
   //! Apply velocity constraints
   virtual void apply_velocity_constraints() = 0;
+
+  //! Apply inclined velocity constraints
+  virtual void apply_inclined_velocity_constraints() = 0;
 
 };  // NodeBase class
 }  // namespace mpm

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -153,11 +153,13 @@ class NodeBase {
   //! Directions can take values between 0 and Dim * Nphases
   //! \param[in] dir Direction of velocity constraint
   //! \param[in] velocity Applied velocity constraint
-  virtual bool assign_inclined_velocity_constraint(unsigned dir, double velocity) = 0;
+  virtual bool assign_inclined_velocity_constraint(unsigned dir,
+                                                   double velocity) = 0;
 
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
-  virtual bool assign_rotation_matrix(Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
+  virtual bool assign_rotation_matrix(
+      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
 
   //! Apply velocity constraints
   virtual void apply_velocity_constraints() = 0;

--- a/include/read_mesh.h
+++ b/include/read_mesh.h
@@ -71,6 +71,19 @@ class ReadMesh {
       read_velocity_constraints(
           const std::string& velocity_constraints_file) = 0;
 
+  //! Read inclined velocity constraints file
+  //! \param[in] inclined_velocity_constraints_file file name with constraints
+  //! in local coordinate
+  virtual std::vector<std::tuple<mpm::Index, unsigned, double>>
+      read_inclined_velocity_constraints(
+          const std::string& inclined_velocity_constraints_file) = 0;
+
+  //! Read nodal euler angles file
+  //! \param[in] nodal_euler_angles_file file name with nodal id and respective
+  //! euler angles
+  virtual std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>
+      read_euler_angles(const std::string& nodal_euler_angles_file) = 0;
+
   //! Read particles volume file
   //! \param[in] volume_files file name with particle volumes
   virtual std::vector<std::tuple<mpm::Index, double>> read_particles_volumes(

--- a/include/read_mesh_ascii.h
+++ b/include/read_mesh_ascii.h
@@ -55,10 +55,23 @@ class ReadMeshAscii : public ReadMesh<Tdim> {
       const std::string& particles_stresses) override;
 
   //! Read constraints file
-  //! \param[in] velocity_constraints_files file name with constraints
+  //! \param[in] velocity_constraints_file file name with constraints
   std::vector<std::tuple<mpm::Index, unsigned, double>>
       read_velocity_constraints(
           const std::string& velocity_constraints_file) override;
+
+  //! Read inclined velocity constraints file
+  //! \param[in] inclined_velocity_constraints_file file name with constraints
+  //! in local coordinate
+  std::vector<std::tuple<mpm::Index, unsigned, double>>
+      read_inclined_velocity_constraints(
+          const std::string& inclined_velocity_constraints_file) override;
+
+  //! Read nodal euler angles file
+  //! \param[in] nodal_euler_angles_file file name with nodal id and respective
+  //! euler angles
+  std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>
+      read_euler_angles(const std::string& nodal_euler_angles_file) override;
 
   //! Read volume file
   //! \param[in] volume_files file name with particle volumes

--- a/include/read_mesh_ascii.tcc
+++ b/include/read_mesh_ascii.tcc
@@ -293,6 +293,100 @@ std::vector<std::tuple<mpm::Index, unsigned, double>>
   return constraints;
 }
 
+//! Return inclined velocity constraints of particles
+template <unsigned Tdim>
+std::vector<std::tuple<mpm::Index, unsigned, double>>
+    mpm::ReadMeshAscii<Tdim>::read_inclined_velocity_constraints(
+        const std::string& inclined_velocity_constraints_file) {
+
+  // Nodal velocity constraints
+  std::vector<std::tuple<mpm::Index, unsigned, double>> constraints;
+  constraints.clear();
+
+  // input file stream
+  std::fstream file;
+  file.open(inclined_velocity_constraints_file.c_str(), std::ios::in);
+
+  try {
+    if (file.is_open() && file.good()) {
+      // Line
+      std::string line;
+      while (std::getline(file, line)) {
+        boost::algorithm::trim(line);
+        std::istringstream istream(line);
+        // ignore comment lines (# or !) or blank lines
+        if ((line.find('#') == std::string::npos) &&
+            (line.find('!') == std::string::npos) && (line != "")) {
+          while (istream.good()) {
+            // ID
+            mpm::Index id;
+            // Direction
+            unsigned dir;
+            // Velocity
+            double velocity;
+            // Read stream
+            istream >> id >> dir >> velocity;
+            constraints.emplace_back(std::make_tuple(id, dir, velocity));
+          }
+        }
+      }
+    }
+    file.close();
+  } catch (std::exception& exception) {
+    console_->error("Read inclined velocity constraints: {}", exception.what());
+    file.close();
+  }
+  return constraints;
+}
+
+//! Return euler angles of nodes
+template <unsigned Tdim>
+std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>
+    mpm::ReadMeshAscii<Tdim>::read_euler_angles(
+        const std::string& nodal_euler_angles_file) {
+
+  // Nodal euler angles
+  std::vector<std::tuple<mpm::Index, Eigen::Matrix<double, Tdim, 1>>>
+      euler_angles;
+  euler_angles.clear();
+
+  // input file stream
+  std::fstream file;
+  file.open(nodal_euler_angles_file.c_str(), std::ios::in);
+
+  try {
+    if (file.is_open() && file.good()) {
+      // Line
+      std::string line;
+      while (std::getline(file, line)) {
+        boost::algorithm::trim(line);
+        std::istringstream istream(line);
+        // ignore comment lines (# or !) or blank lines
+        if ((line.find('#') == std::string::npos) &&
+            (line.find('!') == std::string::npos) && (line != "")) {
+          while (istream.good()) {
+            // ID
+            mpm::Index id;
+            // Angles
+            Eigen::Matrix<double, Tdim, 1> angles;
+            // Read stream
+            istream >> id;
+            for (unsigned i = 0; i < Tdim; ++i) {
+              istream >> angles[i];
+            }
+            euler_angles.emplace_back(std::make_tuple(id, angles));
+          }
+        }
+      }
+    }
+    file.close();
+  } catch (std::exception& exception) {
+    console_->error("Read euler angles: {}", exception.what());
+    file.close();
+  }
+  return euler_angles;
+}
+
 //! Return particles volume
 template <unsigned Tdim>
 std::vector<std::tuple<mpm::Index, double>>


### PR DESCRIPTION
Core code
- [x] add function `assign_rotation_matrix` in `node` to store rotation matrix for transformation to global to local coordinate (and vice versa)
- [x] add function `assign_inclined_velocity_boundary` in `node` to assign velocity boundary condition in the direction of local coordinate
- [x] add function `apply_inclined_velocity_boundary` in `node` to apply these boundary conditions. I will call this function within `apply_velocity_boundary`
- [x] make test cases for `assign_rotation_matrix` in `node`
- [x] make test cases for `assign_inclined_velocity_boundary` in `node` 
- [x] make test cases for `apply_inclined_velocity_boundary` in `node`

Codes for the input:
- [x] in `mesh`, need to make  `assign_inclined_velocity_boundary` 
- [x] in `mesh`, need to make `assign_rotation_matrix` which will include the call to `geometry`'s `rotation_matrix`
- [x] edit input files to include 2 new files: `nodal_euler_angle.txt` to input euler angles needed to make rotation matrix, and `inclined_velocity_boundary.txt` to input velocity boundary in local coordinate, analogous to the current `velocity-boundary.txt`. For this, two functions are made: 
    - [x] in `read_mesh`, write `read_inclined_velocity_constraints` 
    - [x] in `read_mesh`, write `read_euler_angles` 
    - [x] in `mpm_explicit`, modify the `io`
- [x] make test cases for `assign_inclined_velocity_boundary` in `mesh`
- [x] make test cases for `assign_rotation_matrix` in `mesh`
- [x] make test cases for `read_inclined_velocity_constraints` in `read_mesh`
- [x] make test cases for `read_euler_angles` in `read_mesh`
- [x] make test cases for `initialise_mesh` in `mpm_explicit`