### PR TITLE
Add rotation matrix to node

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -21,6 +21,7 @@
 #include "cell.h"
 #include "container.h"
 #include "factory.h"
+#include "geometry.h" 
 #include "hdf5.h"
 #include "logger.h"
 #include "material/material.h"
@@ -206,6 +207,12 @@ class Mesh {
       const std::vector<std::tuple<mpm::Index, unsigned, double>>&
           velocity_constraints);
 
+  //! Assign rotation matrix
+  //! \param[in] inclined_velocity_constraints Constraint at node id and euler
+  //! angles
+  bool assign_rotation_matrices(
+      const std::map<mpm::Index, Eigen::Matrix<double, Tdim, 1>>& euler_angles);
+
   //! Assign velocity constraints to cells
   //! \param[in] velocity_constraints Constraint at cell id, face id, dir, and
   //! velocity
@@ -308,6 +315,8 @@ class Mesh {
   Map<Cell<Tdim>> map_cells_;
   //! Container of cells
   Container<Cell<Tdim>> cells_;
+  //! Geometry to call functions within it
+  std::unique_ptr<mpm::Geometry<Tdim>> geometry_;
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Mesh class

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <vector>
@@ -207,8 +208,8 @@ class Mesh {
       const std::vector<std::tuple<mpm::Index, unsigned, double>>&
           velocity_constraints);
 
-  //! Assign rotation matrix
-  //! \param[in] euler_angles Map of node numebr and respective euler_angles
+  //! Compute and assign rotation matrix to nodes
+  //! \param[in] euler_angles Map of node number and respective euler_angles
   bool compute_nodal_rotation_matrices(
       const std::map<mpm::Index, Eigen::Matrix<double, Tdim, 1>>& euler_angles);
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -208,9 +208,8 @@ class Mesh {
           velocity_constraints);
 
   //! Assign rotation matrix
-  //! \param[in] inclined_velocity_constraints Constraint at node id and euler
-  //! angles
-  bool assign_rotation_matrices(
+  //! \param[in] euler_angles Map of node numebr and respective euler_angles
+  bool compute_nodal_rotation_matrices(
       const std::map<mpm::Index, Eigen::Matrix<double, Tdim, 1>>& euler_angles);
 
   //! Assign velocity constraints to cells

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <array>
 #include <limits>
-#include <map>
 #include <memory>
 #include <numeric>
 #include <vector>

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -21,7 +21,7 @@
 #include "cell.h"
 #include "container.h"
 #include "factory.h"
-#include "geometry.h" 
+#include "geometry.h"
 #include "hdf5.h"
 #include "logger.h"
 #include "material/material.h"

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -521,7 +521,7 @@ bool mpm::Mesh<Tdim>::assign_particles_volumes(
   return status;
 }
 
-//! Assign rotation matrix to nodes
+//! Compute and assign rotation matrix to nodes
 template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::compute_nodal_rotation_matrices(
     const std::map<mpm::Index, Eigen::Matrix<double, Tdim, 1>>& euler_angles) {
@@ -539,11 +539,10 @@ bool mpm::Mesh<Tdim>::compute_nodal_rotation_matrices(
       // Euler angles
       Eigen::Matrix<double, Tdim, 1> angles = nodal_euler_angles.second;
       // Compute rotation matrix
-      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix =
-          geometry_->rotation_matrix(angles);
+      auto rotation_matrix = geometry_->rotation_matrix(angles);
 
       // Apply rotation matrix to nodes
-      map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);
+      map_nodes_.at(nid)->assign_rotation_matrix(rotation_matrix);
       status = true;
     }
   } catch (std::exception& exception) {

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -523,7 +523,7 @@ bool mpm::Mesh<Tdim>::assign_particles_volumes(
 
 //! Assign rotation matrix to nodes
 template <unsigned Tdim>
-bool mpm::Mesh<Tdim>::assign_rotation_matrices(
+bool mpm::Mesh<Tdim>::compute_nodal_rotation_matrices(
     const std::map<mpm::Index, Eigen::Matrix<double, Tdim, 1>>& euler_angles) {
   bool status = false;
   try {
@@ -535,16 +535,17 @@ bool mpm::Mesh<Tdim>::assign_rotation_matrices(
     // Loop through nodal_euler_angles of different nodes
     for (const auto& nodal_euler_angles : euler_angles) {
       // Node id
-      mpm::Index nid = std::get<0>(nodal_euler_angles);
+      mpm::Index nid = nodal_euler_angles.first;
       // Euler angles
-      Eigen::Matrix<double, Tdim, 1> angles = std::get<1>(nodal_euler_angles);
-
+      Eigen::Matrix<double, Tdim, 1> angles = nodal_euler_angles.second;
       // Compute rotation matrix
       Eigen::Matrix<double, Tdim, Tdim> rotation_matrix =
           geometry_->rotation_matrix(angles);
 
-      // Apply constraint
-      status = map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);
+      // Apply rotation matrix to nodes
+      map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);
+
+      status = true;
 
       if (!status)
         throw std::runtime_error("Node or euler angles is/are invalid");

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -544,11 +544,7 @@ bool mpm::Mesh<Tdim>::compute_nodal_rotation_matrices(
 
       // Apply rotation matrix to nodes
       map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);
-
       status = true;
-
-      if (!status)
-        throw std::runtime_error("Node or euler angles is/are invalid");
     }
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -542,7 +542,7 @@ bool mpm::Mesh<Tdim>::compute_nodal_rotation_matrices(
       auto rotation_matrix = geometry_->rotation_matrix(angles);
 
       // Apply rotation matrix to nodes
-      map_nodes_.at(nid)->assign_rotation_matrix(rotation_matrix);
+      map_nodes_[nid]->assign_rotation_matrix(rotation_matrix);
       status = true;
     }
   } catch (std::exception& exception) {

--- a/include/node.h
+++ b/include/node.h
@@ -175,8 +175,9 @@ class Node : public NodeBase<Tdim> {
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
   void assign_rotation_matrix(
-      const Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
+      const Eigen::Matrix<double, Tdim, Tdim>& rotation_matrix) override {
     rotation_matrix_ = rotation_matrix;
+    generic_velocity_constraints_ = true;
   }
 
  private:
@@ -208,6 +209,9 @@ class Node : public NodeBase<Tdim> {
   std::map<unsigned, double> velocity_constraints_;
   //! Rotation matrix for inclined velocity constraints
   Eigen::Matrix<double, Tdim, Tdim> rotation_matrix_;
+  //! A general velocity (non-Cartesian/inclined) constraint is specified at the
+  //! node
+  bool generic_velocity_constraints_{false};
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Node class

--- a/include/node.h
+++ b/include/node.h
@@ -175,9 +175,7 @@ class Node : public NodeBase<Tdim> {
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
   bool assign_rotation_matrix(
-      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
-    rotation_matrix_ = rotation_matrix;
-  }
+      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override;
 
  private:
   //! Mutex

--- a/include/node.h
+++ b/include/node.h
@@ -172,6 +172,13 @@ class Node : public NodeBase<Tdim> {
   //! Apply velocity constraints
   void apply_velocity_constraints() override;
 
+  //! Assign rotation matrix
+  //! \param[in] rotation_matrix Rotation matrix of the node
+  bool assign_rotation_matrix(
+      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
+    rotation_matrix_ = rotation_matrix;
+  }
+
  private:
   //! Mutex
   std::mutex node_mutex_;
@@ -199,6 +206,8 @@ class Node : public NodeBase<Tdim> {
   Eigen::Matrix<double, Tdim, Tnphases> acceleration_;
   //! Velocity constraints
   std::map<unsigned, double> velocity_constraints_;
+  //! Rotation matrix for inclined velocity constraints
+  Eigen::Matrix<double, Tdim, Tdim> rotation_matrix_;
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };  // Node class

--- a/include/node.h
+++ b/include/node.h
@@ -174,8 +174,10 @@ class Node : public NodeBase<Tdim> {
 
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
-  bool assign_rotation_matrix(
-      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override;
+  void assign_rotation_matrix(
+      const Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) override {
+    rotation_matrix_ = rotation_matrix;
+  }
 
  private:
   //! Mutex

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -276,15 +276,3 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_velocity_constraints() {
     this->acceleration_(direction, phase) = 0.;
   }
 }
-
-//! Assign rotation matrix
-//! \param[in] rotation_matrix Rotation matrix of the node
-template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
-bool mpm::Node<Tdim, Tdof, Tnphases>::assign_rotation_matrix(
-    Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) {
-  bool status = true;
-
-  rotation_matrix_ = rotation_matrix;
-
-  return status;
-}

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -276,3 +276,15 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_velocity_constraints() {
     this->acceleration_(direction, phase) = 0.;
   }
 }
+
+//! Assign rotation matrix
+//! \param[in] rotation_matrix Rotation matrix of the node
+template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
+bool mpm::Node<Tdim, Tdof, Tnphases>::assign_rotation_matrix(
+    Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) {
+  bool status = true;
+
+  rotation_matrix_ = rotation_matrix;
+
+  return status;
+}

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -152,6 +152,11 @@ class NodeBase {
   //! Apply velocity constraints
   virtual void apply_velocity_constraints() = 0;
 
+  //! Assign rotation matrix
+  //! \param[in] rotation_matrix Rotation matrix of the node
+  virtual bool assign_rotation_matrix(
+      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
+
 };  // NodeBase class
 }  // namespace mpm
 

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -155,7 +155,7 @@ class NodeBase {
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
   virtual void assign_rotation_matrix(
-      Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
+      const Eigen::Matrix<double, Tdim, Tdim>& rotation_matrix) = 0;
 
 };  // NodeBase class
 }  // namespace mpm

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -154,7 +154,7 @@ class NodeBase {
 
   //! Assign rotation matrix
   //! \param[in] rotation_matrix Rotation matrix of the node
-  virtual bool assign_rotation_matrix(
+  virtual void assign_rotation_matrix(
       Eigen::Matrix<double, Tdim, Tdim> rotation_matrix) = 0;
 
 };  // NodeBase class

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -1773,6 +1773,31 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                   false);
         }
 
+        // Test assign rotation matrices to nodes
+        SECTION("Check assign rotation matrices to nodes") {
+          // Map of nodal id and euler angles
+          std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>> euler_angles;
+          // Euler angles
+          euler_angles.emplace(std::make_pair(
+              0, (Eigen::Matrix<double, Dim, 1>() << 10. * M_PI / 180,
+                  20. * M_PI / 180, 30. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              1, (Eigen::Matrix<double, Dim, 1>() << 40. * M_PI / 180,
+                  50. * M_PI / 180, 60. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              2, (Eigen::Matrix<double, Dim, 1>() << 70. * M_PI / 180,
+                  80. * M_PI / 180, 90. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              3, (Eigen::Matrix<double, Dim, 1>() << 100. * M_PI / 180,
+                  110. * M_PI / 180, 120. * M_PI / 180)
+                     .finished()));
+
+          REQUIRE(mesh->assign_rotation_matrices(euler_angles) == true);
+        }
+
         // Test assign velocity constraints to cells
         SECTION("Check assign velocity constraints to cells") {
           // Vector of particle coordinates

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -826,7 +826,10 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
         SECTION("Check assign rotation matrices to nodes") {
           // Map of nodal id and euler angles
           std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>> euler_angles;
-          // Euler angles
+          // Node 0 (non-existent) with Euler angles of 10 and 20  deg
+          // Node 1 (non-existent) with Euler angles of 30 and 40 deg
+          // Node 2 (non-existent) with Euler angles of 50 and 60 deg
+          // Node 3 (non-existent) with Euler angles of 70 and 80 deg
           euler_angles.emplace(std::make_pair(
               0, (Eigen::Matrix<double, Dim, 1>() << 10. * M_PI / 180,
                   20. * M_PI / 180)
@@ -845,7 +848,22 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                      .finished()));
 
           REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
-          // Check for failure
+
+          // Check for failure when missing node id
+          // Node 100 (non-existent) with Euler angles of 90 and 100 deg
+          euler_angles.emplace(std::make_pair(
+              100, (Eigen::Matrix<double, Dim, 1>() << 90. * M_PI / 180,
+                    100. * M_PI / 180)
+                       .finished()));
+          REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == false);
+
+          // Check for failure of empty input
+          std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>>
+              empty_euler_angles;
+          REQUIRE(mesh->compute_nodal_rotation_matrices(empty_euler_angles) ==
+                  false);
+
+          // Check for failure when no nodes are assigned
           auto mesh_fail = std::make_shared<mpm::Mesh<Dim>>(1);
           REQUIRE(mesh_fail->compute_nodal_rotation_matrices(euler_angles) ==
                   false);
@@ -1781,7 +1799,10 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
         SECTION("Check assign rotation matrices to nodes") {
           // Map of nodal id and euler angles
           std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>> euler_angles;
-          // Euler angles
+          // Node 0 (non-existent) with Euler angles of 10, 20 and 30 deg
+          // Node 1 (non-existent) with Euler angles of 40, 50 and 60 deg
+          // Node 2 (non-existent) with Euler angles of 70, 80 and 90 deg
+          // Node 3 (non-existent) with Euler angles of 100, 110 and 120 deg
           euler_angles.emplace(std::make_pair(
               0, (Eigen::Matrix<double, Dim, 1>() << 10. * M_PI / 180,
                   20. * M_PI / 180, 30. * M_PI / 180)
@@ -1800,7 +1821,22 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                      .finished()));
 
           REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
-          // Check for failure
+
+          // Check for failure when missing node id
+          // Node 100 (non-existent) with Euler angles of 130, 140 and 150 deg
+          euler_angles.emplace(std::make_pair(
+              100, (Eigen::Matrix<double, Dim, 1>() << 130. * M_PI / 180,
+                    140. * M_PI / 180, 150. * M_PI / 180)
+                       .finished()));
+          REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == false);
+
+          // Check for failure of empty input
+          std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>>
+              empty_euler_angles;
+          REQUIRE(mesh->compute_nodal_rotation_matrices(empty_euler_angles) ==
+                  false);
+
+          // Check for failure when no nodes are assigned
           auto mesh_fail = std::make_shared<mpm::Mesh<Dim>>(1);
           REQUIRE(mesh_fail->compute_nodal_rotation_matrices(euler_angles) ==
                   false);

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <limits>
 #include <memory>
 
@@ -819,6 +820,31 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
           velocity_constraints.emplace_back(std::make_tuple(3, 2, 0.0));
           REQUIRE(mesh->assign_velocity_constraints(velocity_constraints) ==
                   false);
+        }
+
+        // Test assign rotation matrices to nodes
+        SECTION("Check assign rotation matrices to nodes") {
+          // Map of nodal id and euler angles
+          std::map<mpm::Index, Eigen::Matrix<double, Dim, 1>> euler_angles;
+          // Euler angles
+          euler_angles.emplace(std::make_pair(
+              0, (Eigen::Matrix<double, Dim, 1>() << 10. * M_PI / 180,
+                  20. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              1, (Eigen::Matrix<double, Dim, 1>() << 30. * M_PI / 180,
+                  40. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              2, (Eigen::Matrix<double, Dim, 1>() << 50. * M_PI / 180,
+                  60. * M_PI / 180)
+                     .finished()));
+          euler_angles.emplace(std::make_pair(
+              3, (Eigen::Matrix<double, Dim, 1>() << 70. * M_PI / 180,
+                  80. * M_PI / 180)
+                     .finished()));
+
+          REQUIRE(mesh->assign_rotation_matrices(euler_angles) == true);
         }
 
         // Test assign velocity constraints to cells

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -845,6 +845,10 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                      .finished()));
 
           REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
+          // Check for failure
+          auto mesh_fail = std::make_shared<mpm::Mesh<Dim>>(1);
+          REQUIRE(mesh_fail->compute_nodal_rotation_matrices(euler_angles) ==
+                  false);
         }
 
         // Test assign velocity constraints to cells
@@ -1796,6 +1800,10 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                      .finished()));
 
           REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
+          // Check for failure
+          auto mesh_fail = std::make_shared<mpm::Mesh<Dim>>(1);
+          REQUIRE(mesh_fail->compute_nodal_rotation_matrices(euler_angles) ==
+                  false);
         }
 
         // Test assign velocity constraints to cells

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -844,7 +844,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                   80. * M_PI / 180)
                      .finished()));
 
-          REQUIRE(mesh->assign_rotation_matrices(euler_angles) == true);
+          REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
         }
 
         // Test assign velocity constraints to cells
@@ -1795,7 +1795,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                   110. * M_PI / 180, 120. * M_PI / 180)
                      .finished()));
 
-          REQUIRE(mesh->assign_rotation_matrices(euler_angles) == true);
+          REQUIRE(mesh->compute_nodal_rotation_matrices(euler_angles) == true);
         }
 
         // Test assign velocity constraints to cells


### PR DESCRIPTION
Node:
- [x] add function `assign_rotation_matrix` in `node` to store rotation matrix for transformation to global to local coordinate (and vice versa)
- Test for `rotation_matrix` in `node` will be done together when applying boundary conditions just like testing for velocity constraints.

Mesh:
- [x] in `mesh`, need to make `assign_rotation_matrix` which will include the call to `geometry`'s `rotation_matrix`
- [x] make test cases for `assign_rotation_matrix` in `mesh`