### PR TITLE
:computer: Explicitly use nodal velocity to update coordinates on velocity update

### DIFF
--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -520,14 +520,14 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Get interpolated nodal acceleration
-      Eigen::Matrix<double, Tdim, 1> nodal_acceleration =
+      const Eigen::Matrix<double, Tdim, 1> nodal_acceleration =
           cell_->interpolate_nodal_acceleration(this->shapefn_, phase);
 
       // Update particle velocity from interpolated nodal acceleration
       this->velocity_.col(phase) += nodal_acceleration * dt;
 
       // Get interpolated nodal velocity
-      Eigen::Matrix<double, Tdim, 1> nodal_velocity =
+      const Eigen::Matrix<double, Tdim, 1> nodal_velocity =
           cell_->interpolate_nodal_velocity(this->shapefn_, phase);
 
       // New position  current position + velocity * dt
@@ -553,14 +553,14 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Get interpolated nodal velocity
-      Eigen::Matrix<double, Tdim, 1> velocity =
+      const Eigen::Matrix<double, Tdim, 1> nodal_velocity =
           cell_->interpolate_nodal_velocity(this->shapefn_, phase);
 
       // Update particle velocity to interpolated nodal velocity
-      this->velocity_.col(phase) = velocity;
+      this->velocity_.col(phase) = nodal_velocity;
 
       // New position current position + velocity * dt
-      this->coordinates_ += this->velocity_.col(phase) * dt;
+      this->coordinates_ += nodal_velocity * dt;
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "


### PR DESCRIPTION
This explicitly sets the coordinate update from the nodal velocity. To avoid any particle based constraints affecting the coordinates, and to ensure all particles move corresponding to a unified nodal velocity.