### PR TITLE
Fix #398 nodal mass bug  

### DIFF
--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -73,6 +73,9 @@ bool mpm::Particle<Tdim, Tnphases>::initialise_particle(
   // Status
   this->status_ = particle.status;
 
+  // If a cell already exists remove particle from that cell
+  if (cell_ != nullptr) cell_->remove_particle_id(this->id_);
+
   // Cell id
   this->cell_id_ = particle.cell_id;
   this->cell_ = nullptr;


### PR DESCRIPTION
The problem arises from the double initialization of the `particles`. Even though the `particles` have the right `cell_id`, the `cell` does not have the right `particles`.

Proposed solution: in resume, remove each particle from the cell it belongs to.