### PR TITLE
Fix node id number for hex-20

### DIFF
--- a/include/hexahedron_element.tcc
+++ b/include/hexahedron_element.tcc
@@ -566,7 +566,7 @@ inline Eigen::VectorXi
   // clang-format off
   const std::map<unsigned, Eigen::Matrix<int, 8, 1>> face_indices_hexahedron{
       {0, (Eigen::Matrix<int, 8, 1>() << 0, 1, 5, 4,  8, 12, 16, 10).finished()},
-      {1, (Eigen::Matrix<int, 8, 1>() << 5, 1, 2, 0, 12, 11, 14, 18).finished()},
+      {1, (Eigen::Matrix<int, 8, 1>() << 5, 1, 2, 6, 12, 11, 14, 18).finished()},
       {2, (Eigen::Matrix<int, 8, 1>() << 7, 6, 2, 3, 19, 14, 13, 15).finished()},
       {3, (Eigen::Matrix<int, 8, 1>() << 0, 4, 7, 3, 10, 17, 15,  9).finished()},
       {4, (Eigen::Matrix<int, 8, 1>() << 1, 0, 3, 2,  8,  9, 13, 11).finished()},

--- a/tests/hexahedron_element_test.cc
+++ b/tests/hexahedron_element_test.cc
@@ -2438,7 +2438,7 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
       Eigen::Matrix<int, 6, 8> indices;
       // clang-format off
       indices << 0, 1, 5, 4,  8, 12, 16, 10,
-                 5, 1, 2, 0, 12, 11, 14, 18,
+                 5, 1, 2, 6, 12, 11, 14, 18,
                  7, 6, 2, 3, 19, 14, 13, 15,
                  0, 4, 7, 3, 10, 17, 15,  9,
                  1, 0, 3, 2,  8,  9, 13, 11,


### PR DESCRIPTION
Just a typo on the node id of the face

Reference: [`GMSH`](http://gmsh.info/doc/texinfo/gmsh.html)
```
Hexahedron:             Hexahedron20:          Hexahedron27:

       v
3----------2            3----13----2           3----13----2
|\     ^   |\           |\         |\          |\         |\
| \    |   | \          | 15       | 14        |15    24  | 14
|  \   |   |  \         9  \       11 \        9  \ 20    11 \
|   7------+---6        |   7----19+---6       |   7----19+---6
|   |  +-- |-- | -> u   |   |      |   |       |22 |  26  | 23|
0---+---\--1   |        0---+-8----1   |       0---+-8----1   |
 \  |    \  \  |         \  17      \  18       \ 17    25 \  18
  \ |     \  \ |         10 |        12|        10 |  21    12|
   \|      w  \|           \|         \|          \|         \|
    4----------5            4----16----5           4----16----5
```
