### PR TITLE
Initial condition for newton-raphson

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -8,6 +8,8 @@
 #include <set>
 #include <vector>
 
+#include <math.h>
+
 #include "Eigen/Dense"
 #include "Eigen/LU"
 

--- a/include/cell.h
+++ b/include/cell.h
@@ -8,8 +8,6 @@
 #include <set>
 #include <vector>
 
-#include <math.h>
-
 #include "Eigen/Dense"
 #include "Eigen/LU"
 

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -1033,7 +1033,7 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::transform_real_to_unit_cell(
       xi(i) = 0.999999999999;
 
   // Maximum iterations of newton raphson
-  const unsigned max_iterations = 100;
+  const unsigned max_iterations = 10000;
 
   // Tolerance for newton raphson
   const double Tolerance = 1.0E-10;
@@ -1189,7 +1189,7 @@ inline Eigen::Matrix<double, 3, 1> mpm::Cell<3>::transform_real_to_unit_cell(
       xi(i) = 0.999999999999;
 
   // Maximum iterations of newton raphson
-  const unsigned max_iterations = 100;
+  const unsigned max_iterations = 10000;
 
   // Tolerance for newton raphson
   const double Tolerance = 1.0E-10;

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -177,15 +177,16 @@ std::vector<std::array<mpm::Index, 2>> mpm::Cell<Tdim>::side_node_pairs()
 
 //! Add a neighbour cell and return the status of addition of a node
 template <unsigned Tdim>
-bool mpm::Cell<Tdim>::add_neighbour(mpm::Index neighbour_id) {
+bool mpm::Cell<Tdim>::add_neighbour(
+    unsigned local_id, const std::shared_ptr<mpm::Cell<Tdim>>& cell_ptr) {
   bool insertion_status = false;
   try {
-    // If cell id is not the same as the current cell
-    if (neighbour_id != this->id())
-      insertion_status = (neighbours_.insert(neighbour_id)).second;
-    else
+    // If number of cell ptrs id is not the current cell id
+    if (cell_ptr->id() != this->id()) {
+      insertion_status = neighbour_cells_.insert(local_id, cell_ptr);
+    } else {
       throw std::runtime_error("Invalid local id of a cell neighbour");
-
+    }
   } catch (std::exception& exception) {
     console_->error("{} {}: {}\n", __FILE__, __LINE__, exception.what());
   }
@@ -1025,6 +1026,11 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::transform_real_to_unit_cell(
     geometry_xi = affine_guess;
   }
 
+  // Check if the first trial xi is within the unit cell (-1, 1)
+  for (unsigned i = 0; i < xi.size(); ++i)
+    if (xi(i) < -1.) xi(i) = -0.999999999999;
+    else if (xi(i) > 1.) xi(i) = 0.999999999999;
+
   // Maximum iterations of newton raphson
   const unsigned max_iterations = 100;
 
@@ -1081,8 +1087,10 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::transform_real_to_unit_cell(
       }
     }
     // Convergence criteria
-    if ((step_length * delta).norm() < Tolerance) break;
-
+    if ((step_length * delta).norm() < Tolerance) {
+      //console_->info("NR solution is successful");
+      break;
+    }
     // Check for nan and set to a trial xi
     if (std::isnan(xi(0)) || std::isnan(xi(1))) xi.setZero();
   }
@@ -1173,6 +1181,11 @@ inline Eigen::Matrix<double, 3, 1> mpm::Cell<3>::transform_real_to_unit_cell(
     if ((affine_residual.squaredNorm() < affine_tolerance) && !affine_nan)
       return xi;
   }
+
+  // Check if the first trial xi is within the unit cell (-1, 1)
+  for (unsigned i = 0; i < xi.size(); ++i)
+    if (xi(i) < -1.) xi(i) = -0.999999999999;
+    else if (xi(i) > 1.) xi(i) = 0.999999999999;
 
   // Maximum iterations of newton raphson
   const unsigned max_iterations = 100;
@@ -1499,25 +1512,4 @@ inline void mpm::Cell<3>::compute_normals() {
     face_normals_.insert(std::make_pair<unsigned, Eigen::VectorXd>(
         static_cast<unsigned>(face_id), normal_vector));
   }
-}
-
-//! Return a sorted list of face node ids
-template <unsigned Tdim>
-inline std::vector<std::vector<mpm::Index>>
-    mpm::Cell<Tdim>::sorted_face_node_ids() {
-  std::vector<std::vector<mpm::Index>> set_face_nodes;
-  //! Set number of faces from element
-  for (unsigned face_id = 0; face_id < element_->nfaces(); ++face_id) {
-    std::vector<mpm::Index> face_nodes;
-
-    // Get the nodes of the face
-    const Eigen::VectorXi indices = element_->face_indices(face_id);
-    for (int id = 0; id < indices.size(); ++id)
-      face_nodes.emplace_back(nodes_[indices(id)]->id());
-
-    // Sort in ascending order
-    std::sort(face_nodes.begin(), face_nodes.end());
-    set_face_nodes.emplace_back(face_nodes);
-  }
-  return set_face_nodes;
 }

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -461,12 +461,12 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
         if (isnan(stress(i))) {
           throw std::runtime_error("Stress computed is not a number");
           nan_status = false;
-        }   
+        }
       }
 
       // Update stress if it is not NaN, keep current stress if NaN
       if (nan_status) {
-        this->stress_.col(phase) = stress;  
+        this->stress_.col(phase) = stress;
       }
 
     } else {

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -452,23 +452,8 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
     if (material_.at(phase) != nullptr) {
       Eigen::Matrix<double, 6, 1> dstrain = this->dstrain_.col(phase);
       // Calculate stress
-      auto stress = material_.at(phase)->compute_stress(
+      this->stress_.col(phase) = material_.at(phase)->compute_stress(
           this->stress_.col(phase), dstrain, this, &state_variables_);
-
-      // Checking NaN
-      bool nan_status = true;
-      for (unsigned i = 0; i < stress.size(); ++i) {
-        if (isnan(stress(i))) {
-          throw std::runtime_error("Stress computed is not a number");
-          nan_status = false;
-        }
-      }
-
-      // Update stress if it is not NaN, keep current stress if NaN
-      if (nan_status) {
-        this->stress_.col(phase) = stress;
-      }
-
     } else {
       throw std::runtime_error("Material is invalid");
     }

--- a/tests/point_in_cell_test.cc
+++ b/tests/point_in_cell_test.cc
@@ -426,4 +426,75 @@ TEST_CASE("Point in cell 2D", "[PointInCell][2D]") {
     for (unsigned i = 0; i < local_point.size(); ++i)
       REQUIRE(local_point[i] == Approx(point_unit_cell[i]).epsilon(Tolerance));
   }
+
+  SECTION("Check point in unit cell overall solution") {
+
+    // Number of nodes in cell
+    const unsigned Nnodes = 4;
+
+    // Coordinates
+    Eigen::Vector2d coords;
+
+    coords << 0.499732, 0.00661057;
+    std::shared_ptr<mpm::NodeBase<Dim>> node0 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(0, coords);
+
+    coords << 0.501049, 0.0062308;
+    std::shared_ptr<mpm::NodeBase<Dim>> node1 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(1, coords);
+
+    coords << 0.499732, 0.00911057;
+    std::shared_ptr<mpm::NodeBase<Dim>> node2 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(2, coords);
+
+    coords << 0.501049, 0.0087308;
+    std::shared_ptr<mpm::NodeBase<Dim>> node3 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
+
+    coords << 0.499732, 0.0116106;
+    std::shared_ptr<mpm::NodeBase<Dim>> node4 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(4, coords);
+
+    coords << 0.501049, 0.0112308;
+    std::shared_ptr<mpm::NodeBase<Dim>> node5 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(5, coords);
+
+    // 4-noded quadrilateral shape functions
+    std::shared_ptr<mpm::Element<Dim>> element =
+        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+
+    Eigen::Vector2d xi;
+    // Coordinates of a point in real cell
+    Eigen::Vector2d point;
+    point << 0.5001136347599692, 0.009000523946142933;
+    // Cell 1
+    mpm::Index id = 0;
+    auto cell1 = std::make_shared<mpm::Cell<Dim>>(id, Nnodes, element);
+
+    REQUIRE(cell1->add_node(0, node0) == true);
+    REQUIRE(cell1->add_node(1, node1) == true);
+    REQUIRE(cell1->add_node(2, node3) == true);
+    REQUIRE(cell1->add_node(3, node2) == true);
+    REQUIRE(cell1->nnodes() == 4);
+
+    // Initialise cell
+    REQUIRE(cell1->initialise() == true);
+    // Test if point is in cell
+    REQUIRE(cell1->is_point_in_cell(point, &xi) == false);
+
+    // Cell 2
+    mpm::Index id2 = 1;
+    auto cell2 = std::make_shared<mpm::Cell<Dim>>(id2, Nnodes, element);
+
+    REQUIRE(cell2->add_node(0, node2) == true);
+    REQUIRE(cell2->add_node(1, node3) == true);
+    REQUIRE(cell2->add_node(2, node5) == true);
+    REQUIRE(cell2->add_node(3, node4) == true);
+    REQUIRE(cell2->nnodes() == 4);
+
+    // Initialise cell
+    REQUIRE(cell2->initialise() == true);
+    // Test if point is in cell
+    REQUIRE(cell2->is_point_in_cell(point, &xi) == true);
+  }
 }


### PR DESCRIPTION
- [x] Affine transformation might give initial condition of newton-raphson outside of [-1, 1], thus creating problems for particles near the edge of an element which might result in failure of finding the natural coordinates of the particle. Thus, initial condition is kept [-1, 1].
- [x] Stress computation from material is checked for NaN (not a number) which usually happens in case of zero divided by zero. 