### PR TITLE
Triangle element class and unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ jobs:
           name: cppcheck
           command: |
             cppcheck --version
-            cppcheck --enable=warning --inconclusive --force --language=c++ --std=c++11 src/*.cc include/*.h include/*.tcc --error-exitcode=1
+            cppcheck --inline-suppr --enable=warning --inconclusive --force --language=c++ --std=c++11 src/*.cc include/*.h include/*.tcc --error-exitcode=1
       # clang-format
       - run:
           name: clang-format
           command: |
-            python ./clang-tools/run-clang-format.py -r include/* src/* tests/*
+            python3 ./clang-tools/run-clang-format.py -r include/* src/* tests/*
       # codecoverage
       - run:
           name: codecov.io

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/quadrilateral_gimp_element_test.cc
     ${mpm_SOURCE_DIR}/tests/quadrilateral_quadrature_test.cc    
     ${mpm_SOURCE_DIR}/tests/read_mesh_ascii_test.cc
+    ${mpm_SOURCE_DIR}/tests/triangle_element_test.cc
+    ${mpm_SOURCE_DIR}/tests/triangle_quadrature_test.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
   )   

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -243,12 +243,13 @@ inline void mpm::Cell<2>::compute_volume() {
       auto node1 = nodes_[indices(1)]->coordinates();
       auto node2 = nodes_[indices(2)]->coordinates();
 
-      // 2 * Area = (x1 * y2 - x2 * y1) - (x0 * y2 - x2 * y0) + (x0 * y1 - x1 *
-      // y0)
+      // Area = 0.5 * [ (x1 * y2 - x2 * y1)
+      //              - (x0 * y2 - x2 * y0)
+      //              + (x0 * y1 - x1 * y0) ]
       volume_ = std::fabs(((node1(0) * node2(1)) - (node2(0) * node1(1))) -
                           ((node0(0) * node2(1)) - (node2(0) * node0(1))) +
-                          ((node0(0) * node1(1)) - (node1(0) * node0(1)))) /
-                2.0;
+                          ((node0(0) * node1(1)) - (node1(0) * node0(1)))) *
+                0.5;
       // Quadrilateral
     } else if (indices.size() == 4) {
 
@@ -552,11 +553,11 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::local_coordinates_point(
                            (node2(0) - node0(0)) * (node1(1) - node0(1))) /
                           2.0;
 
-      xi(0) = 1 / (2 * area) *
+      xi(0) = 1. / (2. * area) *
               ((point(0) - node0(0)) * (node2(1) - node0(1)) -
                (node2(0) - node0(0)) * (point(1) - node0(1)));
 
-      xi(1) = -1 / (2 * area) *
+      xi(1) = -1. / (2. * area) *
               ((point(0) - node0(0)) * (node1(1) - node0(1)) -
                (node1(0) - node0(0)) * (point(1) - node0(1)));
       // Quadrilateral

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -472,13 +472,12 @@ inline bool mpm::Cell<Tdim>::is_point_in_cell(
   // Check if the transformed coordinate is within the unit cell:
   // between 0 and 1-xi(1-i) if the element is a triangle, and between
   // -1 and 1 if otherwise
-  switch (this->element_->corner_indices().size()) {
-    case 3 : for (unsigned i = 0; i < (*xi).size(); ++i)
+  if (this->element_->corner_indices().size()==3) {
+    for (unsigned i = 0; i < (*xi).size(); ++i)
       if ((*xi)(i) < 0. || (*xi)(i) > 1. - (*xi)(1-i) || std::isnan((*xi)(i))) status = false;
-      break;
-    default: for (unsigned i = 0; i < (*xi).size(); ++i)
+  } else {
+    for (unsigned i = 0; i < (*xi).size(); ++i)
       if ((*xi)(i) < -1. || (*xi)(i) > 1. || std::isnan((*xi)(i))) status = false;
-      break;
   }
   return status;
 }

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -242,12 +242,14 @@ inline void mpm::Cell<2>::compute_volume() {
       auto node0 = nodes_[indices(0)]->coordinates();
       auto node1 = nodes_[indices(1)]->coordinates();
       auto node2 = nodes_[indices(2)]->coordinates();
-      
-      // 2 * Area = (x1 * y2 - x2 * y1) - (x0 * y2 - x2 * y0) + (x0 * y1 - x1 * y0)
+
+      // 2 * Area = (x1 * y2 - x2 * y1) - (x0 * y2 - x2 * y0) + (x0 * y1 - x1 *
+      // y0)
       volume_ = std::fabs(((node1(0) * node2(1)) - (node2(0) * node1(1))) -
                           ((node0(0) * node2(1)) - (node2(0) * node0(1))) +
-                          ((node0(0) * node1(1)) - (node1(0) * node0(1))))/2.0;
-    // Quadrilateral
+                          ((node0(0) * node1(1)) - (node1(0) * node0(1)))) /
+                2.0;
+      // Quadrilateral
     } else if (indices.size() == 4) {
 
       //        b
@@ -472,12 +474,14 @@ inline bool mpm::Cell<Tdim>::is_point_in_cell(
   // Check if the transformed coordinate is within the unit cell:
   // between 0 and 1-xi(1-i) if the element is a triangle, and between
   // -1 and 1 if otherwise
-  if (this->element_->corner_indices().size()==3) {
+  if (this->element_->corner_indices().size() == 3) {
     for (unsigned i = 0; i < (*xi).size(); ++i)
-      if ((*xi)(i) < 0. || (*xi)(i) > 1. - (*xi)(1-i) || std::isnan((*xi)(i))) status = false;
+      if ((*xi)(i) < 0. || (*xi)(i) > 1. - (*xi)(1 - i) || std::isnan((*xi)(i)))
+        status = false;
   } else {
     for (unsigned i = 0; i < (*xi).size(); ++i)
-      if ((*xi)(i) < -1. || (*xi)(i) > 1. || std::isnan((*xi)(i))) status = false;
+      if ((*xi)(i) < -1. || (*xi)(i) > 1. || std::isnan((*xi)(i)))
+        status = false;
   }
   return status;
 }
@@ -539,20 +543,23 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::local_coordinates_point(
       //   0 0-----0 1
       //        a
       //
-      
+
       auto node0 = nodes_[indices(0)]->coordinates();
       auto node1 = nodes_[indices(1)]->coordinates();
       auto node2 = nodes_[indices(2)]->coordinates();
 
-      const double area = ((node1(0) - node0(0)) * (node2(1) - node0(1))
-                           -(node2(0) - node0(0)) * (node1(1) - node0(1)))/2.0;
-      
-      xi(0) =  1 / (2*area) * ((point(0) - node0(0)) * (node2(1) - node0(1))
-                                  -(node2(0) - node0(0)) * (point(1) - node0(1)));
-      
-      xi(1) = -1 / (2*area) * ((point(0) - node0(0)) * (node1(1) - node0(1))
-                                  -(node1(0) - node0(0)) * (point(1) - node0(1)));
-    // Quadrilateral
+      const double area = ((node1(0) - node0(0)) * (node2(1) - node0(1)) -
+                           (node2(0) - node0(0)) * (node1(1) - node0(1))) /
+                          2.0;
+
+      xi(0) = 1 / (2 * area) *
+              ((point(0) - node0(0)) * (node2(1) - node0(1)) -
+               (node2(0) - node0(0)) * (point(1) - node0(1)));
+
+      xi(1) = -1 / (2 * area) *
+              ((point(0) - node0(0)) * (node1(1) - node0(1)) -
+               (node1(0) - node0(0)) * (point(1) - node0(1)));
+      // Quadrilateral
     } else if (indices.size() == 4) {
       //        b
       // 3 0--------0 2

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -223,13 +223,31 @@ inline void mpm::Cell<1>::compute_volume() {
 }
 
 //! Compute volume of a 2D cell
-//! Computes the volume of a quadrilateral
+//! Computes the volume of a triangle and a quadrilateral
 template <>
 inline void mpm::Cell<2>::compute_volume() {
   try {
     Eigen::VectorXi indices = element_->corner_indices();
+    // Triangle
+    if (indices.size() == 3) {
+
+      //   2 0
+      //     |`\
+      //     |  `\
+      //     |    `\
+      //     |      `\
+      //     |        `\
+      //   0 0----------0 1
+      //
+      auto node0 = nodes_[indices(0)]->coordinates();
+      auto node1 = nodes_[indices(1)]->coordinates();
+      auto node2 = nodes_[indices(2)]->coordinates();
+      // 2 * Area = (x1 * y2 - x2 * y1) - (x0 * y2 - x2 * y0) + (x0 * y1 - x1 * y0)
+      volume_ = std::fabs(((node1(0) * node2(1)) - (node2(0) - node1(1))) -
+                          ((node0(0) * node2(1)) - (node2(0) - node0(1))) +
+                          ((node0(0) * node1(1)) - (node1(0) - node0(1))))/2.0;
     // Quadrilateral
-    if (indices.size() == 4) {
+    } else if (indices.size() == 4) {
 
       //        b
       // 3 0---------0 2
@@ -502,8 +520,32 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::local_coordinates_point(
     // Indices of corner nodes
     Eigen::VectorXi indices = element_->corner_indices();
 
+    // Triangle
+    if (indices.size() == 3) {
+      //   2 0
+      //     |`\
+      //     |  `\  b
+      //   c |    `\
+      //     |      `\
+      //     |        `\
+      //   0 0----------0 1
+      //           a
+      //
+      
+      auto node0 = nodes_[indices(0)]->coordinates();
+      auto node1 = nodes_[indices(1)]->coordinates();
+      auto node2 = nodes_[indices(2)]->coordinates();
+
+      const double denominator = (node1(0) - node0(0)) * (node2(1) - node0(1))
+                                -(node2(0) - node0(0)) * (node1(1) - node0(1));
+      
+      xi(0) =  1 / denominator * (point(0) - node0(0)) * (node2(1) - node0(1))
+                                -(node2(0) - node0(0)) * (point(1) - node0(1));
+      
+      xi(1) = -1 / denominator * (point(0) - node0(0)) * (node1(1) - node0(1))
+                                -(node1(0) - node0(0)) * (point(1) - node0(1));
     // Quadrilateral
-    if (indices.size() == 4) {
+    } else if (indices.size() == 4) {
       //        b
       // 3 0--------0 2
       //   | \   / |

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -242,10 +242,11 @@ inline void mpm::Cell<2>::compute_volume() {
       auto node0 = nodes_[indices(0)]->coordinates();
       auto node1 = nodes_[indices(1)]->coordinates();
       auto node2 = nodes_[indices(2)]->coordinates();
+      
       // 2 * Area = (x1 * y2 - x2 * y1) - (x0 * y2 - x2 * y0) + (x0 * y1 - x1 * y0)
-      volume_ = std::fabs(((node1(0) * node2(1)) - (node2(0) - node1(1))) -
-                          ((node0(0) * node2(1)) - (node2(0) - node0(1))) +
-                          ((node0(0) * node1(1)) - (node1(0) - node0(1))))/2.0;
+      volume_ = std::fabs(((node1(0) * node2(1)) - (node2(0) * node1(1))) -
+                          ((node0(0) * node2(1)) - (node2(0) * node0(1))) +
+                          ((node0(0) * node1(1)) - (node1(0) * node0(1))))/2.0;
     // Quadrilateral
     } else if (indices.size() == 4) {
 
@@ -539,11 +540,11 @@ inline Eigen::Matrix<double, 2, 1> mpm::Cell<2>::local_coordinates_point(
       const double denominator = (node1(0) - node0(0)) * (node2(1) - node0(1))
                                 -(node2(0) - node0(0)) * (node1(1) - node0(1));
       
-      xi(0) =  1 / denominator * (point(0) - node0(0)) * (node2(1) - node0(1))
-                                -(node2(0) - node0(0)) * (point(1) - node0(1));
+      xi(0) =  1 / denominator * ((point(0) - node0(0)) * (node2(1) - node0(1))
+                                  -(node2(0) - node0(0)) * (point(1) - node0(1)));
       
-      xi(1) = -1 / denominator * (point(0) - node0(0)) * (node1(1) - node0(1))
-                                -(node1(0) - node0(0)) * (point(1) - node0(1));
+      xi(1) = -1 / denominator * ((point(0) - node0(0)) * (node1(1) - node0(1))
+                                  -(node1(0) - node0(0)) * (point(1) - node0(1)));
     // Quadrilateral
     } else if (indices.size() == 4) {
       //        b

--- a/include/hexahedron_element.tcc
+++ b/include/hexahedron_element.tcc
@@ -87,6 +87,7 @@ inline Eigen::MatrixXd mpm::HexahedronElement<3, 8>::unit_cell_coordinates()
                -1., -1.,  1.,
                 1., -1.,  1.,
                 1.,  1.,  1.,
+    // cppcheck-suppress *
                -1.,  1.,  1.;
   // clang-format on
   return unit_cell;
@@ -445,6 +446,7 @@ inline Eigen::MatrixXd mpm::HexahedronElement<3, 20>::unit_cell_coordinates()
                 0., -1.,  1.,
                -1.,  0.,  1.,
                 1.,  0.,  1.,
+    // cppcheck-suppress *
                 0.,  1.,  1.;
   // clang-format on
   return unit_cell;
@@ -496,6 +498,7 @@ inline Eigen::MatrixXi
              0, 4,
              1, 5,
              2, 6,
+    // cppcheck-suppress *
              3, 7;
   // clang-format on
   return indices;
@@ -509,6 +512,7 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::VectorXi
     mpm::HexahedronElement<Tdim, Tnfunctions>::corner_indices() const {
   Eigen::Matrix<int, 8, 1> indices;
+  // cppcheck-suppress *
   indices << 0, 1, 2, 3, 4, 5, 6, 7;
   return indices;
 }
@@ -533,6 +537,7 @@ inline Eigen::MatrixXi
              7, 4, 0,
              7, 0, 3,
              3, 0, 1,
+    // cppcheck-suppress *
              3, 1, 2;
   //clang-format on
   return indices;

--- a/include/quadrilateral_element.tcc
+++ b/include/quadrilateral_element.tcc
@@ -52,6 +52,7 @@ inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 4>::unit_cell_coordinates()
   unit_cell << -1., -1.,
                 1., -1.,
                 1.,  1.,
+    // cppcheck-suppress *
                -1.,  1.;
   // clang-format on
   return unit_cell;
@@ -129,6 +130,7 @@ inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 8>::unit_cell_coordinates()
                 0., -1.,
                 1.,  0.,
                 0.,  1.,
+    // cppcheck-suppress *
                -1.,  0.;
   // clang-format on
   return unit_cell;
@@ -212,6 +214,7 @@ inline Eigen::MatrixXd mpm::QuadrilateralElement<2, 9>::unit_cell_coordinates()
                 1.,  0.,
                 0.,  1.,
                -1.,  0.,
+    // cppcheck-suppress *
                 0.,  0.;
   // clang-format on
   return unit_cell;
@@ -405,6 +408,7 @@ inline Eigen::MatrixXi
   indices << 0, 1,
              1, 2,
              2, 3,
+    // cppcheck-suppress *
              3, 0;
   // clang-format on
   return indices;
@@ -415,6 +419,7 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::VectorXi
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::corner_indices() const {
   Eigen::Matrix<int, 4, 1> indices;
+  // cppcheck-suppress *
   indices << 0, 1, 2, 3;
   return indices;
 }
@@ -429,6 +434,7 @@ inline Eigen::MatrixXi
   indices << 0, 1,
              1, 2,
              2, 3,
+    // cppcheck-suppress *
              3, 0;
   //clang-format on
   return indices;

--- a/include/triangle_element.h
+++ b/include/triangle_element.h
@@ -51,7 +51,7 @@ class TriangleElement : public Element<Tdim> {
     //! Logger
     std::string logger = "triangular::<" + std::to_string(Tdim) + ", " +
                          std::to_string(Tnfunctions) + ">";
-    console_ = std::make_unique<spdlog::logger>(logger,mpm::stdout_sink);
+    console_ = std::make_unique<spdlog::logger>(logger, mpm::stdout_sink);
   }
 
   //! Return number of shape functions
@@ -71,8 +71,8 @@ class TriangleElement : public Element<Tdim> {
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval shapefn_local Shape function of a given cell
   Eigen::VectorXd shapefn_local(
-    const VectorDim& xi, const VectorDim& particle_size,
-    const VectorDim& deformation_gradient) const override;
+      const VectorDim& xi, const VectorDim& particle_size,
+      const VectorDim& deformation_gradient) const override;
 
   //! Evaluate gradient of shape functions
   //! \param[in] xi given local coordinates
@@ -80,8 +80,8 @@ class TriangleElement : public Element<Tdim> {
   //! \param[in] deformation_gradient Deformation gradient
   //! \retval grad_shapefn Gradient of shape function of a given cell
   Eigen::MatrixXd grad_shapefn(
-    const VectorDim& xi, const VectorDim& particle_size,
-    const VectorDim& deformation_gradient) const override;
+      const VectorDim& xi, const VectorDim& particle_size,
+      const VectorDim& deformation_gradient) const override;
 
   //! Compute Jacobian
   //! \param[in] xi given local coordinates
@@ -93,7 +93,7 @@ class TriangleElement : public Element<Tdim> {
       const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
       const VectorDim& particle_size,
       const VectorDim& deformation_gradient) const override;
-  
+
   //! Compute Jacobian local
   //! \param[in] xi given local coordinates
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
@@ -168,13 +168,13 @@ class TriangleElement : public Element<Tdim> {
   //! Return quadrature of the element
   std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
       unsigned nquadratures = 1) const override;
-    
+
  private:
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
 };
 
-} // namespace mpm
+}  // namespace mpm
 #include "triangle_element.tcc"
 
 #endif  // MPM_TRIANGLE_ELEMENT_H_

--- a/include/triangle_element.h
+++ b/include/triangle_element.h
@@ -1,0 +1,180 @@
+#ifndef MPM_TRIANGLE_ELEMENT_H_
+#define MPM_TRIANGLE_ELEMENT_H_
+
+#include "element.h"
+#include "logger.h"
+
+namespace mpm {
+
+//! Triangle element class derived from Element class
+//! \brief Triangle element
+//! \details 3-noded and 6-noded triangle element \n
+//! Shapte function, gradient shape function, B-matrix, indices \n
+//! 3-node Triangle ELement \n
+//! <pre>
+//!   2 0
+//!     |`\
+//!     |  `\
+//!     |    `\
+//!     |      `\
+//!     |        `\
+//!   0 0----------0 1
+//! </pre>
+//! 6-node Triangle Element
+//! <pre>
+//!   2 0
+//!     |`\
+//!     |  `\
+//!   5 0    `0 4
+//!     |      `\
+//!     |        `\
+//!   0 0-----0----0 1
+//!           3
+//! </pre>
+//!
+//!
+//! \tparam Tdim Dimension
+//! \tparam Tnfunctions Number of functions
+template <unsigned Tdim, unsigned Tnfunctions>
+class TriangleElement : public Element<Tdim> {
+
+ public:
+  //! Define vector of size dimension
+  using VectorDim = Eigen::Matrix<double, Tdim, 1>;
+
+  //! constructor with number of shape functions
+  TriangleElement() : mpm::Element<Tdim>() {
+    static_assert(Tdim == 2, "Invalid dimension for a triangular element");
+    static_assert((Tnfunctions == 3 || Tnfunctions == 6),
+                  "Specified number of shape funcions is not defined");
+
+    //! Logger
+    std::string logger = "triangular::<" + std::to_string(Tdim) + ", " +
+                         std::to_string(Tnfunctions) + ">";
+    console_ = std::make_unique<spdlog::logger>(logger,mpm::stdout_sink);
+  }
+
+  //! Return number of shape functions
+  unsigned nfunctions() const override { return Tnfunctions; }
+
+  //! Evaluate shape functions at given local coordinates
+  //! \param[in] xi given local coordinates
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval shapefn Shape function of a given cell
+  Eigen::VectorXd shapefn(const VectorDim& xi, const VectorDim& particle_size,
+                          const VectorDim& deformation_gradient) const override;
+
+  //! Evaluate local shape functions at given coordinates
+  //! \param[in] xi given local coordinates
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval shapefn_local Shape function of a given cell
+  Eigen::VectorXd shapefn_local(
+    const VectorDim& xi, const VectorDim& particle_size,
+    const VectorDim& deformation_gradient) const override;
+
+  //! Evaluate gradient of shape functions
+  //! \param[in] xi given local coordinates
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval grad_shapefn Gradient of shape function of a given cell
+  Eigen::MatrixXd grad_shapefn(
+    const VectorDim& xi, const VectorDim& particle_size,
+    const VectorDim& deformation_gradient) const override;
+
+  //! Compute Jacobian
+  //! \param[in] xi given local coordinates
+  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval jacobian Jacobian matrix
+  Eigen::Matrix<double, Tdim, Tdim> jacobian(
+      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+      const VectorDim& particle_size,
+      const VectorDim& deformation_gradient) const override;
+  
+  //! Compute Jacobian local
+  //! \param[in] xi given local coordinates
+  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval jacobian Jacobian matrix
+  Eigen::Matrix<double, Tdim, Tdim> jacobian_local(
+      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+      const VectorDim& particle_size,
+      const VectorDim& deformation_gradient) const override;
+
+  //! Evaluate the B matrix at given local coordinates for a real cell
+  //! \param[in] xi given local coordinates
+  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
+  //! \param[in] particle_size Particle size
+  //! \param[in] deformation_gradient Deformation gradient
+  //! \retval bmatrix B matrix
+  std::vector<Eigen::MatrixXd> bmatrix(
+      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+      const VectorDim& particle_size,
+      const VectorDim& deformation_gradient) const override;
+
+  //! Evaluate the Ni Nj matrix
+  //! \param[in] xi_s Vector of local coordinates
+  //! \retval ni_nj_matrix Ni Nj matrix
+  Eigen::MatrixXd ni_nj_matrix(
+      const std::vector<VectorDim>& xi_s) const override;
+
+  //! Evaluate the Laplace matrix at given local coordinates for a real cell
+  //! \param[in] xi_s Vector of local coordinates
+  //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
+  //! \retval laplace_matrix Laplace matrix
+  Eigen::MatrixXd laplace_matrix(
+      const std::vector<VectorDim>& xi_s,
+      const Eigen::MatrixXd& nodal_coordinates) const override;
+
+  //! Return the degree of shape function
+  mpm::ElementDegree degree() const override;
+
+  //! Return the type of shape function
+  mpm::ShapefnType shapefn_type() const override {
+    return mpm::ShapefnType::NORMAL_MPM;
+  }
+
+  //! Return nodal coordinates of a unit cell
+  Eigen::MatrixXd unit_cell_coordinates() const override;
+
+  //! Return the side indices of a cell to calculate the cell length
+  //! \retval indices Outer-indices that form the sides of the cell
+  Eigen::MatrixXi sides_indices() const override;
+
+  //! Return the corner indices of a cell to calculate the cell volume
+  //! \retval indices Outer-indices that form the cell
+  Eigen::VectorXi corner_indices() const override;
+
+  //! Return indices of a sub-tetrahedrons in a volume
+  //! to check if a point is inside /outside of a hedron
+  //! \retval indices Indices that form sub-tetrahedrons
+  Eigen::MatrixXi inhedron_indices() const override;
+
+  //! Return indices of a face of an element
+  //! \param[in] face_id given id of the face
+  //! \retval indices Indices that make the face
+  Eigen::VectorXi face_indices(unsigned face_id) const override;
+
+  //! Return the number of faces in a triangle
+  unsigned nfaces() const override { return 3; }
+
+  //! Return unit element length
+  double unit_element_length() const override { return 1.; }
+
+  //! Return quadrature of the element
+  std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
+      unsigned nquadratures = 1) const override;
+    
+ private:
+  //! Logger
+  std::unique_ptr<spdlog::logger> console_;
+};
+
+} // namespace mpm
+#include "triangle_element.tcc"
+
+#endif  // MPM_TRIANGLE_ELEMENT_H_

--- a/include/triangle_element.tcc
+++ b/include/triangle_element.tcc
@@ -21,7 +21,7 @@ inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn(
   return shapefn;
 }
 
-//! Return gradient of shape functions of a 4-node Triangle Element at a
+//! Return gradient of shape functions of a 3-node Triangle Element at a
 //! given local coordinate, with particle size and deformation gradient
 template <>
 inline Eigen::MatrixXd mpm::TriangleElement<2, 3>::grad_shapefn(

--- a/include/triangle_element.tcc
+++ b/include/triangle_element.tcc
@@ -48,6 +48,7 @@ inline Eigen::MatrixXd mpm::TriangleElement<2, 3>::unit_cell_coordinates()
   // clang-format off
   unit_cell << 0., 0.,
                1., 0.,
+    // cppcheck-suppress *
                0., 1.;
   // clang-format on
   return unit_cell;
@@ -117,6 +118,7 @@ inline Eigen::MatrixXd mpm::TriangleElement<2, 6>::unit_cell_coordinates()
                0. , 1. ,
                0.5, 0. ,
                0.5, 0.5,
+    // cppcheck-suppress *
                0. , 0.5;
   // clang-format on
   return unit_cell;
@@ -301,6 +303,7 @@ inline Eigen::MatrixXi
   // clang-format off
   indices << 0, 1,
              1, 2,
+    // cppcheck-suppress *
              2, 0;
   // clang-format on
   return indices;
@@ -311,6 +314,7 @@ template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::VectorXi
     mpm::TriangleElement<Tdim, Tnfunctions>::corner_indices() const {
   Eigen::Matrix<int, 3, 1> indices;
+  // cppcheck-suppress *
   indices << 0, 1, 2;
   return indices;
 }
@@ -324,6 +328,7 @@ inline Eigen::MatrixXi
   // clang-format off
   indices << 0, 1,
              1, 2,
+    // cppcheck-suppress *
              2, 0;
   //clang-format on
   return indices;

--- a/include/triangle_element.tcc
+++ b/include/triangle_element.tcc
@@ -9,8 +9,8 @@
 
 //! Return shape functions of a 3-node Triangle Element at a given local
 //! coordinate, with particle size and deformation gradient
-template<>
-inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn(  
+template <>
+inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn( 
     const Eigen::Matrix<double, 2, 1>& xi,
     const Eigen::Matrix<double, 2, 1>& particle_size,
     const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
@@ -23,7 +23,7 @@ inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn(
 
 //! Return gradient of shape functions of a 4-node Triangle Element at a
 //! given local coordinate, with particle size and deformation gradient
-template<>
+template <>
 inline Eigen::MatrixXd mpm::TriangleElement<2, 3>::grad_shapefn(
     const Eigen::Matrix<double, 2, 1>& xi,
     const Eigen::Matrix<double, 2, 1>& particle_size,
@@ -72,8 +72,7 @@ inline Eigen::VectorXd mpm::TriangleElement<2, 6>::shapefn(
     const Eigen::Matrix<double, 2, 1>& particle_size,
     const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
   Eigen::Matrix<double, 6, 1> shapefn;
-  shapefn(0) =
-      (1. - xi(0) - xi(1)) * (1. - 2. * xi(0) - 2. * xi(1));
+  shapefn(0) = (1. - xi(0) - xi(1)) * (1. - 2. * xi(0) - 2. * xi(1));
   shapefn(1) = xi(0) * (2. * xi(0) - 1.);
   shapefn(2) = xi(1) * (2. * xi(1) - 1.);
   shapefn(3) = 4. * xi(0) * (1. - xi(0) - xi(1));
@@ -84,7 +83,7 @@ inline Eigen::VectorXd mpm::TriangleElement<2, 6>::shapefn(
 
 //! Return gradient of shape functions of a 6-node Triangle Element at a
 //! given local coordinate, with particle size and deformation gradient
-template<>
+template <>
 inline Eigen::MatrixXd mpm::TriangleElement<2, 6>::grad_shapefn(
     const Eigen::Matrix<double, 2, 1>& xi,
     const Eigen::Matrix<double, 2, 1>& particle_size,
@@ -127,24 +126,23 @@ inline Eigen::MatrixXd mpm::TriangleElement<2, 6>::unit_cell_coordinates()
 //! Return the degree of element
 //! 3-noded triangle
 template <>
-inline mpm::ElementDegree mpm::TriangleElement<2, 3>::degree() const{
+inline mpm::ElementDegree mpm::TriangleElement<2, 3>::degree() const {
   return mpm::ElementDegree::Linear;
 }
 
 //! Return the degree of element
 //! 6-noded triangle
 template <>
-inline mpm::ElementDegree mpm::TriangleElement<2, 6>::degree() const{
+inline mpm::ElementDegree mpm::TriangleElement<2, 6>::degree() const {
   return mpm::ElementDegree::Quadratic;
 }
 
 //! Return local shape functions of a Triangle Element at a given local
 //! coordinate, with particle size and deformation gradient
 template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::VectorXd
-    mpm::TriangleElement<Tdim, Tnfunctions>::shapefn_local(
-        const VectorDim& xi, const VectorDim& particle_size,
-        const VectorDim& deformation_gradient) const {
+inline Eigen::VectorXd mpm::TriangleElement<Tdim, Tnfunctions>::shapefn_local(
+    const VectorDim& xi, const VectorDim& particle_size,
+    const VectorDim& deformation_gradient) const {
   return this->shapefn(xi, particle_size, deformation_gradient);
 }
 
@@ -159,14 +157,15 @@ inline Eigen::Matrix<double, Tdim, Tdim>
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
       mpm::TriangleElement<Tdim, Tnfunctions>::grad_shapefn(
-        xi, particle_size, deformation_gradient);
+          xi, particle_size, deformation_gradient);
 
-  try{
+  try {
     // Check if matrices dimensions are correct
-    if((grad_shapefn.rows() != nodal_coordinates.rows()) || (xi.size() != nodal_coordinates.cols()))
+    if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
+        (xi.size() != nodal_coordinates.cols()))
       throw std::runtime_error(
-        "Jacobian calculation: Incorrect dimension of xi and "
-        "nodal_coordinates");
+          "Jacobian calculation: Incorrect dimension of xi and "
+          "nodal_coordinates");
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
     return Eigen::Matrix<double, Tdim, Tdim>::Zero();
@@ -180,7 +179,7 @@ inline Eigen::Matrix<double, Tdim, Tdim>
 template <unsigned Tdim, unsigned Tnfunctions>
 inline Eigen::Matrix<double, Tdim, Tdim>
     mpm::TriangleElement<Tdim, Tnfunctions>::jacobian_local(
-      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
         const VectorDim& particle_size,
         const VectorDim& deformation_gradient) const {
   // Jacobian dx_i/dxi_j
@@ -192,13 +191,13 @@ inline Eigen::Matrix<double, Tdim, Tdim>
 //! coordinate for a real cell
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::vector<Eigen::MatrixXd>
-mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
-  const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
-  const VectorDim& particle_size,
-  const VectorDim& deformation_gradient) const {
+    mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
   // Get gradient shape functions
   Eigen::MatrixXd grad_sf =
-    this->grad_shapefn(xi, particle_size, deformation_gradient);
+      this->grad_shapefn(xi, particle_size, deformation_gradient);
 
   // B-matrix
   std::vector<Eigen::MatrixXd> bmatrix;
@@ -209,8 +208,8 @@ mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
     if ((grad_sf.rows() != nodal_coordinates.rows()) ||
         (xi.rows() != nodal_coordinates.cols()))
       throw std::runtime_error(
-        "Bmatrix - Jacobian calculation: Incorrect dimension of xi and "
-        "nodal_coordinates");
+          "Bmatrix - Jacobian calculation: Incorrect dimension of xi and "
+          "nodal_coordinates");
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
     return bmatrix;
@@ -218,7 +217,7 @@ mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
 
   // Jacobian dx_i/dxi_j
   Eigen::Matrix<double, Tdim, Tdim> jacobian =
-    (grad_sf.transpose() * nodal_coordinates);
+      (grad_sf.transpose() * nodal_coordinates);
 
   // Gradient shapefn of the cell
   // dN/dx = [J]^-1 * dN/dxi_j
@@ -238,9 +237,8 @@ mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
 
 //! Return ni_nj_matrix of a Triangle Element
 template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::MatrixXd
-    mpm::TriangleElement<Tdim, Tnfunctions>::ni_nj_matrix(
-        const std::vector<VectorDim>& xi_s) const {
+inline Eigen::MatrixXd mpm::TriangleElement<Tdim, Tnfunctions>::ni_nj_matrix(
+    const std::vector<VectorDim>& xi_s) const {
   // Ni Nj matrix
   Eigen::Matrix<double, Tnfunctions, Tnfunctions> ni_nj_matrix;
   ni_nj_matrix.setZero();
@@ -255,11 +253,9 @@ inline Eigen::MatrixXd
 
 //! Return the laplace_matrix of a Triangle Element
 template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::MatrixXd
-    mpm::TriangleElement<Tdim, Tnfunctions>::laplace_matrix(
-        const std::vector<VectorDim>& xi_s,
-        const Eigen::MatrixXd& nodal_coordinates) const {
-
+inline Eigen::MatrixXd mpm::TriangleElement<Tdim, Tnfunctions>::laplace_matrix(
+    const std::vector<VectorDim>& xi_s,
+    const Eigen::MatrixXd& nodal_coordinates) const {
   try {
     // Check if matrices dimensions are correct
     if ((this->nfunctions() != nodal_coordinates.rows()) ||
@@ -297,8 +293,8 @@ inline Eigen::MatrixXd
 //! \tparam Tdim Dimension
 //! \tparam Tnfunctions Number of shape functions
 template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::MatrixXi
-    mpm::TriangleElement<Tdim, Tnfunctions>::sides_indices() const {
+inline Eigen::MatrixXi mpm::TriangleElement<Tdim, Tnfunctions>::sides_indices()
+    const {
   Eigen::Matrix<int, 3, 2> indices;
   // clang-format off
   indices << 0, 1,
@@ -311,8 +307,8 @@ inline Eigen::MatrixXi
 
 //! Return the corner indices of a cell to calculate the cell volume
 template <unsigned Tdim, unsigned Tnfunctions>
-inline Eigen::VectorXi
-    mpm::TriangleElement<Tdim, Tnfunctions>::corner_indices() const {
+inline Eigen::VectorXi mpm::TriangleElement<Tdim, Tnfunctions>::corner_indices()
+    const {
   Eigen::Matrix<int, 3, 1> indices;
   // cppcheck-suppress *
   indices << 0, 1, 2;

--- a/include/triangle_element.tcc
+++ b/include/triangle_element.tcc
@@ -1,0 +1,378 @@
+// 3-node Triangle Element
+//!   2 0
+//!     |`\
+//!     |  `\
+//!     |    `\
+//!     |      `\
+//!     |        `\
+//!   0 0----------0 1
+
+//! Return shape functions of a 3-node Triangle Element at a given local
+//! coordinate, with particle size and deformation gradient
+template<>
+inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn(  
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
+  Eigen::Matrix<double, 3, 1> shapefn;
+  shapefn(0) = 1 - (xi(0) + xi(1));
+  shapefn(1) = xi(0);
+  shapefn(2) = xi(1);
+  return shapefn;
+}
+
+//! Return gradient of shape functions of a 4-node Triangle Element at a
+//! given local coordinate, with particle size and deformation gradient
+template<>
+inline Eigen::MatrixXd mpm::TriangleElement<2, 3>::grad_shapefn(
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
+  Eigen::Matrix<double, 3, 2> grad_shapefn;
+
+  grad_shapefn(0, 0) = -1.;
+  grad_shapefn(1, 0) = 1.;
+  grad_shapefn(2, 0) = 0.;
+  grad_shapefn(0, 1) = -1.;
+  grad_shapefn(1, 1) = 0.;
+  grad_shapefn(2, 1) = 1.;
+  return grad_shapefn;
+}
+
+//! Return nodal coordinates of a unit cell
+template <>
+inline Eigen::MatrixXd mpm::TriangleElement<2, 3>::unit_cell_coordinates()
+    const {
+  // Coordinates of a unit cell
+  Eigen::Matrix<double, 3, 2> unit_cell;
+  // clang-format off
+  unit_cell << 0., 0.,
+               1., 0.,
+               0., 1.;
+  // clang-format on
+  return unit_cell;
+}
+
+// 6-node Triangle Element
+//!   2 0
+//!     |`\
+//!     |  `\
+//!   5 0    `0 4
+//!     |      `\
+//!     |        `\
+//!   0 0-----0----0 1
+//!           3
+
+//! Return shape functions of a 6-node Triangle Element at a given local
+//! coordinate, with particle size and deformation gradient
+template <>
+inline Eigen::VectorXd mpm::TriangleElement<2, 6>::shapefn(
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
+  Eigen::Matrix<double, 6, 1> shapefn;
+  shapefn(0) =
+      (1. - xi(0) - xi(1)) * (1. - 2. * xi(0) - 2. * xi(1));
+  shapefn(1) = xi(0) * (2. * xi(0) - 1.);
+  shapefn(2) = xi(1) * (2. * xi(1) - 1.);
+  shapefn(3) = 4. * xi(0) * (1. - xi(0) - xi(1));
+  shapefn(4) = 4. * xi(0) * xi(1);
+  shapefn(5) = 4. * xi(1) * (1. - xi(0) - xi(1));
+  return shapefn;
+}
+
+//! Return gradient of shape functions of a 6-node Triangle Element at a
+//! given local coordinate, with particle size and deformation gradient
+template<>
+inline Eigen::MatrixXd mpm::TriangleElement<2, 6>::grad_shapefn(
+    const Eigen::Matrix<double, 2, 1>& xi,
+    const Eigen::Matrix<double, 2, 1>& particle_size,
+    const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {
+  Eigen::Matrix<double, 6, 2> grad_shapefn;
+  grad_shapefn(0, 0) = 4. * xi(0) + 4. * xi(1) - 3.;
+  grad_shapefn(1, 0) = 4. * xi(0) - 1.;
+  grad_shapefn(2, 0) = 0;
+  grad_shapefn(3, 0) = 4. - 8. * xi(0) - 4. * xi(1);
+  grad_shapefn(4, 0) = 4. * xi(1);
+  grad_shapefn(5, 0) = -4. * xi(1);
+
+  grad_shapefn(0, 1) = 4. * xi(0) + 4. * xi(1) - 3.;
+  grad_shapefn(1, 1) = 0;
+  grad_shapefn(2, 1) = 4. * xi(1) - 1.;
+  grad_shapefn(3, 1) = -4. * xi(0);
+  grad_shapefn(4, 1) = 4. * xi(0);
+  grad_shapefn(5, 1) = 4. - 4. * xi(0) - 8. * xi(1);
+  return grad_shapefn;
+}
+
+//! Return nodal coordinates of a unit cell
+template <>
+inline Eigen::MatrixXd mpm::TriangleElement<2, 6>::unit_cell_coordinates()
+    const {
+  // Coordinates of a unit cell
+  Eigen::Matrix<double, 6, 2> unit_cell;
+  // clang-format off
+  unit_cell << 0. , 0. ,
+               1. , 0. ,
+               0. , 1. ,
+               0.5, 0. ,
+               0.5, 0.5,
+               0. , 0.5;
+  // clang-format on
+  return unit_cell;
+}
+
+//! Return the degree of element
+//! 3-noded triangle
+template <>
+inline mpm::ElementDegree mpm::TriangleElement<2, 3>::degree() const{
+  return mpm::ElementDegree::Linear;
+}
+
+//! Return the degree of element
+//! 6-noded triangle
+template <>
+inline mpm::ElementDegree mpm::TriangleElement<2, 6>::degree() const{
+  return mpm::ElementDegree::Quadratic;
+}
+
+//! Return local shape functions of a Triangle Element at a given local
+//! coordinate, with particle size and deformation gradient
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::VectorXd
+    mpm::TriangleElement<Tdim, Tnfunctions>::shapefn_local(
+        const VectorDim& xi, const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
+  return this->shapefn(xi, particle_size, deformation_gradient);
+}
+
+//! Compute Jacobian with particle size and deformation gradient
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::Matrix<double, Tdim, Tdim>
+    mpm::TriangleElement<Tdim, Tnfunctions>::jacobian(
+        const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
+
+  // Get gradient shape functions
+  const Eigen::MatrixXd grad_shapefn =
+      mpm::TriangleElement<Tdim, Tnfunctions>::grad_shapefn(
+        xi, particle_size, deformation_gradient);
+
+  try{
+    // Check if matrices dimensions are correct
+    if((grad_shapefn.rows() != nodal_coordinates.rows()) || (xi.size() != nodal_coordinates.cols()))
+      throw std::runtime_error(
+        "Jacobian calculation: Incorrect dimension of xi and "
+        "nodal_coordinates");
+  } catch (std::exception& exception) {
+    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
+    return Eigen::Matrix<double, Tdim, Tdim>::Zero();
+  }
+
+  // Jacobian dx_i/dxi_j
+  return (grad_shapefn.transpose() * nodal_coordinates);
+}
+
+//! Compute Jacobian local with particle size and deformation gradient
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::Matrix<double, Tdim, Tdim>
+    mpm::TriangleElement<Tdim, Tnfunctions>::jacobian_local(
+      const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+        const VectorDim& particle_size,
+        const VectorDim& deformation_gradient) const {
+  // Jacobian dx_i/dxi_j
+  return this->jacobian(xi, nodal_coordinates, particle_size,
+                        deformation_gradient);
+}
+
+//! Return the B-matrix of a Triangle Element at a given local
+//! coordinate for a real cell
+template <unsigned Tdim, unsigned Tnfunctions>
+inline std::vector<Eigen::MatrixXd>
+mpm::TriangleElement<Tdim, Tnfunctions>::bmatrix(
+  const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
+  const VectorDim& particle_size,
+  const VectorDim& deformation_gradient) const {
+  // Get gradient shape functions
+  Eigen::MatrixXd grad_sf =
+    this->grad_shapefn(xi, particle_size, deformation_gradient);
+
+  // B-matrix
+  std::vector<Eigen::MatrixXd> bmatrix;
+  bmatrix.reserve(Tnfunctions);
+
+  try {
+    // Check if matrces dimensions are correct
+    if ((grad_sf.rows() != nodal_coordinates.rows()) ||
+        (xi.rows() != nodal_coordinates.cols()))
+      throw std::runtime_error(
+        "Bmatrix - Jacobian calculation: Incorrect dimension of xi and "
+        "nodal_coordinates");
+  } catch (std::exception& exception) {
+    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
+    return bmatrix;
+  }
+
+  // Jacobian dx_i/dxi_j
+  Eigen::Matrix<double, Tdim, Tdim> jacobian =
+    (grad_sf.transpose() * nodal_coordinates);
+
+  // Gradient shapefn of the cell
+  // dN/dx = [J]^-1 * dN/dxi_j
+  Eigen::MatrixXd grad_shapefn = grad_sf * (jacobian.inverse()).transpose();
+
+  for (unsigned i = 0; i < Tnfunctions; ++i) {
+    Eigen::Matrix<double, 3, Tdim> bi;
+    // clang-format off
+    bi(0, 0) = grad_shapefn(i, 0); bi(0, 1) = 0.;
+    bi(1, 0) = 0.;                 bi(1, 1) = grad_shapefn(i, 1);
+    bi(2, 0) = grad_shapefn(i, 1); bi(2, 1) = grad_shapefn(i, 0);
+    bmatrix.push_back(bi);
+    // clang-format on
+  }
+  return bmatrix;
+}
+
+//! Return ni_nj_matrix of a Triangle Element
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::MatrixXd
+    mpm::TriangleElement<Tdim, Tnfunctions>::ni_nj_matrix(
+        const std::vector<VectorDim>& xi_s) const {
+  // Ni Nj matrix
+  Eigen::Matrix<double, Tnfunctions, Tnfunctions> ni_nj_matrix;
+  ni_nj_matrix.setZero();
+  for (const auto& xi : xi_s) {
+    const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
+        this->shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                      Eigen::Matrix<double, Tdim, 1>::Zero());
+    ni_nj_matrix += (shape_fn * shape_fn.transpose());
+  }
+  return ni_nj_matrix;
+}
+
+//! Return the laplace_matrix of a Triangle Element
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::MatrixXd
+    mpm::TriangleElement<Tdim, Tnfunctions>::laplace_matrix(
+        const std::vector<VectorDim>& xi_s,
+        const Eigen::MatrixXd& nodal_coordinates) const {
+
+  try {
+    // Check if matrices dimensions are correct
+    if ((this->nfunctions() != nodal_coordinates.rows()) ||
+        (xi_s.at(0).size() != nodal_coordinates.cols()))
+      throw std::runtime_error(
+          "Jacobian calculation: Incorrect dimension of xi & nodes");
+  } catch (std::exception& exception) {
+    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
+  }
+
+  // Laplace matrix
+  Eigen::Matrix<double, Tnfunctions, Tnfunctions> laplace_matrix;
+  laplace_matrix.setZero();
+  for (const auto& xi : xi_s) {
+    // Get gradient shape functions
+    const Eigen::MatrixXd grad_sf =
+        this->grad_shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
+                           Eigen::Matrix<double, Tdim, 1>::Zero());
+
+    // Jacobian dx_i/dxi_j
+    const Eigen::Matrix<double, Tdim, Tdim> jacobian =
+        (grad_sf.transpose() * nodal_coordinates);
+
+    // Gradient shapefn of the cell
+    // dN/dx = [J]^-1 * dN/dxi
+    const Eigen::MatrixXd grad_shapefn = grad_sf * jacobian.inverse();
+
+    laplace_matrix += (grad_shapefn * grad_shapefn.transpose());
+  }
+  return laplace_matrix;
+}
+
+//! Return the indices of a cell sides
+//! \retval indices Sides that form the cell
+//! \tparam Tdim Dimension
+//! \tparam Tnfunctions Number of shape functions
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::MatrixXi
+    mpm::TriangleElement<Tdim, Tnfunctions>::sides_indices() const {
+  Eigen::Matrix<int, 3, 2> indices;
+  // clang-format off
+  indices << 0, 1,
+             1, 2,
+             2, 0;
+  // clang-format on
+  return indices;
+}
+
+//! Return the corner indices of a cell to calculate the cell volume
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::VectorXi
+    mpm::TriangleElement<Tdim, Tnfunctions>::corner_indices() const {
+  Eigen::Matrix<int, 3, 1> indices;
+  indices << 0, 1, 2;
+  return indices;
+}
+
+//! Return indices of a sub-tetrahedrons in a volume
+template <unsigned Tdim, unsigned Tnfunctions>
+inline Eigen::MatrixXi
+    mpm::TriangleElement<Tdim, Tnfunctions>::inhedron_indices() const {
+  Eigen::Matrix<int, 3, Tdim, Eigen::RowMajor> indices;
+
+  // clang-format off
+  indices << 0, 1,
+             1, 2,
+             2, 0;
+  //clang-format on
+  return indices;
+}
+
+//! Return indices of a face of the element
+//! 3-noded triangle
+template <>
+inline Eigen::VectorXi
+    mpm::TriangleElement<2, 3>::face_indices(unsigned face_id) const {
+  
+  //! Face ids and its associated nodal indices
+  const std::map<unsigned, Eigen::Matrix<int, 2, 1>>
+      face_indices_triangle{{0, Eigen::Matrix<int, 2, 1>(0, 1)},
+                            {1, Eigen::Matrix<int, 2, 1>(1, 2)},
+                            {2, Eigen::Matrix<int, 2, 1>(2, 0)}}; 
+
+  return face_indices_triangle.at(face_id);
+}
+
+//! Return indices of a face of the element
+//! 6-noded triangle
+template <>
+inline Eigen::VectorXi
+    mpm::TriangleElement<2, 6>::face_indices(unsigned face_id) const {
+  
+  //! Face ids and its associated nodal indices
+  const std::map<unsigned, Eigen::Matrix<int, 3, 1>>
+      face_indices_triangle{{0, Eigen::Matrix<int, 3, 1>(0, 1, 3)},
+                            {1, Eigen::Matrix<int, 3, 1>(1, 2, 4)},
+                            {2, Eigen::Matrix<int, 3, 1>(2, 0, 5)}};
+
+  return face_indices_triangle.at(face_id);
+}
+
+//! Return quadrature
+template <unsigned Tdim, unsigned Tnfunctions>
+inline std::shared_ptr<mpm::Quadrature<Tdim>>
+    mpm::TriangleElement<Tdim, Tnfunctions>::quadrature(
+        unsigned nquadratures) const {
+  switch (nquadratures) {
+    case 1:
+      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QT1");
+      break;
+    case 2:
+      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QT2");
+      break;
+    default:
+      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QT1");
+      break;
+  }
+}

--- a/include/triangle_element.tcc
+++ b/include/triangle_element.tcc
@@ -10,7 +10,7 @@
 //! Return shape functions of a 3-node Triangle Element at a given local
 //! coordinate, with particle size and deformation gradient
 template <>
-inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn( 
+inline Eigen::VectorXd mpm::TriangleElement<2, 3>::shapefn(
     const Eigen::Matrix<double, 2, 1>& xi,
     const Eigen::Matrix<double, 2, 1>& particle_size,
     const Eigen::Matrix<double, 2, 1>& deformation_gradient) const {

--- a/include/triangle_quadrature.h
+++ b/include/triangle_quadrature.h
@@ -1,0 +1,41 @@
+#ifndef MPM_TRIANGLE_QUADRATURE_H_
+#define MPM_TRIANGLE_QUADRATURE_H_
+
+#include <exception>
+
+#include <Eigen/Dense>
+
+#include "quadrature.h"
+
+//! MPM namespace
+namespace mpm {
+
+// Triangle quadrature class derived from Quadrature base class
+//! \brief Quadrature (gauss points) for a triangle element
+//! \tparam Tdim Dimension
+//! \tparam Tnquadratures number of quadratures
+template <unsigned Tdim, unsigned Tnquadratures>
+class TriangleQuadrature : public Quadrature<Tdim> {
+
+ public:
+  TriangleQuadrature() : Quadrature<Tdim>() {
+    static_assert(Tdim == 2, "Invalid dimension for a triangle element");
+    static_assert(
+      ((Tnquadratures == 1) || (Tnquadratures == 3)),
+        "Invalid number of quadratures");
+  }
+
+  //! Return quadrature points
+  //! \param[out] qpoints Quadrature points in local coordinates
+  Eigen::MatrixXd quadratures() const override;
+
+  //! Return weights
+  //! \param[out] weights Weights for quadrature points
+  Eigen::VectorXd weights() const override;
+};
+
+}  // namespace mpm
+
+#include "triangle_quadrature.tcc"
+
+#endif  // MPM_TRIANGLE_QUADRATURE_H_

--- a/include/triangle_quadrature.h
+++ b/include/triangle_quadrature.h
@@ -20,9 +20,8 @@ class TriangleQuadrature : public Quadrature<Tdim> {
  public:
   TriangleQuadrature() : Quadrature<Tdim>() {
     static_assert(Tdim == 2, "Invalid dimension for a triangle element");
-    static_assert(
-      ((Tnquadratures == 1) || (Tnquadratures == 3)),
-        "Invalid number of quadratures");
+    static_assert(((Tnquadratures == 1) || (Tnquadratures == 3)),
+                  "Invalid number of quadratures");
   }
 
   //! Return quadrature points

--- a/include/triangle_quadrature.tcc
+++ b/include/triangle_quadrature.tcc
@@ -1,0 +1,45 @@
+// Getting the quadratures for Tnquadratures = 1
+template <>
+inline Eigen::MatrixXd mpm::TriangleQuadrature<2, 1>::quadratures() const {
+  Eigen::Matrix<double, 2, 1> quadratures;
+  quadratures(0, 0) = 1. / 3.;
+  quadratures(1, 0) = 1. / 3.;
+
+  return quadratures;
+}
+
+// Getting the weights for Tnquadratures = 1
+template <>
+inline Eigen::VectorXd mpm::TriangleQuadrature<2, 1>::weights() const {
+  Eigen::VectorXd weights(1);
+  weights(0) = 0.5;
+
+  return weights;
+}
+
+// Getting the quadratures for Tnquadratures = 3
+template <>
+inline Eigen::MatrixXd mpm::TriangleQuadrature<2, 3>::quadratures() const {
+  Eigen::Matrix<double, 2, 3> quadratures;
+  const double val_1_by_sqrt3 = 1. / std::sqrt(3.);
+
+  quadratures(0, 0) = 1. / 6.;
+  quadratures(1, 0) = 1. / 6.;
+  quadratures(0, 1) = 2. / 3.;
+  quadratures(1, 1) = 1. / 6.;
+  quadratures(0, 2) = 1. / 6.;
+  quadratures(1, 2) = 2. / 3.;
+
+  return quadratures;
+}
+
+// Getting the weights for Tnquadratures = 3
+template <>
+inline Eigen::VectorXd mpm::TriangleQuadrature<2, 3>::weights() const {
+  Eigen::VectorXd weights(3);
+  weights(0) = 1. / 3.;
+  weights(1) = 1. / 3.;
+  weights(2) = 1. / 3.;
+
+  return weights;
+}

--- a/src/element.cc
+++ b/src/element.cc
@@ -3,6 +3,15 @@
 #include "hexahedron_element.h"
 #include "quadrilateral_element.h"
 #include "quadrilateral_gimp_element.h"
+#include "triangle_element.h"
+
+// Triangle 3-noded element
+static Register<mpm::Element<2>, mpm::TriangleElement<2, 3>> tri3(
+    "ED2T3");
+
+// Triangle 6-noded element
+static Register<mpm::Element<2>, mpm::TriangleElement<2, 6>> tri6(
+    "ED2T6");
 
 // Quadrilateral 4-noded element
 static Register<mpm::Element<2>, mpm::QuadrilateralElement<2, 4>> quad4(

--- a/src/element.cc
+++ b/src/element.cc
@@ -6,12 +6,10 @@
 #include "triangle_element.h"
 
 // Triangle 3-noded element
-static Register<mpm::Element<2>, mpm::TriangleElement<2, 3>> tri3(
-    "ED2T3");
+static Register<mpm::Element<2>, mpm::TriangleElement<2, 3>> tri3("ED2T3");
 
 // Triangle 6-noded element
-static Register<mpm::Element<2>, mpm::TriangleElement<2, 6>> tri6(
-    "ED2T6");
+static Register<mpm::Element<2>, mpm::TriangleElement<2, 6>> tri6("ED2T6");
 
 // Quadrilateral 4-noded element
 static Register<mpm::Element<2>, mpm::QuadrilateralElement<2, 4>> quad4(

--- a/src/quadrature.cc
+++ b/src/quadrature.cc
@@ -5,12 +5,12 @@
 #include "triangle_quadrature.h"
 
 // Triangle 1
-static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 1>>
-    triangle1("QT1");
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 1>>triangle1(
+    "QT1");
 
 // Triangle 3
-static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 3>>
-    triangle3("QT2");
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 3>>triangle3(
+    "QT2");
 
 // Quadrilateral 1
 static Register<mpm::Quadrature<2>, mpm::QuadrilateralQuadrature<2, 1>>

--- a/src/quadrature.cc
+++ b/src/quadrature.cc
@@ -5,11 +5,11 @@
 #include "triangle_quadrature.h"
 
 // Triangle 1
-static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 1>>triangle1(
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 1>> triangle1(
     "QT1");
 
 // Triangle 3
-static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 3>>triangle3(
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 3>> triangle3(
     "QT2");
 
 // Quadrilateral 1

--- a/src/quadrature.cc
+++ b/src/quadrature.cc
@@ -2,6 +2,15 @@
 #include "factory.h"
 #include "hexahedron_quadrature.h"
 #include "quadrilateral_quadrature.h"
+#include "triangle_quadrature.h"
+
+// Triangle 1
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 1>>
+    triangle1("QT1");
+
+// Triangle 3
+static Register<mpm::Quadrature<2>, mpm::TriangleQuadrature<2, 3>>
+    triangle3("QT2");
 
 // Quadrilateral 1
 static Register<mpm::Quadrature<2>, mpm::QuadrilateralQuadrature<2, 1>>

--- a/tests/triangle_element_test.cc
+++ b/tests/triangle_element_test.cc
@@ -24,7 +24,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -35,7 +35,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -52,7 +52,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 0.333, 0.333;
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -63,7 +63,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -80,7 +80,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 0.5, 0.4;
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -91,7 +91,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -109,7 +109,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       auto shapefn = tri->shapefn_local(coords, Eigen::Vector2d::Zero(),
-                                         Eigen::Vector2d::Zero());
+                                        Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -120,8 +120,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Check shapefn with deformation gradient
-    SECTION(
-        "Three noded triangle element shapefn with deformation gradient") {
+    SECTION("Three noded triangle element shapefn with deformation gradient") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       Eigen::Matrix<double, Dim, 1> psize;
@@ -171,7 +170,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get Jacobian
       auto jac = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
-                                Eigen::Vector2d::Zero());
+                               Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -204,7 +203,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get Jacobian
       auto jac = tri->jacobian_local(xi, coords, Eigen::Vector2d::Zero(),
-                                      Eigen::Vector2d::Zero());
+                                     Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -272,11 +271,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -314,11 +313,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -335,8 +334,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Coordinates is (0.5,0.5)
-    SECTION(
-        "Three noded triangle B-matrix cell for coordinates(0.5,0.5)") {
+    SECTION("Three noded triangle B-matrix cell for coordinates(0.5,0.5)") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0.5, 0.5;
@@ -357,11 +355,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -378,8 +376,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Check BMatrix with deformation gradient
-    SECTION(
-        "Three noded triangle B-matrix cell with deformation gradient") {
+    SECTION("Three noded triangle B-matrix cell with deformation gradient") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0.333, 0.333;
@@ -435,9 +432,9 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       // clang-format on
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
       auto jacobian = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
-                                     Eigen::Vector2d::Zero());
+                                    Eigen::Vector2d::Zero());
     }
 
     // Ni Nj matrix of a cell
@@ -445,11 +442,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
 
       Eigen::Matrix<double, Dim, 1> xi;
-      xi << 1.0/6, 1.0/6;
+      xi << 1.0 / 6, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 2.0/3, 1.0/6;
+      xi << 2.0 / 3, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 1.0/6, 2.0/3;
+      xi << 1.0 / 6, 2.0 / 3;
       xi_s.emplace_back(xi);
 
       REQUIRE(xi_s.size() == 3);
@@ -503,11 +500,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
 
       Eigen::Matrix<double, Dim, 1> xi;
-      xi << 1.0/6, 1.0/6;
+      xi << 1.0 / 6, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 2.0/3, 1.0/6;
+      xi << 2.0 / 3, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 1.0/6, 2.0/3;
+      xi << 1.0 / 6, 2.0 / 3;
       xi_s.emplace_back(xi);
 
       REQUIRE(xi_s.size() == 3);
@@ -641,7 +638,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -655,7 +652,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -679,7 +676,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 0.5, 0.5;
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -693,7 +690,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -717,7 +714,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords << 0.2, 0.4;
       auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -731,7 +728,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       REQUIRE(gradsf.rows() == nfunctions);
       REQUIRE(gradsf.cols() == Dim);
 
@@ -755,7 +752,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       auto shapefn = tri->shapefn_local(coords, Eigen::Vector2d::Zero(),
-                                         Eigen::Vector2d::Zero());
+                                        Eigen::Vector2d::Zero());
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
@@ -769,8 +766,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Coordinates is (0,0)
-    SECTION(
-        "Six noded triangle element shapefn with deformation gradient") {
+    SECTION("Six noded triangle Jacobian for local coordinates(0.5,0.5)") {
       Eigen::Matrix<double, Dim, 1> coords;
       coords.setZero();
       Eigen::Matrix<double, Dim, 1> psize;
@@ -834,7 +830,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get Jacobian
       auto jac = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
-                                Eigen::Vector2d::Zero());
+                               Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -871,7 +867,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get Jacobian
       auto jac = tri->jacobian_local(xi, coords, Eigen::Vector2d::Zero(),
-                                      Eigen::Vector2d::Zero());
+                                     Eigen::Vector2d::Zero());
 
       // Check size of jacobian
       REQUIRE(jac.size() == jacobian.size());
@@ -946,11 +942,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -967,8 +963,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Coordinates is (0.5,0.5)
-    SECTION(
-        "Six noded triangle B-matrix cell for coordinates(0.5,0.5)") {
+    SECTION("Six noded triangle B-matrix cell for coordinates(0.5,0.5)") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0.5, 0.5;
@@ -992,11 +987,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -1013,8 +1008,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Coordinates is (0.2,0.4)
-    SECTION(
-        "Six noded triangle B-matrix cell for coordinates(0.2,0.4)") {
+    SECTION("Six noded triangle B-matrix cell for coordinates(0.2,0.4)") {
       // Reference coordinates
       Eigen::Matrix<double, Dim, 1> xi;
       xi << 0.2, 0.4;
@@ -1038,11 +1032,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
 
       // Check gradient of shape functions
       auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
-                                       Eigen::Vector2d::Zero());
+                                      Eigen::Vector2d::Zero());
       gradsf *= ((jacobian.inverse()).transpose());
 
       // Check size of B-matrix
@@ -1121,9 +1115,9 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       // clang-format on
       // Get B-Matrix
       auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
-                                   Eigen::Vector2d::Zero());
+                                  Eigen::Vector2d::Zero());
       auto jacobian = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
-                                     Eigen::Vector2d::Zero());
+                                    Eigen::Vector2d::Zero());
     }
 
     // Ni Nj matrix of a cell
@@ -1131,11 +1125,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
 
       Eigen::Matrix<double, Dim, 1> xi;
-      xi << 1.0/6, 1.0/6;
+      xi << 1.0 / 6, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 2.0/3, 1.0/6;
+      xi << 2.0 / 3, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 1.0/6, 2.0/3;
+      xi << 1.0 / 6, 2.0 / 3;
       xi_s.emplace_back(xi);
 
       REQUIRE(xi_s.size() == 3);
@@ -1151,7 +1145,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       REQUIRE(ni_nj_matrix.sum() ==
               Approx(1. * xi_s.size()).epsilon(Tolerance));
 
-      Eigen::Matrix<double, 6, 6  > mass;
+      Eigen::Matrix<double, 6, 6> mass;
       // clang-format off
       mass <<  0.07407407407407, -0.03703703703704, -0.03703703703704,
                0.03703703703704, -0.07407407407407,  0.03703703703704,
@@ -1200,11 +1194,11 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       Eigen::Matrix<double, Dim, 1> xi;
       const double one_by_sqrt3 = std::fabs(1 / std::sqrt(3));
-      xi << 1.0/6, 1.0/6;
+      xi << 1.0 / 6, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 2.0/3, 1.0/6;
+      xi << 2.0 / 3, 1.0 / 6;
       xi_s.emplace_back(xi);
-      xi << 1.0/6, 2.0/3;
+      xi << 1.0 / 6, 2.0 / 3;
       xi_s.emplace_back(xi);
 
       REQUIRE(xi_s.size() == 3);
@@ -1230,6 +1224,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
       REQUIRE(laplace_matrix.sum() == Approx(0.).epsilon(Tolerance));
 
       Eigen::Matrix<double, 6, 6> laplace;
+      // clang-format off
       laplace <<  0.83333333333333,  0.22222222222222,  0.05555555555556,
                  -0.88888888888889,  0.00000000000000, -0.22222222222222,
                   0.22222222222222,  0.83333333333333,  0.05555555555556,
@@ -1242,6 +1237,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
                  -0.44444444444444,  2.66666666666667, -1.77777777777778,
                  -0.22222222222222,  0.00000000000000, -0.22222222222222,
                  -0.44444444444444, -1.77777777777778,  2.66666666666667;
+      // clang-format on
       for (unsigned i = 0; i < nfunctions; ++i)
         for (unsigned j = 0; j < nfunctions; ++j)
           REQUIRE(laplace_matrix(i, j) ==

--- a/tests/triangle_element_test.cc
+++ b/tests/triangle_element_test.cc
@@ -806,8 +806,7 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
     }
 
     // Check Jacobian
-    SECTION(
-        "Six noded triangle Jacobian for local coordinates(0.5,0.5)") {
+    SECTION("Six noded triangle Jacobian for local coordinates(0.5,0.5)") {
       Eigen::Matrix<double, 6, Dim> coords;
       // clang-format off
       coords << 2.0, 1.0,

--- a/tests/triangle_element_test.cc
+++ b/tests/triangle_element_test.cc
@@ -1,0 +1,1339 @@
+// Triangle element test
+#include <memory>
+
+#include "catch.hpp"
+
+#include "triangle_element.h"
+
+//! \brief Check triangle element class
+TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
+  const unsigned Dim = 2;
+  const double Tolerance = 1.E-7;
+
+  //! Check for 3 noded element
+  SECTION("Triangle element with three nodes") {
+    const unsigned nfunctions = 3;
+    std::shared_ptr<mpm::Element<Dim>> tri =
+        std::make_shared<mpm::TriangleElement<Dim, nfunctions>>();
+
+    // Check degree
+    REQUIRE(tri->degree() == mpm::ElementDegree::Linear);
+
+    // Coordinates is (0,0)
+    SECTION("Three noded triangle element for coordinates(0,0)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(0, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(1.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0.333, 0.333);
+    SECTION("Three noded triangle element for coordinates(0.333, 0.333)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords << 0.333, 0.333;
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(0.334).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.333).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.333).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(0, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(1.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0.5,0.4)
+    SECTION("Three noded triangle element for coordinates(0.5,0.4)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords << 0.5, 0.4;
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(0.1).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.5).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.4).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+
+      REQUIRE(gradsf(0, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(1.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0,0)
+    SECTION("Three noded local sf triangle element for coordinates(0,0)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      auto shapefn = tri->shapefn_local(coords, Eigen::Vector2d::Zero(),
+                                         Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+    }
+
+    // Check shapefn with deformation gradient
+    SECTION(
+        "Three noded triangle element shapefn with deformation gradient") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize.setZero();
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad.setZero();
+      auto shapefn = tri->shapefn(coords, psize, defgrad);
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, psize, defgrad);
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(0, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(1.0).epsilon(Tolerance));
+    }
+
+    // Check Jacobian
+    SECTION(
+        "Three noded triangle Jacobian for local coordinates(0.333,0.333)") {
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.333, 0.333;
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                Eigen::Vector2d::Zero());
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Check local Jacobian
+    SECTION(
+        "Three noded Triangle local Jacobian for local "
+        "coordinates(0.333,0.333)") {
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.333, 0.333;
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian_local(xi, coords, Eigen::Vector2d::Zero(),
+                                      Eigen::Vector2d::Zero());
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Check Jacobian
+    SECTION("Three noded triangle Jacobian with deformation gradient") {
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize.setZero();
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad.setZero();
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.333, 0.333;
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian(xi, coords, psize, defgrad);
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0,0)
+    SECTION("Three noded triangle B-matrix cell for coordinates(0,0)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi.setZero();
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Coordinates is (0.333,0.333)
+    SECTION("Three noded triangle B-matrix cell for coordinates(0.333,0.333)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.333, 0.333;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Coordinates is (0.5,0.5)
+    SECTION(
+        "Three noded triangle B-matrix cell for coordinates(0.5,0.5)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Check BMatrix with deformation gradient
+    SECTION(
+        "Three noded triangle B-matrix cell with deformation gradient") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.333, 0.333;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian << 2.0, 1.0,
+                  0.0, 3.0;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize.setZero();
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad.setZero();
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, psize, defgrad);
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, psize, defgrad);
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    SECTION("Three noded triangle B-matrix and Jacobian failure") {
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0., 0.;
+
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+      auto jacobian = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                     Eigen::Vector2d::Zero());
+    }
+
+    // Ni Nj matrix of a cell
+    SECTION("Three noded triangle ni-nj-matrix") {
+      std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 1.0/6, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 2.0/3, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 1.0/6, 2.0/3;
+      xi_s.emplace_back(xi);
+
+      REQUIRE(xi_s.size() == 3);
+
+      // Get Ni Nj matrix
+      const auto ni_nj_matrix = tri->ni_nj_matrix(xi_s);
+
+      // Check size of ni_nj_matrix
+      REQUIRE(ni_nj_matrix.rows() == nfunctions);
+      REQUIRE(ni_nj_matrix.cols() == nfunctions);
+
+      // Sum should be equal to 1. * xi_s.size()
+      REQUIRE(ni_nj_matrix.sum() ==
+              Approx(1. * xi_s.size()).epsilon(Tolerance));
+
+      Eigen::Matrix<double, 3, 3> mass;
+      // clang-format off
+      mass <<  0.50, 0.25, 0.25,
+               0.25, 0.50, 0.25,
+               0.25, 0.25, 0.50;
+      // clang-format on
+
+      // auxiliary matrices for checking its multiplication by scalar
+      auto ni_nj_matrix_unit = 1.0 * ni_nj_matrix;
+      auto ni_nj_matrix_zero = 0.0 * ni_nj_matrix;
+      auto ni_nj_matrix_negative = -2.0 * ni_nj_matrix;
+      double scalar = 21.65489;
+      auto ni_nj_matrix_scalar = scalar * ni_nj_matrix;
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        for (unsigned j = 0; j < nfunctions; ++j) {
+          REQUIRE(ni_nj_matrix(i, j) == Approx(mass(i, j)).epsilon(Tolerance));
+          // check multiplication by unity;
+          REQUIRE(ni_nj_matrix_unit(i, j) ==
+                  Approx(1.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by zero;
+          REQUIRE(ni_nj_matrix_zero(i, j) ==
+                  Approx(0.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by negative number;
+          REQUIRE(ni_nj_matrix_negative(i, j) ==
+                  Approx(-2.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by an arbitrary scalar;
+          REQUIRE(ni_nj_matrix_scalar(i, j) ==
+                  Approx(scalar * mass(i, j)).epsilon(Tolerance));
+        }
+      }
+    }
+
+    // Laplace matrix of a cell
+    SECTION("Three noded triangle laplace-matrix") {
+      std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 1.0/6, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 2.0/3, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 1.0/6, 2.0/3;
+      xi_s.emplace_back(xi);
+
+      REQUIRE(xi_s.size() == 3);
+
+      Eigen::Matrix<double, 3, Dim> coords;
+      // clang-format off
+      coords << 2., 1.,
+                4., 2.,
+                2., 4.;
+      // clang-format on
+
+      // Get laplace matrix
+      const auto laplace_matrix = tri->laplace_matrix(xi_s, coords);
+
+      // Check size of laplace-matrix
+      REQUIRE(laplace_matrix.rows() == nfunctions);
+      REQUIRE(laplace_matrix.cols() == nfunctions);
+
+      // Sum should be equal to 0.
+      REQUIRE(laplace_matrix.sum() == Approx(0.).epsilon(Tolerance));
+
+      Eigen::Matrix<double, 3, 3> laplace;
+      // clang-format off
+      laplace <<  0.8333333333333333, -0.6666666666666667, -0.1666666666666667,
+                 -0.6666666666666667,  0.8333333333333333, -0.1666666666666667,
+                 -0.1666666666666667, -0.1666666666666667,  0.3333333333333333;
+      // clang-format on
+      for (unsigned i = 0; i < nfunctions; ++i)
+        for (unsigned j = 0; j < nfunctions; ++j)
+          REQUIRE(laplace_matrix(i, j) ==
+                  Approx(laplace(i, j)).epsilon(Tolerance));
+    }
+
+    SECTION("Three noded triangle coordinates of unit cell") {
+      const unsigned nfunctions = 3;
+
+      // Coordinates of a unit cell
+      Eigen::Matrix<double, nfunctions, Dim> unit_cell;
+      // clang-format off
+      unit_cell <<  0.,  0.,
+                    1.,  0.,
+                    0.,  1.;
+      // clang-format on
+
+      auto coordinates = tri->unit_cell_coordinates();
+      REQUIRE(coordinates.rows() == nfunctions);
+      REQUIRE(coordinates.cols() == Dim);
+      for (unsigned i = 0; i < nfunctions; ++i) {  // Iterate through nfunctions
+        for (unsigned j = 0; j < Dim; ++j) {       // Dimension
+          REQUIRE(coordinates(i, j) ==
+                  Approx(unit_cell(i, j)).epsilon(Tolerance));
+        }
+      }
+    }
+
+    SECTION("Three noded triangle element for side indices") {
+      // Check for sides indices
+      Eigen::MatrixXi indices = tri->sides_indices();
+      REQUIRE(indices.rows() == 3);
+      REQUIRE(indices.cols() == 2);
+
+      REQUIRE(indices(0, 0) == 0);
+      REQUIRE(indices(0, 1) == 1);
+
+      REQUIRE(indices(1, 0) == 1);
+      REQUIRE(indices(1, 1) == 2);
+
+      REQUIRE(indices(2, 0) == 2);
+      REQUIRE(indices(2, 1) == 0);
+    }
+
+    SECTION("Three noded triangle element for corner indices") {
+      // Check for corner indices
+      Eigen::VectorXi indices = tri->corner_indices();
+      REQUIRE(indices.size() == 3);
+      REQUIRE(indices(0) == 0);
+      REQUIRE(indices(1) == 1);
+      REQUIRE(indices(2) == 2);
+    }
+
+    SECTION("Three noded triangle element for inhedron indices") {
+      // Check for inhedron indices
+      Eigen::MatrixXi indices = tri->inhedron_indices();
+      REQUIRE(indices.rows() == 3);
+      REQUIRE(indices.cols() == 2);
+
+      REQUIRE(indices(0, 0) == 0);
+      REQUIRE(indices(0, 1) == 1);
+
+      REQUIRE(indices(1, 0) == 1);
+      REQUIRE(indices(1, 1) == 2);
+
+      REQUIRE(indices(2, 0) == 2);
+      REQUIRE(indices(2, 1) == 0);
+    }
+
+    SECTION("Four noded triangle shape function for face indices") {
+      // Check for face indices
+      Eigen::Matrix<int, 3, 2> indices;
+      // clang-format off
+      indices << 0, 1,
+                 1, 2,
+                 2, 0;
+      // clang-format on
+      // Check for all face indices
+      for (unsigned i = 0; i < indices.rows(); ++i) {
+        const auto check_indices = tri->face_indices(i);
+        REQUIRE(check_indices.rows() == 2);
+        REQUIRE(check_indices.cols() == 1);
+
+        for (unsigned j = 0; j < indices.cols(); ++j)
+          REQUIRE(check_indices(j) == indices(i, j));
+      }
+
+      // Check number of faces
+      REQUIRE(tri->nfaces() == 3);
+    }
+  }
+
+  //! Check for 6 noded element
+  SECTION("Triangle element with six nodes") {
+    const unsigned nfunctions = 6;
+    std::shared_ptr<mpm::Element<Dim>> tri =
+        std::make_shared<mpm::TriangleElement<Dim, nfunctions>>();
+
+    // Check degree
+    REQUIRE(tri->degree() == mpm::ElementDegree::Quadratic);
+
+    // Coordinates is (0,0)
+    SECTION("Six noded triangle element for coordinates(0,0)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(4) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(5) == Approx(0.0).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-3.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 0) == Approx(4.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 0) == Approx(0.0).epsilon(Tolerance));
+
+      REQUIRE(gradsf(0, 1) == Approx(-3.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 1) == Approx(4.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0.5,0.5)
+    SECTION("Six noded triangle element for coordinates(0.5,0.5)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords << 0.5, 0.5;
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(4) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(5) == Approx(0.0).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 0) == Approx(-2.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 0) == Approx(2.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 0) == Approx(-2.0).epsilon(Tolerance));
+
+      REQUIRE(gradsf(0, 1) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 1) == Approx(-2.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 1) == Approx(2.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 1) == Approx(-2.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0.2,0.4)
+    SECTION("Six noded triangle element for coordinates(0.2, 0.4)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords << 0.2, 0.4;
+      auto shapefn = tri->shapefn(coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(-0.08).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(-0.12).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(-0.08).epsilon(Tolerance));
+      REQUIRE(shapefn(3) == Approx(0.32).epsilon(Tolerance));
+      REQUIRE(shapefn(4) == Approx(0.32).epsilon(Tolerance));
+      REQUIRE(shapefn(5) == Approx(0.64).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-0.6).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(-0.2).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 0) == Approx(0.8).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 0) == Approx(1.6).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 0) == Approx(-1.6).epsilon(Tolerance));
+
+      REQUIRE(gradsf(0, 1) == Approx(-0.6).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(0.6).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 1) == Approx(-0.8).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 1) == Approx(0.8).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 1) == Approx(0.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0,0)
+    SECTION("Six noded local sf triangle element for coordinates(0,0)") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      auto shapefn = tri->shapefn_local(coords, Eigen::Vector2d::Zero(),
+                                         Eigen::Vector2d::Zero());
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(4) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(5) == Approx(0.0).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0,0)
+    SECTION(
+        "Six noded triangle element shapefn with deformation gradient") {
+      Eigen::Matrix<double, Dim, 1> coords;
+      coords.setZero();
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize.setZero();
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad.setZero();
+      auto shapefn = tri->shapefn(coords, psize, defgrad);
+
+      // Check shape function
+      REQUIRE(shapefn.size() == nfunctions);
+
+      REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
+      REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(2) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(3) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(4) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(shapefn(5) == Approx(0.0).epsilon(Tolerance));
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(coords, psize, defgrad);
+      REQUIRE(gradsf.rows() == nfunctions);
+      REQUIRE(gradsf.cols() == Dim);
+
+      REQUIRE(gradsf(0, 0) == Approx(-3.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 0) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 0) == Approx(4.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 0) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 0) == Approx(0.0).epsilon(Tolerance));
+
+      REQUIRE(gradsf(0, 1) == Approx(-3.0).epsilon(Tolerance));
+      REQUIRE(gradsf(1, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(2, 1) == Approx(-1.0).epsilon(Tolerance));
+      REQUIRE(gradsf(3, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(4, 1) == Approx(0.0).epsilon(Tolerance));
+      REQUIRE(gradsf(5, 1) == Approx(4.0).epsilon(Tolerance));
+    }
+
+    // Check Jacobian
+    SECTION(
+        "Six noded triangle Jacobian for local coordinates(0.5,0.5)") {
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Jacobian result
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                Eigen::Vector2d::Zero());
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Check local Jacobian
+    SECTION(
+        "Six noded triangle local Jacobian for local "
+        "coordinates(0.5,0.5)") {
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Jacobian result
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian_local(xi, coords, Eigen::Vector2d::Zero(),
+                                      Eigen::Vector2d::Zero());
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Check Jacobian
+    SECTION("Six noded triangle Jacobian with deformation gradient") {
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize.setZero();
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad.setZero();
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Jacobian result
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get Jacobian
+      auto jac = tri->jacobian(xi, coords, psize, defgrad);
+
+      // Check size of jacobian
+      REQUIRE(jac.size() == jacobian.size());
+
+      // Check Jacobian
+      for (unsigned i = 0; i < Dim; ++i)
+        for (unsigned j = 0; j < Dim; ++j)
+          REQUIRE(jac(i, j) == Approx(jacobian(i, j)).epsilon(Tolerance));
+    }
+
+    // Coordinates is (0,0)
+    SECTION("Six noded triangle B-matrix cell for coordinates(0,0)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi.setZero();
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Coordinates is (0.5,0.5)
+    SECTION(
+        "Six noded triangle B-matrix cell for coordinates(0.5,0.5)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Coordinates is (0.2,0.4)
+    SECTION(
+        "Six noded triangle B-matrix cell for coordinates(0.2,0.4)") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.2, 0.4;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, Eigen::Vector2d::Zero(),
+                                       Eigen::Vector2d::Zero());
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    // Check Bmatrix with deformation gradient
+    SECTION("Six noded triangle B-matrix with deformation gradient") {
+      // Reference coordinates
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0.5, 0.5;
+
+      // Nodal coordinates
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, Dim> jacobian;
+      // clang-format off
+      jacobian <<  2.0, 1.0,
+                   0.0, 3.0;
+      // clang-format on
+
+      Eigen::Matrix<double, Dim, 1> psize;
+      psize << 0.5, 0.5;
+      Eigen::Matrix<double, Dim, 1> defgrad;
+      defgrad << 0.5, 0.5;
+
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, psize, defgrad);
+
+      // Check gradient of shape functions
+      auto gradsf = tri->grad_shapefn(xi, psize, defgrad);
+      gradsf *= ((jacobian.inverse()).transpose());
+
+      // Check size of B-matrix
+      REQUIRE(bmatrix.size() == nfunctions);
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        REQUIRE(bmatrix.at(i)(0, 0) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(0, 1) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 0) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(1, 1) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 0) == Approx(gradsf(i, 1)).epsilon(Tolerance));
+        REQUIRE(bmatrix.at(i)(2, 1) == Approx(gradsf(i, 0)).epsilon(Tolerance));
+      }
+    }
+
+    SECTION("Six noded triangle B-matrix and Jacobian failure") {
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 0., 0.;
+
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+      // Get B-Matrix
+      auto bmatrix = tri->bmatrix(xi, coords, Eigen::Vector2d::Zero(),
+                                   Eigen::Vector2d::Zero());
+      auto jacobian = tri->jacobian(xi, coords, Eigen::Vector2d::Zero(),
+                                     Eigen::Vector2d::Zero());
+    }
+
+    // Ni Nj matrix of a cell
+    SECTION("Six noded triangle ni-nj-matrix") {
+      std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      xi << 1.0/6, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 2.0/3, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 1.0/6, 2.0/3;
+      xi_s.emplace_back(xi);
+
+      REQUIRE(xi_s.size() == 3);
+
+      // Get Ni Nj matrix
+      const auto ni_nj_matrix = tri->ni_nj_matrix(xi_s);
+
+      // Check size of ni_nj_matrix
+      REQUIRE(ni_nj_matrix.rows() == nfunctions);
+      REQUIRE(ni_nj_matrix.cols() == nfunctions);
+
+      // Sum should be equal to 1. * xi_s.size()
+      REQUIRE(ni_nj_matrix.sum() ==
+              Approx(1. * xi_s.size()).epsilon(Tolerance));
+
+      Eigen::Matrix<double, 6, 6  > mass;
+      // clang-format off
+      mass <<  0.07407407407407, -0.03703703703704, -0.03703703703704,
+               0.03703703703704, -0.07407407407407,  0.03703703703704,
+              -0.03703703703704,  0.07407407407407, -0.03703703703704,
+	       0.03703703703704,  0.03703703703704, -0.07407407407407,
+              -0.03703703703704, -0.03703703703704,  0.07407407407407,
+              -0.07407407407407,  0.03703703703704,  0.03703703703704,
+               0.03703703703704,  0.03703703703704, -0.07407407407407,
+               0.40740740740741,  0.29629629629630,  0.29629629629630,
+              -0.07407407407407,  0.03703703703704,  0.03703703703704,
+               0.29629629629630,  0.40740740740741,  0.29629629629630,
+               0.03703703703704, -0.07407407407407,  0.03703703703704,
+               0.29629629629630,  0.29629629629630,  0.40740740740741;
+
+      // clang-format on
+
+      // auxiliary matrices for checking its multiplication by scalar
+      auto ni_nj_matrix_unit = 1.0 * ni_nj_matrix;
+      auto ni_nj_matrix_zero = 0.0 * ni_nj_matrix;
+      auto ni_nj_matrix_negative = -2.0 * ni_nj_matrix;
+      double scalar = 21.65489;
+      auto ni_nj_matrix_scalar = scalar * ni_nj_matrix;
+
+      for (unsigned i = 0; i < nfunctions; ++i) {
+        for (unsigned j = 0; j < nfunctions; ++j) {
+          REQUIRE(ni_nj_matrix(i, j) == Approx(mass(i, j)).epsilon(Tolerance));
+          // check multiplication by unity;
+          REQUIRE(ni_nj_matrix_unit(i, j) ==
+                  Approx(1.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by zero;
+          REQUIRE(ni_nj_matrix_zero(i, j) ==
+                  Approx(0.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by negative number;
+          REQUIRE(ni_nj_matrix_negative(i, j) ==
+                  Approx(-2.0 * mass(i, j)).epsilon(Tolerance));
+          // check multiplication by an arbitrary scalar;
+          REQUIRE(ni_nj_matrix_scalar(i, j) ==
+                  Approx(scalar * mass(i, j)).epsilon(Tolerance));
+        }
+      }
+    }
+
+    // Laplace matrix of a cell
+    SECTION("Six noded triangle laplace-matrix") {
+      std::vector<Eigen::Matrix<double, Dim, 1>> xi_s;
+
+      Eigen::Matrix<double, Dim, 1> xi;
+      const double one_by_sqrt3 = std::fabs(1 / std::sqrt(3));
+      xi << 1.0/6, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 2.0/3, 1.0/6;
+      xi_s.emplace_back(xi);
+      xi << 1.0/6, 2.0/3;
+      xi_s.emplace_back(xi);
+
+      REQUIRE(xi_s.size() == 3);
+
+      Eigen::Matrix<double, 6, Dim> coords;
+      // clang-format off
+      coords << 2.0, 1.0,
+                4.0, 2.0,
+                2.0, 4.0,
+                3.0, 1.5,
+                3.0, 3.0,
+                2.0, 2.5;
+      // clang-format on
+
+      // Get laplace matrix
+      const auto laplace_matrix = tri->laplace_matrix(xi_s, coords);
+
+      // Check size of laplace-matrix
+      REQUIRE(laplace_matrix.rows() == nfunctions);
+      REQUIRE(laplace_matrix.cols() == nfunctions);
+
+      // Sum should be equal to 0.
+      REQUIRE(laplace_matrix.sum() == Approx(0.).epsilon(Tolerance));
+
+      Eigen::Matrix<double, 6, 6> laplace;
+      laplace <<  0.83333333333333,  0.22222222222222,  0.05555555555556,
+                 -0.88888888888889,  0.00000000000000, -0.22222222222222,
+                  0.22222222222222,  0.83333333333333,  0.05555555555556,
+                 -0.88888888888889, -0.22222222222222,  0.00000000000000,
+                  0.05555555555556,  0.05555555555556,  0.33333333333333,
+                  0.00000000000000, -0.22222222222222, -0.22222222222222,
+                 -0.88888888888889, -0.88888888888889,  0.00000000000000,
+                  2.66666666666667, -0.44444444444444, -0.44444444444444,
+                  0.00000000000000, -0.22222222222222, -0.22222222222222,
+                 -0.44444444444444,  2.66666666666667, -1.77777777777778,
+                 -0.22222222222222,  0.00000000000000, -0.22222222222222,
+                 -0.44444444444444, -1.77777777777778,  2.66666666666667;
+      for (unsigned i = 0; i < nfunctions; ++i)
+        for (unsigned j = 0; j < nfunctions; ++j)
+          REQUIRE(laplace_matrix(i, j) ==
+                  Approx(laplace(i, j)).epsilon(Tolerance));
+    }
+
+    SECTION("Six noded triangle coordinates of unit cell") {
+      const unsigned nfunctions = 6;
+
+      // Coordinates of a unit cell
+      Eigen::Matrix<double, nfunctions, Dim> unit_cell;
+      // clang-format off
+      unit_cell <<  0.0,  0.0,
+                    1.0,  0.0,
+                    0.0,  1.0,
+                    0.5,  0.0,
+                    0.5,  0.5,
+                    0.0,  0.5;
+      // clang-format on
+
+      auto coordinates = tri->unit_cell_coordinates();
+      REQUIRE(coordinates.rows() == nfunctions);
+      REQUIRE(coordinates.cols() == Dim);
+      for (unsigned i = 0; i < nfunctions; ++i) {  // Iterate through nfunctions
+        for (unsigned j = 0; j < Dim; ++j) {       // Dimension
+          REQUIRE(coordinates(i, j) ==
+                  Approx(unit_cell(i, j)).epsilon(Tolerance));
+        }
+      }
+    }
+
+    SECTION("Six noded triangle element for side indices") {
+      // Check for sides indices
+      Eigen::MatrixXi indices = tri->sides_indices();
+      REQUIRE(indices.rows() == 3);
+      REQUIRE(indices.cols() == 2);
+
+      REQUIRE(indices(0, 0) == 0);
+      REQUIRE(indices(0, 1) == 1);
+
+      REQUIRE(indices(1, 0) == 1);
+      REQUIRE(indices(1, 1) == 2);
+
+      REQUIRE(indices(2, 0) == 2);
+      REQUIRE(indices(2, 1) == 0);
+    }
+
+    SECTION("Six noded triangle element for corner indices") {
+      // Check for corner indices
+      Eigen::VectorXi indices = tri->corner_indices();
+      REQUIRE(indices.size() == 3);
+      REQUIRE(indices(0) == 0);
+      REQUIRE(indices(1) == 1);
+      REQUIRE(indices(2) == 2);
+    }
+
+    SECTION("Six noded triangle element for inhedron indices") {
+      // Check for inhedron indices
+      Eigen::MatrixXi indices = tri->inhedron_indices();
+      REQUIRE(indices.rows() == 3);
+      REQUIRE(indices.cols() == 2);
+
+      REQUIRE(indices(0, 0) == 0);
+      REQUIRE(indices(0, 1) == 1);
+
+      REQUIRE(indices(1, 0) == 1);
+      REQUIRE(indices(1, 1) == 2);
+
+      REQUIRE(indices(2, 0) == 2);
+      REQUIRE(indices(2, 1) == 0);
+    }
+
+    SECTION("Six noded triangle shape function for face indices") {
+      // Check for face indices
+      Eigen::Matrix<int, 3, 3> indices;
+      // clang-format off
+      indices << 0, 1, 3,
+                 1, 2, 4,
+                 2, 0, 5;
+      // clang-format on
+      // Check for all face indices
+      for (unsigned i = 0; i < indices.rows(); ++i) {
+        const auto check_indices = tri->face_indices(i);
+        REQUIRE(check_indices.rows() == 3);
+        REQUIRE(check_indices.cols() == 1);
+
+        for (unsigned j = 0; j < indices.cols(); ++j)
+          REQUIRE(check_indices(j) == indices(i, j));
+      }
+
+      // Check number of faces
+      REQUIRE(tri->nfaces() == 3);
+    }
+  }
+}

--- a/tests/triangle_quadrature_test.cc
+++ b/tests/triangle_quadrature_test.cc
@@ -1,0 +1,77 @@
+// Quadrilateral quadrature test
+#include <cmath>
+
+#include <limits>
+#include <memory>
+
+#include "catch.hpp"
+#include "triangle_quadrature.h"
+
+//! \brief Check TriangleQuadrature class
+TEST_CASE("Triangle quadratures are checked",
+          "[triquadrature][tri][quadrature][2D]") {
+  const unsigned Dim = 2;
+  const double Tolerance = 1.E-7;
+
+  //! Check for a single point quadrature function
+  SECTION("Triangle with a single quadrature") {
+    const unsigned Nquadratures = 1;
+
+    auto tri =
+        std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
+
+    // Check quadratures
+    auto points = tri->quadratures();
+
+    // Check size
+    REQUIRE(points.rows() == 2);
+    REQUIRE(points.cols() == 1);
+
+    // Check quadrature points
+    REQUIRE(points(0, 0) == Approx(1. / 3.).epsilon(Tolerance));
+    REQUIRE(points(1, 0) == Approx(1. / 3.).epsilon(Tolerance));
+
+    // Check weights
+    auto weights = tri->weights();
+
+    // Check size
+    REQUIRE(weights.size() == 1);
+
+    // Check weights
+    REQUIRE(weights(0) == Approx(0.5).epsilon(Tolerance));
+  }
+
+  //! Check for three quadrature points
+  SECTION("Triangle with three quadratures") {
+    const unsigned Nquadratures = 3;
+
+    auto tri =
+        std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
+
+    // Check quadratures
+    auto points = tri->quadratures();
+
+    // Check size
+    REQUIRE(points.rows() == 2);
+    REQUIRE(points.cols() == 3);
+
+    // Check quadrature points
+    REQUIRE(points(0, 0) == Approx(1. / 6.).epsilon(Tolerance));
+    REQUIRE(points(1, 0) == Approx(1. / 6.).epsilon(Tolerance));
+    REQUIRE(points(0, 1) == Approx(2. / 3.).epsilon(Tolerance));
+    REQUIRE(points(1, 1) == Approx(1. / 6.).epsilon(Tolerance));
+    REQUIRE(points(0, 2) == Approx(1. / 6.).epsilon(Tolerance));
+    REQUIRE(points(1, 2) == Approx(2. / 3.).epsilon(Tolerance));
+
+    // Check weights
+    auto weights = tri->weights();
+
+    // Check size
+    REQUIRE(weights.size() == 3);
+
+    // Check weights
+    REQUIRE(weights(0) == Approx(1. / 3.).epsilon(Tolerance));
+    REQUIRE(weights(1) == Approx(1. / 3.).epsilon(Tolerance));
+    REQUIRE(weights(2) == Approx(1. / 3.).epsilon(Tolerance));
+  }
+}

--- a/tests/triangle_quadrature_test.cc
+++ b/tests/triangle_quadrature_test.cc
@@ -17,8 +17,7 @@ TEST_CASE("Triangle quadratures are checked",
   SECTION("Triangle with a single quadrature") {
     const unsigned Nquadratures = 1;
 
-    auto tri =
-        std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
+    auto tri = std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
 
     // Check quadratures
     auto points = tri->quadratures();
@@ -45,8 +44,7 @@ TEST_CASE("Triangle quadratures are checked",
   SECTION("Triangle with three quadratures") {
     const unsigned Nquadratures = 3;
 
-    auto tri =
-        std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
+    auto tri = std::make_shared<mpm::TriangleQuadrature<Dim, Nquadratures>>();
 
     // Check quadratures
     auto points = tri->quadratures();


### PR DESCRIPTION
Implement the `TriangleElement` class that includes:

- 3-noded triangular element.
- 6-noded triangular element.

And the quadrature rules for such elements (`TriangleQuadrature `class):

- 1 quadrature point.
- 3 quadrature points.

The unit tests for these classes are also implemented.