### PR TITLE
Displacement vtp output and fix typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ link_libraries (${CMAKE_THREAD_LIBS_INIT})
 # VTK
 find_package(VTK)
 if (VTK_FOUND)
+  include(${VTK_USE_FILE})
   include_directories(${VTK_INCLUDE_DIRS})
   link_libraries(${VTK_LIBRARIES})
   add_definitions("-DUSE_VTK")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ link_libraries (${CMAKE_THREAD_LIBS_INIT})
 # VTK
 find_package(VTK)
 if (VTK_FOUND)
-  include(${VTK_USE_FILE})
   include_directories(${VTK_INCLUDE_DIRS})
   link_libraries(${VTK_LIBRARIES})
   add_definitions("-DUSE_VTK")

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -480,15 +480,21 @@ std::vector<Eigen::Matrix<double, 3, 1>> mpm::Mesh<Tdim>::particles_vector_data(
       // Strains
       else if (attribute == "strains") {
         auto pdata = (*pitr)->strain(phase);
-        // Fill stresses to the size of dimensions
+        // Fill strains to the size of dimensions
         for (unsigned i = 0; i < Tdim; ++i) data(i) = pdata(i);
       }
       // Velocities
       else if (attribute == "velocities") {
         auto pdata = (*pitr)->velocity(phase);
-        // Fill stresses to the size of dimensions
+        // Fill velocities to the size of dimensions
         for (unsigned i = 0; i < Tdim; ++i) data(i) = pdata(i);
       }
+      // Displacements
+      else if (attribute == "displacements") {
+        auto pdata = (*pitr)->displacement(phase);
+        // Fill displacements to the size of dimensions
+        for (unsigned i = 0; i < Tdim; ++i) data(i) = pdata(i);
+      }      
       // Error
       else
         throw std::runtime_error("Invalid particle vector data attribute: !");

--- a/include/mpm_base.tcc
+++ b/include/mpm_base.tcc
@@ -57,7 +57,7 @@ mpm::MPMBase<Tdim>::MPMBase(std::unique_ptr<IO>&& io)
   }
 
   // Default VTK attributes
-  std::vector<std::string> vtk = {"velocities", "stresses", "strains"};
+  std::vector<std::string> vtk = {"velocities", "stresses", "strains", "displacements"};
   try {
     if (post_process_.at("vtk").is_array() &&
         post_process_.at("vtk").size() > 0) {

--- a/include/particle.h
+++ b/include/particle.h
@@ -204,6 +204,13 @@ class Particle : public ParticleBase<Tdim> {
     return velocity_.col(phase);
   }
 
+  //! Return displacement of the particle
+  //! \param[in] phase Index corresponding to the phase
+  VectorDim displacement(unsigned phase) const override {
+    return displacement_.col(phase);
+  }
+
+
   //! Assign traction to the particle
   //! \param[in] phase Index corresponding to the phase
   //! \param[in] direction Index corresponding to the direction of traction
@@ -273,6 +280,8 @@ class Particle : public ParticleBase<Tdim> {
   using ParticleBase<Tdim>::id_;
   //! coordinates
   using ParticleBase<Tdim>::coordinates_;
+  //! coordinates
+  using ParticleBase<Tdim>::original_coordinates_;
   //! Reference coordinates (in a cell)
   using ParticleBase<Tdim>::xi_;
   //! Cell
@@ -309,6 +318,8 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::Matrix<double, 6, Tnphases> dstrain_;
   //! Velocity
   Eigen::Matrix<double, Tdim, Tnphases> velocity_;
+  //! Displacements
+  Eigen::Matrix<double, Tdim, Tnphases> displacement_;
   //! Particle velocity constraints
   std::map<unsigned, double> particle_velocity_constraints_;
   //! Set traction

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -93,6 +93,8 @@ void mpm::Particle<Tdim, Tnphases>::initialise() {
   stress_.setZero();
   traction_.setZero();
   velocity_.setZero();
+  displacement_.setZero();
+  original_coordinates_.setZero();
   volume_.fill(std::numeric_limits<double>::max());
   volumetric_strain_centroid_.setZero();
 }
@@ -575,6 +577,10 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
 
       // New position  current position + velocity * dt
       this->coordinates_ += nodal_velocity * dt;
+
+      // Update displacement
+      this->displacement_ = this->coordinates_ - this->original_coordinates_;
+
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "
@@ -607,6 +613,10 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
 
       // New position current position + velocity * dt
       this->coordinates_ += nodal_velocity * dt;
+
+      // Update displacement
+      this->displacement_ = this->coordinates_ - this->original_coordinates_;
+
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -94,7 +94,6 @@ void mpm::Particle<Tdim, Tnphases>::initialise() {
   traction_.setZero();
   velocity_.setZero();
   displacement_.setZero();
-  original_coordinates_.setZero();
   volume_.fill(std::numeric_limits<double>::max());
   volumetric_strain_centroid_.setZero();
 }

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -575,7 +575,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
           cell_->interpolate_nodal_velocity(this->shapefn_, phase);
 
       // New position  current position + velocity * dt
-      this->coordinates_ += nodal_velocity * dt;
+      this->coordinates_ += this->velocity_.col(phase) * dt;
 
       // Update displacement
       this->displacement_ = this->coordinates_ - this->original_coordinates_;
@@ -611,7 +611,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
       this->apply_particle_velocity_constraints();
 
       // New position current position + velocity * dt
-      this->coordinates_ += nodal_velocity * dt;
+      this->coordinates_ += this->velocity_.col(phase) * dt;
 
       // Update displacement
       this->displacement_ = this->coordinates_ - this->original_coordinates_;

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -575,7 +575,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
           cell_->interpolate_nodal_velocity(this->shapefn_, phase);
 
       // New position  current position + velocity * dt
-      this->coordinates_ += this->velocity_.col(phase) * dt;
+      this->coordinates_ += nodal_velocity * dt;
 
       // Update displacement
       this->displacement_ = this->coordinates_ - this->original_coordinates_;
@@ -611,7 +611,7 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
       this->apply_particle_velocity_constraints();
 
       // New position current position + velocity * dt
-      this->coordinates_ += this->velocity_.col(phase) * dt;
+      this->coordinates_ += nodal_velocity * dt;
 
       // Update displacement
       this->displacement_ = this->coordinates_ - this->original_coordinates_;

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -179,6 +179,9 @@ class ParticleBase {
   //! Return velocity
   virtual VectorDim velocity(unsigned phase) const = 0;
 
+  //! Return displacement
+  virtual VectorDim displacement(unsigned phase) const = 0;
+
   //! Assign traction
   virtual bool assign_traction(unsigned phase, unsigned direction,
                                double traction) = 0;
@@ -213,6 +216,8 @@ class ParticleBase {
   Index id_{std::numeric_limits<Index>::max()};
   //! coordinates
   VectorDim coordinates_;
+  //! Original coordinates
+  VectorDim original_coordinates_;
   //! Cell id
   Index cell_id_{std::numeric_limits<Index>::max()};
   //! Status

--- a/include/particle_base.tcc
+++ b/include/particle_base.tcc
@@ -5,6 +5,7 @@ mpm::ParticleBase<Tdim>::ParticleBase(Index id, const VectorDim& coord)
   // Check if the dimension is between 1 & 3
   static_assert((Tdim >= 1 && Tdim <= 3), "Invalid global dimension");
   coordinates_ = coord;
+  original_coordinates_ = coord;
   status_ = true;
 }
 


### PR DESCRIPTION
- [x] Add a variable `original_coordinates_` in order to record displacement in reference to the original location of particles
- [x] Add `displacement` output 
- [ ] Test cases  