### PR TITLE
:dart: :hammer: Codecoverage ignore external files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,8 @@ ignore: # files and folders for processing
   - external/catch.hpp
   - external/json.hpp
   - external/sparsepp/*
-  - external/spdlog/*
+  - external/spdlog/**/*
   - external/tclap/*
   - external/tsl/*
+  - external/**/*
   - src/main.cc


### PR DESCRIPTION
Ignore external files in codecoverage