### PR TITLE
:computer: Refactor and remove phases in particle class

### DIFF
--- a/include/material/bingham.tcc
+++ b/include/material/bingham.tcc
@@ -36,10 +36,8 @@ Eigen::Matrix<double, 6, 1> mpm::Bingham<Tdim>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain,
     const ParticleBase<Tdim>* ptr, mpm::dense_map* state_vars) {
 
-  const unsigned phase = 0;
-
   // Get strain rate
-  auto strain_rate = ptr->strain_rate(phase);
+  auto strain_rate = ptr->strain_rate();
 
   // Convert strain rate to rate of deformation tensor
   strain_rate.tail(3) *= 0.5;
@@ -81,7 +79,7 @@ Eigen::Matrix<double, 6, 1> mpm::Bingham<Tdim>::compute_stress(
   // stress = -thermodynamic_pressure I + tau, where I is identity matrix or
   // direc_delta in Voigt notation
   const Eigen::Matrix<double, 6, 1> updated_stress =
-      -ptr->pressure(phase) * this->dirac_delta() + tau;
+      -ptr->pressure() * this->dirac_delta() + tau;
 
   return updated_stress;
 }

--- a/include/material/newtonian.tcc
+++ b/include/material/newtonian.tcc
@@ -31,7 +31,7 @@ Eigen::Matrix<double, 6, 1> mpm::Newtonian<2>::compute_stress(
 
   const unsigned phase = 0;
 
-  const double pressure = ptr->pressure(phase);
+  const double pressure = ptr->pressure();
 
   const double volumetric_strain = dstrain(0) + dstrain(1);
 
@@ -57,7 +57,7 @@ Eigen::Matrix<double, 6, 1> mpm::Newtonian<3>::compute_stress(
 
   const unsigned phase = 0;
 
-  const double pressure = ptr->pressure(phase);
+  const double pressure = ptr->pressure();
 
   const double volumetric_strain = dstrain(0) + dstrain(1) + dstrain(2);
 

--- a/include/material/newtonian.tcc
+++ b/include/material/newtonian.tcc
@@ -29,8 +29,6 @@ Eigen::Matrix<double, 6, 1> mpm::Newtonian<2>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain, const ParticleBase<2>* ptr,
     mpm::dense_map* state_vars) {
 
-  const unsigned phase = 0;
-
   const double pressure = ptr->pressure();
 
   const double volumetric_strain = dstrain(0) + dstrain(1);
@@ -54,8 +52,6 @@ template <>
 Eigen::Matrix<double, 6, 1> mpm::Newtonian<3>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain, const ParticleBase<3>* ptr,
     mpm::dense_map* state_vars) {
-
-  const unsigned phase = 0;
 
   const double pressure = ptr->pressure();
 

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -504,7 +504,7 @@ std::vector<Eigen::Matrix<double, 3, 1>> mpm::Mesh<Tdim>::particles_vector_data(
     for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr) {
       Eigen::Vector3d data;
       data.setZero();
-      auto pdata = (*pitr)->vector_data(phase, attribute);
+      auto pdata = (*pitr)->vector_data(attribute);
       // Fill stresses to the size of dimensions
       for (unsigned i = 0; i < Tdim; ++i) data(i) = pdata(i);
 
@@ -605,7 +605,7 @@ bool mpm::Mesh<Tdim>::assign_particles_volumes(
       double volume = std::get<1>(particle_volume);
 
       if (map_particles_.find(pid) != map_particles_.end())
-        status = map_particles_[pid]->assign_volume(phase, volume);
+        status = map_particles_[pid]->assign_volume(volume);
 
       if (!status)
         throw std::runtime_error("Cannot assign invalid particle volume");
@@ -669,7 +669,7 @@ bool mpm::Mesh<Tdim>::assign_particles_tractions(
       double traction = std::get<2>(particle_traction);
 
       if (map_particles_.find(pid) != map_particles_.end())
-        status = map_particles_[pid]->assign_traction(phase, dir, traction);
+        status = map_particles_[pid]->assign_traction(dir, traction);
 
       if (!status) throw std::runtime_error("Traction is invalid for particle");
     }
@@ -764,7 +764,7 @@ bool mpm::Mesh<Tdim>::assign_particles_stresses(
 
     unsigned i = 0;
     for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr) {
-      (*pitr)->initial_stress(phase, particle_stresses.at(i));
+      (*pitr)->initial_stress(particle_stresses.at(i));
       ++i;
     }
   } catch (std::exception& exception) {
@@ -874,7 +874,7 @@ bool mpm::Mesh<Tdim>::write_particles_hdf5(unsigned phase,
   particle_data.reserve(nparticles);
 
   for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr)
-    particle_data.emplace_back((*pitr)->hdf5(phase));
+    particle_data.emplace_back((*pitr)->hdf5());
 
   // Calculate the size and the offsets of our struct members in memory
   const hsize_t NRECORDS = nparticles;

--- a/include/mpm_base.h
+++ b/include/mpm_base.h
@@ -24,6 +24,13 @@
 #include "particle.h"
 
 namespace mpm {
+  
+//! Stress update method
+//! USF: Update Stress First
+//! USL: Update Stress Last
+//! MUSL: Modified Stress Last
+enum class StressUpdate { USF, USL, MUSL };
+extern std::map<std::string, StressUpdate> stress_update;
 
 //! MPMBase class
 //! \brief A class that implements the fully base one phase mpm
@@ -89,6 +96,8 @@ class MPMBase : public MPM {
   //! Logger
   using mpm::MPM::console_;
 
+  //! Stress update method (default USF = 0, USL = 1, MUSL = 2)
+  mpm::StressUpdate stress_update_{mpm::StressUpdate::USF};
   //! velocity update
   bool velocity_update_{false};
   //! Gravity

--- a/include/mpm_base.h
+++ b/include/mpm_base.h
@@ -24,7 +24,7 @@
 #include "particle.h"
 
 namespace mpm {
-  
+
 //! Stress update method
 //! USF: Update Stress First
 //! USL: Update Stress Last

--- a/include/mpm_base.tcc
+++ b/include/mpm_base.tcc
@@ -35,6 +35,18 @@ mpm::MPMBase<Tdim>::MPMBase(std::unique_ptr<IO>&& io)
       throw std::runtime_error("Specified gravity dimension is invalid");
     }
 
+    // Stress update method (USF/USL/MUSL)
+    try {
+      if (analysis_.find("stress_update") != analysis_.end())
+        stress_update_ = mpm::stress_update.at(
+            analysis_["stress_update"].template get<std::string>());
+    } catch (std::exception& exception) {
+      console_->warn(
+          "{} #{}: {}. Stress update method is not specified, using USF as "
+          "default\n",
+          __FILE__, __LINE__, exception.what());
+    }
+
     // Velocity update
     try {
       velocity_update_ = analysis_["velocity_update"].template get<bool>();

--- a/include/mpm_base.tcc
+++ b/include/mpm_base.tcc
@@ -328,9 +328,8 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
 
     auto particles_traction_begin = std::chrono::steady_clock::now();
     // Compute volume
-    mesh_->iterate_over_particles(
-        std::bind(&mpm::ParticleBase<Tdim>::compute_volume,
-                  std::placeholders::_1, phase));
+    mesh_->iterate_over_particles(std::bind(
+        &mpm::ParticleBase<Tdim>::compute_volume, std::placeholders::_1));
 
     // Read and assign particles volumes
     if (!io_->file_name("particles_volumes").empty()) {
@@ -487,7 +486,7 @@ bool mpm::MPMBase<Tdim>::apply_properties_to_particles_sets() {
       for (const auto& sitr : sids) {
         mesh_->iterate_over_particle_set(
             sitr, std::bind(&mpm::ParticleBase<Tdim>::assign_material,
-                            std::placeholders::_1, phase, set_material));
+                            std::placeholders::_1, set_material));
       }
     }
     status = true;

--- a/include/mpm_explicit.tcc
+++ b/include/mpm_explicit.tcc
@@ -172,7 +172,7 @@ bool mpm::MPMExplicit<Tdim>::solve() {
         std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
 
     // Update stress first
-    if (!usl_) {
+    if (this->stress_update_ == mpm::StressUpdate::USF) {
       // Iterate over each particle to calculate strain
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_strain,
@@ -275,7 +275,7 @@ bool mpm::MPMExplicit<Tdim>::solve() {
                     std::placeholders::_1, this->dt_));
 
     // Update Stress Last
-    if (usl_ == true) {
+    if (this->stress_update_ == mpm::StressUpdate::USL) {
       // Iterate over each particle to calculate strain
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_strain,
@@ -332,11 +332,12 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     }
   }
   auto solver_end = std::chrono::steady_clock::now();
-  console_->info("Rank {}, Explicit {} solver duration: {} ms", mpi_rank,
-                 (this->usl_ ? "USL" : "USF"),
-                 std::chrono::duration_cast<std::chrono::milliseconds>(
-                     solver_end - solver_begin)
-                     .count());
+  console_->info(
+      "Rank {}, Explicit {} solver duration: {} ms", mpi_rank,
+      (this->stress_update_ == mpm::StressUpdate::USL ? "USL" : "USF"),
+      std::chrono::duration_cast<std::chrono::milliseconds>(solver_end -
+                                                            solver_begin)
+          .count());
 
   return status;
 }

--- a/include/mpm_explicit.tcc
+++ b/include/mpm_explicit.tcc
@@ -67,7 +67,7 @@ bool mpm::MPMExplicit<Tdim>::solve() {
   // Iterate over each particle to assign material
   mesh_->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Tdim>::assign_material,
-                std::placeholders::_1, phase, material));
+                std::placeholders::_1, material));
 
   // Assign material to particle sets
   if (particle_props["particle_sets"].size() != 0) {
@@ -76,8 +76,8 @@ bool mpm::MPMExplicit<Tdim>::solve() {
   }
 
   // Compute mass
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1, phase));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1));
 
 #ifdef USE_MPI
   if (mpi_size > 1 && mesh_->ncells() > 1) {
@@ -145,7 +145,7 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Assign mass and momentum to nodes
     mesh_->iterate_over_particles(
         std::bind(&mpm::ParticleBase<Tdim>::map_mass_momentum_to_nodes,
-                  std::placeholders::_1, phase));
+                  std::placeholders::_1));
 
 #ifdef USE_MPI
     // Run if there is more than a single MPI task
@@ -176,19 +176,19 @@ bool mpm::MPMExplicit<Tdim>::solve() {
       // Iterate over each particle to calculate strain
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_strain,
-                    std::placeholders::_1, phase, dt_));
+                    std::placeholders::_1, dt_));
 
       // Iterate over each particle to update particle volume
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::update_volume_strainrate,
-                    std::placeholders::_1, phase, this->dt_));
+                    std::placeholders::_1, this->dt_));
 
       // Pressure smoothing
       if (pressure_smoothing_) {
         // Assign pressure to nodes
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::map_pressure_to_nodes,
-                      std::placeholders::_1, phase));
+                      std::placeholders::_1));
 
 #ifdef USE_MPI
         // Run if there is more than a single MPI task
@@ -205,13 +205,12 @@ bool mpm::MPMExplicit<Tdim>::solve() {
         // Smooth pressure over particles
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::compute_pressure_smoothing,
-                      std::placeholders::_1, phase));
+                      std::placeholders::_1));
       }
 
       // Iterate over each particle to compute stress
-      mesh_->iterate_over_particles(
-          std::bind(&mpm::ParticleBase<Tdim>::compute_stress,
-                    std::placeholders::_1, phase));
+      mesh_->iterate_over_particles(std::bind(
+          &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
     }
 
     // Spawn a task for external force
@@ -219,12 +218,11 @@ bool mpm::MPMExplicit<Tdim>::solve() {
       // Iterate over each particle to compute nodal body force
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::map_body_force,
-                    std::placeholders::_1, phase, this->gravity_));
+                    std::placeholders::_1, this->gravity_));
 
       // Iterate over each particle to map traction force to nodes
-      mesh_->iterate_over_particles(
-          std::bind(&mpm::ParticleBase<Tdim>::map_traction_force,
-                    std::placeholders::_1, phase));
+      mesh_->iterate_over_particles(std::bind(
+          &mpm::ParticleBase<Tdim>::map_traction_force, std::placeholders::_1));
 
       //! Apply nodal tractions
       if (nodal_tractions_) this->apply_nodal_tractions();
@@ -233,9 +231,8 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Spawn a task for internal force
     task_group.run([&] {
       // Iterate over each particle to compute nodal internal force
-      mesh_->iterate_over_particles(
-          std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
-                    std::placeholders::_1, phase));
+      mesh_->iterate_over_particles(std::bind(
+          &mpm::ParticleBase<Tdim>::map_internal_force, std::placeholders::_1));
     });
     task_group.wait();
 
@@ -270,31 +267,31 @@ bool mpm::MPMExplicit<Tdim>::solve() {
       // Iterate over each particle to compute updated position
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_updated_position_velocity,
-                    std::placeholders::_1, phase, this->dt_));
+                    std::placeholders::_1, this->dt_));
     else
       // Iterate over each particle to compute updated position
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_updated_position,
-                    std::placeholders::_1, phase, this->dt_));
+                    std::placeholders::_1, this->dt_));
 
     // Update Stress Last
     if (usl_ == true) {
       // Iterate over each particle to calculate strain
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::compute_strain,
-                    std::placeholders::_1, phase, dt_));
+                    std::placeholders::_1, dt_));
 
       // Iterate over each particle to update particle volume
       mesh_->iterate_over_particles(
           std::bind(&mpm::ParticleBase<Tdim>::update_volume_strainrate,
-                    std::placeholders::_1, phase, this->dt_));
+                    std::placeholders::_1, this->dt_));
 
       // Pressure smoothing
       if (pressure_smoothing_) {
         // Assign pressure to nodes
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::map_pressure_to_nodes,
-                      std::placeholders::_1, phase));
+                      std::placeholders::_1));
 
 #ifdef USE_MPI
         // Run if there is more than a single MPI task
@@ -311,13 +308,12 @@ bool mpm::MPMExplicit<Tdim>::solve() {
         // Smooth pressure over particles
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::compute_pressure_smoothing,
-                      std::placeholders::_1, phase));
+                      std::placeholders::_1));
       }
 
       // Iterate over each particle to compute stress
-      mesh_->iterate_over_particles(
-          std::bind(&mpm::ParticleBase<Tdim>::compute_stress,
-                    std::placeholders::_1, phase));
+      mesh_->iterate_over_particles(std::bind(
+          &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
     }
 
     // Locate particles

--- a/include/particle.h
+++ b/include/particle.h
@@ -267,8 +267,6 @@ class Particle : public ParticleBase<Tdim> {
   double mass_;
   //! Volume
   double volume_;
-  //! Phase
-  unsigned phase_{0};
   //! Size of particle
   Eigen::Matrix<double, 1, Tdim> size_;
   //! Size of particle in natural coordinates

--- a/include/particle.h
+++ b/include/particle.h
@@ -20,8 +20,7 @@ using Index = unsigned long long;
 //! \brief Base class that stores the information about particles
 //! \details Particle class: id_ and coordinates.
 //! \tparam Tdim Dimension
-//! \tparam Tnphases Number of phases
-template <unsigned Tdim, unsigned Tnphases>
+template <unsigned Tdim>
 class Particle : public ParticleBase<Tdim> {
  public:
   //! Define a vector of size dimension
@@ -45,10 +44,10 @@ class Particle : public ParticleBase<Tdim> {
   ~Particle() override{};
 
   //! Delete copy constructor
-  Particle(const Particle<Tdim, Tnphases>&) = delete;
+  Particle(const Particle<Tdim>&) = delete;
 
   //! Delete assignment operator
-  Particle& operator=(const Particle<Tdim, Tnphases>&) = delete;
+  Particle& operator=(const Particle<Tdim>&) = delete;
 
   //! Initialise particle from HDF5 data
   //! \param[in] particle HDF5 data of particle
@@ -56,9 +55,8 @@ class Particle : public ParticleBase<Tdim> {
   bool initialise_particle(const HDF5Particle& particle) override;
 
   //! Retrun particle data as HDF5
-  //! \param[in] phase Properties of a given phase
   //! \retval particle HDF5 data of the particle
-  HDF5Particle hdf5(unsigned phase) const override;
+  HDF5Particle hdf5() const override;
 
   //! Initialise properties
   void initialise() override;
@@ -102,152 +100,112 @@ class Particle : public ParticleBase<Tdim> {
   bool compute_shapefn() override;
 
   //! Assign volume
-  //! \param[in] phase Index corresponding to the phase
-  //! \param[in] volume Volume of particle for the phase
-  bool assign_volume(unsigned phase, double volume) override;
+  //! \param[in] volume Volume of particle
+  bool assign_volume(double volume) override;
 
   //! Return volume
-  //! \param[in] phase Index corresponding to the phase
-  double volume(unsigned phase) const override { return volume_(phase); }
+  double volume() const override { return volume_; }
 
   //! Return size of particle in natural coordinates
   VectorDim natural_size() const override { return natural_size_; }
 
   //! Compute volume as cell volume / nparticles
-  //! \param[in] phase Index corresponding to the phase
-  bool compute_volume(unsigned phase) override;
+  bool compute_volume() override;
 
   //! Update volume based on centre volumetric strain rate
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] dt Analysis time step
-  bool update_volume_strainrate(unsigned phase, double dt) override;
+  bool update_volume_strainrate(double dt) override;
 
   //! Return mass density
   //! \param[in] phase Index corresponding to the phase
-  double mass_density(unsigned phase) const override {
-    return mass_density_(phase);
-  }
+  double mass_density() const override { return mass_density_; }
 
   //! Compute mass as volume * density
-  //! \param[in] phase Index corresponding to the phase
-  bool compute_mass(unsigned phase) override;
+  bool compute_mass() override;
 
   //! Map particle mass and momentum to nodes
-  //! \param[in] phase Index corresponding to the phase
-  bool map_mass_momentum_to_nodes(unsigned phase) override;
+  bool map_mass_momentum_to_nodes() override;
 
   //! Assign nodal mass to particles
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] mass Mass from the particles in a cell
   //! \retval status Assignment status
-  void assign_mass(unsigned phase, double mass) override {
-    mass_(phase) = mass;
-  }
+  void assign_mass(double mass) override { mass_ = mass; }
 
   //! Return mass of the particles
-  //! \param[in] phase Index corresponding to the phase
-  double mass(unsigned phase) const override { return mass_(phase); }
+  double mass() const override { return mass_; }
 
   //! Assign material
   //! \param[in] material Pointer to a material
   bool assign_material(
-      unsigned phase, const std::shared_ptr<Material<Tdim>>& material) override;
+      const std::shared_ptr<Material<Tdim>>& material) override;
 
   //! Compute strain
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] dt Analysis time step
-  void compute_strain(unsigned phase, double dt) override;
+  void compute_strain(double dt) override;
 
   //! Return strain of the particle
-  //! \param[in] phase Index corresponding to the phase
-  Eigen::Matrix<double, 6, 1> strain(unsigned phase) const override {
-    return strain_.col(phase);
-  }
+  Eigen::Matrix<double, 6, 1> strain() const override { return strain_; }
 
   //! Return strain rate of the particle
-  //! \param[in] phase Index corresponding to the phase
-  Eigen::Matrix<double, 6, 1> strain_rate(unsigned phase) const override {
-    return strain_rate_.col(phase);
+  Eigen::Matrix<double, 6, 1> strain_rate() const override {
+    return strain_rate_;
   };
 
   //! Return volumetric strain of centroid
-  //! \param[in] phase Index corresponding to the phase
   //! \retval volumetric strain at centroid
-  double volumetric_strain_centroid(unsigned phase) const override {
-    return volumetric_strain_centroid_(phase);
+  double volumetric_strain_centroid() const override {
+    return volumetric_strain_centroid_;
   }
 
   //! Initial stress
-  //! \param[in] phase Index corresponding to the phase
-  //! \param[in] stress Initial sress corresponding to the phase
-  void initial_stress(unsigned phase,
-                      const Eigen::Matrix<double, 6, 1>& stress) override {
-    this->stress_.col(phase) = stress;
+  //! \param[in] stress Initial sress
+  void initial_stress(const Eigen::Matrix<double, 6, 1>& stress) override {
+    this->stress_ = stress;
   }
 
   //! Compute stress
-  bool compute_stress(unsigned phase) override;
+  bool compute_stress() override;
 
   //! Return stress of the particle
-  //! \param[in] phase Index corresponding to the phase
-  Eigen::Matrix<double, 6, 1> stress(unsigned phase) const override {
-    return stress_.col(phase);
-  }
+  Eigen::Matrix<double, 6, 1> stress() const override { return stress_; }
 
   //! Map body force
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] pgravity Gravity of a particle
-  void map_body_force(unsigned phase, const VectorDim& pgravity) override;
+  void map_body_force(const VectorDim& pgravity) override;
 
   //! Map internal force
-  //! \param[in] phase Index corresponding to the phase
-  bool map_internal_force(unsigned phase) override;
+  bool map_internal_force() override;
 
   //! Assign velocity to the particle
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] velocity A vector of particle velocity
   //! \retval status Assignment status
-  bool assign_velocity(unsigned phase, const VectorDim& velocity) override;
+  bool assign_velocity(const VectorDim& velocity) override;
 
   //! Return velocity of the particle
-  //! \param[in] phase Index corresponding to the phase
-  VectorDim velocity(unsigned phase) const override {
-    return velocity_.col(phase);
-  }
+  VectorDim velocity() const override { return velocity_; }
 
   //! Return displacement of the particle
-  //! \param[in] phase Index corresponding to the phase
-  VectorDim displacement(unsigned phase) const override {
-    return displacement_.col(phase);
-  }
+  VectorDim displacement() const override { return displacement_; }
 
   //! Assign traction to the particle
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] direction Index corresponding to the direction of traction
   //! \param[in] traction Particle traction in specified direction
   //! \retval status Assignment status
-  bool assign_traction(unsigned phase, unsigned direction,
-                       double traction) override;
+  bool assign_traction(unsigned direction, double traction) override;
 
   //! Return traction of the particle
-  //! \param[in] phase Index corresponding to the phase
-  VectorDim traction(unsigned phase) const override {
-    return traction_.col(phase);
-  }
+  VectorDim traction() const override { return traction_; }
 
   //! Map traction force
-  //! \param[in] phase Index corresponding to the phase
-  void map_traction_force(unsigned phase) override;
+  void map_traction_force() override;
 
   //! Compute updated position of the particle
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] dt Analysis time step
-  bool compute_updated_position(unsigned phase, double dt) override;
+  bool compute_updated_position(double dt) override;
 
   //! Compute updated position of the particle based on nodal velocity
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] dt Analysis time step
-  bool compute_updated_position_velocity(unsigned phase, double dt) override;
+  bool compute_updated_position_velocity(double dt) override;
 
   //! Return a state variable
   //! \param[in] var State variable
@@ -257,32 +215,26 @@ class Particle : public ParticleBase<Tdim> {
   }
 
   //! Update pressure of the particles
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] dvolumetric_strain dvolumetric strain in a cell
-  bool update_pressure(unsigned phase, double dvolumetric_strain) override;
+  bool update_pressure(double dvolumetric_strain) override;
 
   //! Map particle pressure to nodes
-  //! \param[in] phase Index corresponding to the phase
-  bool map_pressure_to_nodes(unsigned phase) override;
+  bool map_pressure_to_nodes() override;
 
   //! Compute pressure smoothing of the particle based on nodal pressure
-  //! \param[in] phase Index corresponding to the phase
-  bool compute_pressure_smoothing(unsigned phase) override;
+  bool compute_pressure_smoothing() override;
 
   //! Return pressure of the particles
-  //! \param[in] phase Index corresponding to the phase
   //! $$\hat{p}_p = \sum_{i = 1}^{n_n} N_i(x_p) p_i$$
-  double pressure(unsigned phase) const override { return pressure_(phase); }
+  double pressure() const override { return pressure_; }
 
   //! Return vector data of particles
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] property Property string
   //! \retval vecdata Vector data of particle property
-  Eigen::VectorXd vector_data(unsigned phase,
-                              const std::string& property) override;
+  Eigen::VectorXd vector_data(const std::string& property) override;
 
   //! Assign particle velocity constraints
-  //! Directions can take values between 0 and Dim * Nphases
+  //! Directions can take values between 0 and Dim
   //! \param[in] dir Direction of particle velocity constraint
   //! \param[in] velocity Applied particle velocity constraint
   //! \retval status Assignment status
@@ -310,37 +262,39 @@ class Particle : public ParticleBase<Tdim> {
   //! State variables
   using ParticleBase<Tdim>::state_variables_;
   //! Volumetric mass density (mass / volume)
-  Eigen::Matrix<double, 1, Tnphases> mass_density_;
+  double mass_density_;
   //! Mass
-  Eigen::Matrix<double, 1, Tnphases> mass_;
+  double mass_;
   //! Volume
-  Eigen::Matrix<double, 1, Tnphases> volume_;
+  double volume_;
+  //! Phase
+  unsigned phase_{0};
   //! Size of particle
   Eigen::Matrix<double, 1, Tdim> size_;
   //! Size of particle in natural coordinates
   Eigen::Matrix<double, 1, Tdim> natural_size_;
   //! Pressure
-  Eigen::Matrix<double, 1, Tnphases> pressure_;
+  double pressure_;
   //! Stresses
-  Eigen::Matrix<double, 6, Tnphases> stress_;
+  Eigen::Matrix<double, 6, 1> stress_;
   //! Strains
-  Eigen::Matrix<double, 6, Tnphases> strain_;
+  Eigen::Matrix<double, 6, 1> strain_;
   //! Volumetric strain at centroid
-  Eigen::Matrix<double, Tnphases, 1> volumetric_strain_centroid_;
+  double volumetric_strain_centroid_;
   //! Strain rate
-  Eigen::Matrix<double, 6, Tnphases> strain_rate_;
+  Eigen::Matrix<double, 6, 1> strain_rate_;
   //! dstrains
-  Eigen::Matrix<double, 6, Tnphases> dstrain_;
+  Eigen::Matrix<double, 6, 1> dstrain_;
   //! Velocity
-  Eigen::Matrix<double, Tdim, Tnphases> velocity_;
+  Eigen::Matrix<double, Tdim, 1> velocity_;
   //! Displacement
-  Eigen::Matrix<double, Tdim, Tnphases> displacement_;
+  Eigen::Matrix<double, Tdim, 1> displacement_;
   //! Particle velocity constraints
   std::map<unsigned, double> particle_velocity_constraints_;
   //! Set traction
   bool set_traction_{false};
   //! Traction
-  Eigen::Matrix<double, Tdim, Tnphases> traction_;
+  Eigen::Matrix<double, Tdim, 1> traction_;
   //! Shape functions
   Eigen::VectorXd shapefn_;
   //! B-Matrix
@@ -348,7 +302,7 @@ class Particle : public ParticleBase<Tdim> {
   //! Logger
   std::unique_ptr<spdlog::logger> console_;
   //! Map of vector properties
-  std::map<std::string, std::function<Eigen::VectorXd(unsigned)>> properties_;
+  std::map<std::string, std::function<Eigen::VectorXd()>> properties_;
 
 };  // Particle class
 }  // namespace mpm

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -1,28 +1,25 @@
 //! Construct a particle with id and coordinates
-template <unsigned Tdim, unsigned Tnphases>
-mpm::Particle<Tdim, Tnphases>::Particle(Index id, const VectorDim& coord)
+template <unsigned Tdim>
+mpm::Particle<Tdim>::Particle(Index id, const VectorDim& coord)
     : mpm::ParticleBase<Tdim>(id, coord) {
   this->initialise();
+  // Clear cell ptr
   cell_ = nullptr;
-
-  //! Set material pointer to null
-  material_.clear();
-  for (unsigned i = 0; i < Tnphases; ++i) material_[i] = nullptr;
-
-  //! Logger
+  // Set material pointer to null
+  material_ = nullptr;
+  // Logger
   std::string logger =
       "particle" + std::to_string(Tdim) + "d::" + std::to_string(id);
   console_ = std::make_unique<spdlog::logger>(logger, mpm::stdout_sink);
 }
 
 //! Construct a particle with id, coordinates and status
-template <unsigned Tdim, unsigned Tnphases>
-mpm::Particle<Tdim, Tnphases>::Particle(Index id, const VectorDim& coord,
-                                        bool status)
+template <unsigned Tdim>
+mpm::Particle<Tdim>::Particle(Index id, const VectorDim& coord, bool status)
     : mpm::ParticleBase<Tdim>(id, coord, status) {
   this->initialise();
   cell_ = nullptr;
-  material_.clear();
+  material_ = nullptr;
   //! Logger
   std::string logger =
       "particle" + std::to_string(Tdim) + "d::" + std::to_string(id);
@@ -30,21 +27,17 @@ mpm::Particle<Tdim, Tnphases>::Particle(Index id, const VectorDim& coord,
 }
 
 //! Initialise particle data from HDF5
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::initialise_particle(
-    const HDF5Particle& particle) {
-
-  // TODO: Set phase
-  const unsigned phase = 0;
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::initialise_particle(const HDF5Particle& particle) {
 
   // Assign id
   this->id_ = particle.id;
   // Mass
-  this->mass_(phase) = particle.mass;
+  this->mass_ = particle.mass;
   // Volume
-  this->assign_volume(phase, particle.volume);
+  this->assign_volume(particle.volume);
   // Mass Density
-  this->mass_density_(phase) = particle.mass / particle.volume;
+  this->mass_density_ = particle.mass / particle.volume;
   // Set local size of particle
   Eigen::Vector3d psize;
   psize << particle.nsize_x, particle.nsize_y, particle.nsize_z;
@@ -55,41 +48,39 @@ bool mpm::Particle<Tdim, Tnphases>::initialise_particle(
   Eigen::Vector3d coordinates;
   coordinates << particle.coord_x, particle.coord_y, particle.coord_z;
   // Initialise coordinates
-  for (unsigned i = 0; i < Tdim; ++i)
-    this->coordinates_(i, phase) = coordinates(i);
+  for (unsigned i = 0; i < Tdim; ++i) this->coordinates_(i) = coordinates(i);
 
   // Displacement
   Eigen::Vector3d displacement;
   displacement << particle.displacement_x, particle.displacement_y,
       particle.displacement_z;
   // Initialise displacement
-  for (unsigned i = 0; i < Tdim; ++i)
-    this->displacement_(i, phase) = displacement(i);
+  for (unsigned i = 0; i < Tdim; ++i) this->displacement_(i) = displacement(i);
 
   // Velocity
   Eigen::Vector3d velocity;
   velocity << particle.velocity_x, particle.velocity_y, particle.velocity_z;
   // Initialise velocity
-  for (unsigned i = 0; i < Tdim; ++i) this->velocity_(i, phase) = velocity(i);
+  for (unsigned i = 0; i < Tdim; ++i) this->velocity_(i) = velocity(i);
 
   // Stress
-  this->stress_.col(phase)[0] = particle.stress_xx;
-  this->stress_.col(phase)[1] = particle.stress_yy;
-  this->stress_.col(phase)[2] = particle.stress_zz;
-  this->stress_.col(phase)[3] = particle.tau_xy;
-  this->stress_.col(phase)[4] = particle.tau_yz;
-  this->stress_.col(phase)[5] = particle.tau_xz;
+  this->stress_[0] = particle.stress_xx;
+  this->stress_[1] = particle.stress_yy;
+  this->stress_[2] = particle.stress_zz;
+  this->stress_[3] = particle.tau_xy;
+  this->stress_[4] = particle.tau_yz;
+  this->stress_[5] = particle.tau_xz;
 
   // Strain
-  this->strain_.col(phase)[0] = particle.strain_xx;
-  this->strain_.col(phase)[1] = particle.strain_yy;
-  this->strain_.col(phase)[2] = particle.strain_zz;
-  this->strain_.col(phase)[3] = particle.gamma_xy;
-  this->strain_.col(phase)[4] = particle.gamma_yz;
-  this->strain_.col(phase)[5] = particle.gamma_xz;
+  this->strain_[0] = particle.strain_xx;
+  this->strain_[1] = particle.strain_yy;
+  this->strain_[2] = particle.strain_zz;
+  this->strain_[3] = particle.gamma_xy;
+  this->strain_[4] = particle.gamma_yz;
+  this->strain_[5] = particle.gamma_xz;
 
   // Volumetric strain
-  this->volumetric_strain_centroid_(phase) = particle.epsilon_v;
+  this->volumetric_strain_centroid_ = particle.epsilon_v;
 
   // Status
   this->status_ = particle.status;
@@ -101,24 +92,23 @@ bool mpm::Particle<Tdim, Tnphases>::initialise_particle(
 }
 
 //! Return particle data in HDF5 format
-template <unsigned Tdim, unsigned Tnphases>
+template <unsigned Tdim>
 // cppcheck-suppress *
-mpm::HDF5Particle mpm::Particle<Tdim, Tnphases>::hdf5(unsigned phase) const {
+mpm::HDF5Particle mpm::Particle<Tdim>::hdf5() const {
 
   mpm::HDF5Particle particle_data;
 
   Eigen::Vector3d coordinates;
   coordinates.setZero();
-  for (unsigned j = 0; j < Tdim; ++j) coordinates[j] = this->coordinates()[j];
+  for (unsigned j = 0; j < Tdim; ++j) coordinates[j] = this->coordinates_[j];
 
   Eigen::Vector3d displacement;
   displacement.setZero();
-  for (unsigned j = 0; j < Tdim; ++j)
-    displacement[j] = this->displacement(phase)[j];
+  for (unsigned j = 0; j < Tdim; ++j) displacement[j] = this->displacement_[j];
 
   Eigen::Vector3d velocity;
   velocity.setZero();
-  for (unsigned j = 0; j < Tdim; ++j) velocity[j] = this->velocity(phase)[j];
+  for (unsigned j = 0; j < Tdim; ++j) velocity[j] = this->velocity_[j];
 
   // Particle local size
   Eigen::Vector3d nsize;
@@ -126,14 +116,14 @@ mpm::HDF5Particle mpm::Particle<Tdim, Tnphases>::hdf5(unsigned phase) const {
   Eigen::VectorXd size = this->natural_size();
   for (unsigned j = 0; j < Tdim; ++j) nsize[j] = size[j];
 
-  Eigen::Matrix<double, 6, 1> stress = this->stress(phase);
+  Eigen::Matrix<double, 6, 1> stress = this->stress_;
 
-  Eigen::Matrix<double, 6, 1> strain = this->strain(phase);
+  Eigen::Matrix<double, 6, 1> strain = this->strain_;
 
   particle_data.id = this->id();
-  particle_data.mass = this->mass(phase);
-  particle_data.volume = this->volume(phase);
-  particle_data.pressure = this->pressure(phase);
+  particle_data.mass = this->mass();
+  particle_data.volume = this->volume();
+  particle_data.pressure = this->pressure();
 
   particle_data.coord_x = coordinates[0];
   particle_data.coord_y = coordinates[1];
@@ -165,7 +155,7 @@ mpm::HDF5Particle mpm::Particle<Tdim, Tnphases>::hdf5(unsigned phase) const {
   particle_data.gamma_yz = strain[4];
   particle_data.gamma_xz = strain[5];
 
-  particle_data.epsilon_v = this->volumetric_strain_centroid(phase);
+  particle_data.epsilon_v = this->volumetric_strain_centroid_;
 
   particle_data.status = this->status();
 
@@ -175,13 +165,13 @@ mpm::HDF5Particle mpm::Particle<Tdim, Tnphases>::hdf5(unsigned phase) const {
 }
 
 // Initialise particle properties
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::initialise() {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::initialise() {
   displacement_.setZero();
   dstrain_.setZero();
-  mass_.setZero();
+  mass_ = 0.;
   natural_size_.setZero();
-  pressure_.setZero();
+  pressure_ = 0.;
   set_traction_ = false;
   size_.setZero();
   strain_rate_.setZero();
@@ -189,23 +179,19 @@ void mpm::Particle<Tdim, Tnphases>::initialise() {
   stress_.setZero();
   traction_.setZero();
   velocity_.setZero();
-  volume_.fill(std::numeric_limits<double>::max());
-  volumetric_strain_centroid_.setZero();
+  volume_ = std::numeric_limits<double>::max();
+  volumetric_strain_centroid_ = 0.;
 
   // Initialize vector data properties
-  this->properties_["stresses"] = [&](unsigned phase) { return stress(phase); };
-  this->properties_["strains"] = [&](unsigned phase) { return strain(phase); };
-  this->properties_["velocities"] = [&](unsigned phase) {
-    return velocity(phase);
-  };
-  this->properties_["displacements"] = [&](unsigned phase) {
-    return displacement(phase);
-  };
+  this->properties_["stresses"] = [&]() { return stress(); };
+  this->properties_["strains"] = [&]() { return strain(); };
+  this->properties_["velocities"] = [&]() { return velocity(); };
+  this->properties_["displacements"] = [&]() { return displacement(); };
 }
 
 // Assign a cell to particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_cell(
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_cell(
     const std::shared_ptr<Cell<Tdim>>& cellptr) {
   bool status = true;
   try {
@@ -232,8 +218,8 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell(
 }
 
 // Assign a cell to particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_cell_xi(
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_cell_xi(
     const std::shared_ptr<Cell<Tdim>>& cellptr,
     const Eigen::Matrix<double, Tdim, 1>& xi) {
   bool status = true;
@@ -269,8 +255,8 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell_xi(
 }
 
 // Assign a cell id to particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_cell_id(mpm::Index id) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_cell_id(mpm::Index id) {
   bool status = false;
   try {
     // if a cell ptr is null
@@ -288,23 +274,23 @@ bool mpm::Particle<Tdim, Tnphases>::assign_cell_id(mpm::Index id) {
 }
 
 // Remove cell for the particle
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::remove_cell() {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::remove_cell() {
   // if a cell is not nullptr
   if (cell_ != nullptr) cell_->remove_particle_id(this->id_);
   cell_id_ = std::numeric_limits<Index>::max();
 }
 
 // Assign a material to particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_material(
-    unsigned phase, const std::shared_ptr<Material<Tdim>>& material) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_material(
+    const std::shared_ptr<Material<Tdim>>& material) {
   bool status = false;
   try {
     // Check if material is valid and properties are set
     if (material != nullptr) {
-      material_.at(phase) = material;
-      state_variables_ = material_.at(phase)->initialise_state_variables();
+      material_ = material;
+      state_variables_ = material_->initialise_state_variables();
       status = true;
     } else {
       throw std::runtime_error("Material is undefined!");
@@ -316,8 +302,8 @@ bool mpm::Particle<Tdim, Tnphases>::assign_material(
 }
 
 // Compute reference location cell to particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_reference_location() {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
@@ -343,8 +329,8 @@ bool mpm::Particle<Tdim, Tnphases>::compute_reference_location() {
 }
 
 // Compute shape functions and gradients
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_shapefn() {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
@@ -375,18 +361,17 @@ bool mpm::Particle<Tdim, Tnphases>::compute_shapefn() {
 }
 
 // Assign volume to the particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_volume(unsigned phase,
-                                                  double volume) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_volume(double volume) {
   bool status = true;
   try {
     if (volume <= 0.)
       throw std::runtime_error("Particle volume cannot be negative");
 
-    this->volume_(phase) = volume;
+    this->volume_ = volume;
     // Compute size of particle in each direction
     const double length =
-        std::pow(this->volume_(phase), static_cast<double>(1. / Tdim));
+        std::pow(this->volume_, static_cast<double>(1. / Tdim));
     // Set particle size as length on each side
     this->size_.fill(length);
 
@@ -407,14 +392,14 @@ bool mpm::Particle<Tdim, Tnphases>::assign_volume(unsigned phase,
 }
 
 // Compute volume of the particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_volume(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_volume() {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Volume of the cell / # of particles
-      this->assign_volume(phase, cell_->volume() / cell_->nparticles());
+      this->assign_volume(cell_->volume() / cell_->nparticles());
     } else {
       throw std::runtime_error(
           "Cell is not initialised! "
@@ -428,22 +413,19 @@ bool mpm::Particle<Tdim, Tnphases>::compute_volume(unsigned phase) {
 }
 
 // Update volume based on the central strain rate
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::update_volume_strainrate(unsigned phase,
-                                                             double dt) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::update_volume_strainrate(double dt) {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr and a valid volume
-    if (cell_ != nullptr &&
-        volume_(phase) != std::numeric_limits<double>::max()) {
+    if (cell_ != nullptr && volume_ != std::numeric_limits<double>::max()) {
       // Compute at centroid
       // Strain rate for reduced integration
       Eigen::VectorXd strain_rate_centroid =
-          cell_->compute_strain_rate_centroid(phase);
-      this->volume_(phase) *= (1. + dt * strain_rate_centroid.head(Tdim).sum());
-      this->mass_density_(phase) =
-          this->mass_density_(phase) /
-          (1. + dt * strain_rate_centroid.head(Tdim).sum());
+          cell_->compute_strain_rate_centroid(phase_);
+      this->volume_ *= (1. + dt * strain_rate_centroid.head(Tdim).sum());
+      this->mass_density_ = this->mass_density_ /
+                            (1. + dt * strain_rate_centroid.head(Tdim).sum());
     } else {
       throw std::runtime_error(
           "Cell or volume is not initialised! cannot update particle volume");
@@ -456,18 +438,16 @@ bool mpm::Particle<Tdim, Tnphases>::update_volume_strainrate(unsigned phase,
 }
 
 // Compute mass of particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_mass(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_mass() {
   bool status = true;
   try {
     // Check if particle volume is set and material ptr is valid
-    if (volume_(phase) != std::numeric_limits<double>::max() &&
-        material_.at(phase) != nullptr) {
+    if (volume_ != std::numeric_limits<double>::max() && material_ != nullptr) {
       // Mass = volume of particle * mass_density
-      this->mass_density_(phase) =
-          material_.at(phase)->template property<double>(
-              std::string("density"));
-      this->mass_(phase) = volume_(phase) * mass_density_(phase);
+      this->mass_density_ =
+          material_->template property<double>(std::string("density"));
+      this->mass_ = volume_ * mass_density_;
     } else {
       throw std::runtime_error(
           "Cell or material is invalid! cannot compute mass for the particle");
@@ -480,15 +460,15 @@ bool mpm::Particle<Tdim, Tnphases>::compute_mass(unsigned phase) {
 }
 
 //! Map particle mass and momentum to nodes
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::map_mass_momentum_to_nodes(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::map_mass_momentum_to_nodes() {
   bool status = true;
   try {
     // Check if particle mass is set
-    if (mass_(phase) != std::numeric_limits<double>::max()) {
+    if (mass_ != std::numeric_limits<double>::max()) {
       // Map particle mass and momentum to nodes
-      this->cell_->map_mass_momentum_to_nodes(
-          this->shapefn_, phase, mass_(phase), velocity_.col(phase));
+      this->cell_->map_mass_momentum_to_nodes(this->shapefn_, phase_, mass_,
+                                              velocity_);
     } else {
       throw std::runtime_error("Particle mass has not been computed");
     }
@@ -500,10 +480,10 @@ bool mpm::Particle<Tdim, Tnphases>::map_mass_momentum_to_nodes(unsigned phase) {
 }
 
 // Compute strain of the particle
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::compute_strain(unsigned phase, double dt) {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::compute_strain(double dt) {
   // Strain rate
-  const auto strain_rate = cell_->compute_strain_rate(bmatrix_, phase);
+  const auto strain_rate = cell_->compute_strain_rate(bmatrix_, phase_);
   // particle_strain_rate
   Eigen::Matrix<double, 6, 1> particle_strain_rate;
   particle_strain_rate.setZero();
@@ -531,16 +511,16 @@ void mpm::Particle<Tdim, Tnphases>::compute_strain(unsigned phase, double dt) {
       particle_strain_rate(i) = 0.;
 
   // Assign strain rate
-  strain_rate_.col(phase) = particle_strain_rate;
+  strain_rate_ = particle_strain_rate;
   // Update dstrain
-  dstrain_.col(phase) = particle_strain_rate * dt;
+  dstrain_ = particle_strain_rate * dt;
   // Update strain
-  strain_.col(phase) += particle_strain_rate * dt;
+  strain_ += particle_strain_rate * dt;
 
   // Compute at centroid
   // Strain rate for reduced integration
   Eigen::VectorXd strain_rate_centroid =
-      cell_->compute_strain_rate_centroid(phase);
+      cell_->compute_strain_rate_centroid(phase_);
 
   // Check to see if value is below threshold
   for (unsigned i = 0; i < strain_rate_centroid.size(); ++i)
@@ -549,23 +529,23 @@ void mpm::Particle<Tdim, Tnphases>::compute_strain(unsigned phase, double dt) {
 
   // Assign volumetric strain at centroid
   const double dvolumetric_strain = dt * strain_rate_centroid.head(Tdim).sum();
-  volumetric_strain_centroid_(phase) += dvolumetric_strain;
+  volumetric_strain_centroid_ += dvolumetric_strain;
 
   // Update thermodynamic pressure
-  this->update_pressure(phase, dvolumetric_strain);
+  this->update_pressure(dvolumetric_strain);
 }
 
 // Compute stress
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_stress() {
   bool status = true;
   try {
     // Check if material ptr is valid
-    if (material_.at(phase) != nullptr) {
-      Eigen::Matrix<double, 6, 1> dstrain = this->dstrain_.col(phase);
+    if (material_ != nullptr) {
+      Eigen::Matrix<double, 6, 1> dstrain = this->dstrain_;
       // Calculate stress
-      this->stress_.col(phase) = material_.at(phase)->compute_stress(
-          this->stress_.col(phase), dstrain, this, &state_variables_);
+      this->stress_ = material_->compute_stress(this->stress_, dstrain, this,
+                                                &state_variables_);
     } else {
       throw std::runtime_error("Material is invalid");
     }
@@ -577,29 +557,25 @@ bool mpm::Particle<Tdim, Tnphases>::compute_stress(unsigned phase) {
 }
 
 //! Map body force
-//! \param[in] phase Index corresponding to the phase
 //! \param[in] pgravity Gravity of a particle
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::map_body_force(unsigned phase,
-                                                   const VectorDim& pgravity) {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::map_body_force(const VectorDim& pgravity) {
   // Compute nodal body forces
-  cell_->compute_nodal_body_force(this->shapefn_, phase, this->mass_(phase),
+  cell_->compute_nodal_body_force(this->shapefn_, phase_, this->mass_,
                                   pgravity);
 }
 
 //! Map internal force
-//! \param[in] phase Index corresponding to the phase
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::map_internal_force(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::map_internal_force() {
   bool status = true;
   try {
     // Check if  material ptr is valid
-    if (material_.at(phase) != nullptr) {
+    if (material_ != nullptr) {
       // Compute nodal internal forces
       // -pstress * volume
-      cell_->compute_nodal_internal_force(this->bmatrix_, phase,
-                                          this->volume_(phase),
-                                          -1. * this->stress_.col(phase));
+      cell_->compute_nodal_internal_force(this->bmatrix_, phase_, this->volume_,
+                                          -1. * this->stress_);
     } else {
       throw std::runtime_error("Material is invalid");
     }
@@ -611,16 +587,13 @@ bool mpm::Particle<Tdim, Tnphases>::map_internal_force(unsigned phase) {
 }
 
 // Assign velocity to the particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_velocity(
-    unsigned phase, const Eigen::Matrix<double, Tdim, 1>& velocity) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_velocity(
+    const Eigen::Matrix<double, Tdim, 1>& velocity) {
   bool status = false;
   try {
-    if (phase >= Tnphases)
-      throw std::runtime_error("Particle velocity: Invalid phase");
-
     // Assign velocity
-    velocity_.col(phase) = velocity;
+    velocity_ = velocity;
     status = true;
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
@@ -630,20 +603,17 @@ bool mpm::Particle<Tdim, Tnphases>::assign_velocity(
 }
 
 // Assign traction to the particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_traction(unsigned phase,
-                                                    unsigned direction,
-                                                    double traction) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_traction(unsigned direction, double traction) {
   bool status = false;
   try {
-    if (phase >= Tnphases || direction >= Tdim ||
-        this->volume_(phase) == std::numeric_limits<double>::max()) {
+    if (direction >= Tdim ||
+        this->volume_ == std::numeric_limits<double>::max()) {
       throw std::runtime_error(
-          "Particle traction property: volume / direction / phase is invalid");
+          "Particle traction property: volume / direction is invalid");
     }
     // Assign traction
-    traction_(direction, phase) =
-        traction * this->volume_(phase) / this->size_(direction);
+    traction_(direction) = traction * this->volume_ / this->size_(direction);
     status = true;
     this->set_traction_ = true;
   } catch (std::exception& exception) {
@@ -654,36 +624,34 @@ bool mpm::Particle<Tdim, Tnphases>::assign_traction(unsigned phase,
 }
 
 //! Map traction force
-//! \param[in] phase Index corresponding to the phase
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::map_traction_force(unsigned phase) {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::map_traction_force() {
   if (this->set_traction_)
     // Map particle traction forces to nodes
-    cell_->compute_nodal_traction_force(this->shapefn_, phase,
-                                        this->traction_.col(phase));
+    cell_->compute_nodal_traction_force(this->shapefn_, phase_,
+                                        this->traction_);
 }
 
 // Compute updated position of the particle
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
-                                                             double dt) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_updated_position(double dt) {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Get interpolated nodal acceleration
       const Eigen::Matrix<double, Tdim, 1> nodal_acceleration =
-          cell_->interpolate_nodal_acceleration(this->shapefn_, phase);
+          cell_->interpolate_nodal_acceleration(this->shapefn_, phase_);
 
       // Update particle velocity from interpolated nodal acceleration
-      this->velocity_.col(phase) += nodal_acceleration * dt;
+      this->velocity_ += nodal_acceleration * dt;
 
       // Apply particle velocity constraints
       this->apply_particle_velocity_constraints();
 
       // Get interpolated nodal velocity
       const Eigen::Matrix<double, Tdim, 1> nodal_velocity =
-          cell_->interpolate_nodal_velocity(this->shapefn_, phase);
+          cell_->interpolate_nodal_velocity(this->shapefn_, phase_);
 
       // New position  current position + velocity * dt
       this->coordinates_ += nodal_velocity * dt;
@@ -702,19 +670,18 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position(unsigned phase,
 }
 
 // Compute updated position of the particle based on nodal velocity
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
-    unsigned phase, double dt) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_updated_position_velocity(double dt) {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr) {
       // Get interpolated nodal velocity
       const Eigen::Matrix<double, Tdim, 1> nodal_velocity =
-          cell_->interpolate_nodal_velocity(this->shapefn_, phase);
+          cell_->interpolate_nodal_velocity(this->shapefn_, phase_);
 
       // Update particle velocity to interpolated nodal velocity
-      this->velocity_.col(phase) = nodal_velocity;
+      this->velocity_ = nodal_velocity;
 
       // Apply particle velocity constraints
       this->apply_particle_velocity_constraints();
@@ -736,16 +703,14 @@ bool mpm::Particle<Tdim, Tnphases>::compute_updated_position_velocity(
 }
 
 // Update pressure
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::update_pressure(unsigned phase,
-                                                    double dvolumetric_strain) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::update_pressure(double dvolumetric_strain) {
   bool status = true;
   try {
     // Check if material ptr is valid
-    if (material_.at(phase) != nullptr) {
+    if (material_ != nullptr) {
       // Update pressure
-      this->pressure_(phase) +=
-          material_.at(phase)->thermodynamic_pressure(dvolumetric_strain);
+      this->pressure_ += material_->thermodynamic_pressure(dvolumetric_strain);
     } else {
       throw std::runtime_error("Material is invalid");
     }
@@ -757,15 +722,15 @@ bool mpm::Particle<Tdim, Tnphases>::update_pressure(unsigned phase,
 }
 
 //! Map particle pressure to nodes
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::map_pressure_to_nodes(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::map_pressure_to_nodes() {
   bool status = true;
   try {
     // Check if particle mass is set
-    if (mass_(phase) != std::numeric_limits<double>::max()) {
+    if (mass_ != std::numeric_limits<double>::max()) {
       // Map particle mass and momentum to nodes
-      this->cell_->map_pressure_to_nodes(this->shapefn_, phase, mass_(phase),
-                                         pressure_(phase));
+      this->cell_->map_pressure_to_nodes(this->shapefn_, phase_, mass_,
+                                         pressure_);
     } else {
       throw std::runtime_error("Particle mass has not been computed");
     }
@@ -777,15 +742,15 @@ bool mpm::Particle<Tdim, Tnphases>::map_pressure_to_nodes(unsigned phase) {
 }
 
 // Compute pressure smoothing of the particle based on nodal pressure
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::compute_pressure_smoothing(unsigned phase) {
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::compute_pressure_smoothing() {
   bool status = true;
   try {
     // Check if particle has a valid cell ptr
     if (cell_ != nullptr)
       // Update particle pressure to interpolated nodal pressure
-      this->pressure_(phase) =
-          cell_->interpolate_nodal_pressure(this->shapefn_, phase);
+      this->pressure_ =
+          cell_->interpolate_nodal_pressure(this->shapefn_, phase_);
     else
       throw std::runtime_error(
           "Cell is not initialised! "
@@ -799,14 +764,14 @@ bool mpm::Particle<Tdim, Tnphases>::compute_pressure_smoothing(unsigned phase) {
 }
 
 //! Assign particle velocity constraint
-//! Constrain directions can take values between 0 and Dim * Nphases
-template <unsigned Tdim, unsigned Tnphases>
-bool mpm::Particle<Tdim, Tnphases>::assign_particle_velocity_constraint(
-    unsigned dir, double velocity) {
+//! Constrain directions can take values between 0 and Dim
+template <unsigned Tdim>
+bool mpm::Particle<Tdim>::assign_particle_velocity_constraint(unsigned dir,
+                                                              double velocity) {
   bool status = true;
   try {
-    //! Constrain directions can take values between 0 and Dim * Nphases
-    if (dir < (Tdim * Tnphases))
+    //! Constrain directions can take values between 0 and Dim
+    if (dir < Tdim)
       this->particle_velocity_constraints_.insert(
           std::make_pair<unsigned, double>(static_cast<unsigned>(dir),
                                            static_cast<double>(velocity)));
@@ -822,23 +787,20 @@ bool mpm::Particle<Tdim, Tnphases>::assign_particle_velocity_constraint(
 }
 
 //! Apply particle velocity constraints
-template <unsigned Tdim, unsigned Tnphases>
-void mpm::Particle<Tdim, Tnphases>::apply_particle_velocity_constraints() {
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::apply_particle_velocity_constraints() {
   // Set particle velocity constraint
   for (const auto& constraint : this->particle_velocity_constraints_) {
-    // Direction value in the constraint (0, Dim * Nphases)
+    // Direction value in the constraint (0, Dim)
     const unsigned dir = constraint.first;
     // Direction: dir % Tdim (modulus)
     const auto direction = static_cast<unsigned>(dir % Tdim);
-    // Phase: Integer value of division (dir / Tdim)
-    const auto phase = static_cast<unsigned>(dir / Tdim);
-    this->velocity_(direction, phase) = constraint.second;
+    this->velocity_(direction) = constraint.second;
   }
 }
 
 //! Return particle vector data
-template <unsigned Tdim, unsigned Tnphases>
-Eigen::VectorXd mpm::Particle<Tdim, Tnphases>::vector_data(
-    unsigned phase, const std::string& property) {
-  return this->properties_.at(property)(phase);
+template <unsigned Tdim>
+Eigen::VectorXd mpm::Particle<Tdim>::vector_data(const std::string& property) {
+  return this->properties_.at(property)();
 }

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -55,9 +55,8 @@ class ParticleBase {
   virtual bool initialise_particle(const HDF5Particle& particle) = 0;
 
   //! Retrun particle data as HDF5
-  //! \param[in] phase Properties of a given phase
   //! \retval particle HDF5 data of the particle
-  virtual HDF5Particle hdf5(unsigned phase) const = 0;
+  virtual HDF5Particle hdf5() const = 0;
 
   //! Return id of the particleBase
   Index id() const { return id_; }
@@ -99,32 +98,32 @@ class ParticleBase {
   virtual bool compute_shapefn() = 0;
 
   //! Assign volume
-  virtual bool assign_volume(unsigned phase, double volume) = 0;
+  virtual bool assign_volume(double volume) = 0;
 
   //! Return volume
-  virtual double volume(unsigned phase) const = 0;
+  virtual double volume() const = 0;
 
   //! Return size of particle in natural coordinates
   virtual VectorDim natural_size() const = 0;
 
   //! Compute volume of particle
-  virtual bool compute_volume(unsigned phase) = 0;
+  virtual bool compute_volume() = 0;
 
   //! Update volume based on centre volumetric strain rate
-  virtual bool update_volume_strainrate(unsigned phase, double dt) = 0;
+  virtual bool update_volume_strainrate(double dt) = 0;
 
   //! Return mass density
-  virtual double mass_density(unsigned phase) const = 0;
+  virtual double mass_density() const = 0;
 
   //! Compute mass of particle
-  virtual bool compute_mass(unsigned phase) = 0;
+  virtual bool compute_mass() = 0;
 
   //! Map particle mass and momentum to nodes
-  virtual bool map_mass_momentum_to_nodes(unsigned phase) = 0;
+  virtual bool map_mass_momentum_to_nodes() = 0;
 
   // Assign material
   virtual bool assign_material(
-      unsigned phase, const std::shared_ptr<Material<Tdim>>& material) = 0;
+      const std::shared_ptr<Material<Tdim>>& material) = 0;
 
   //! Assign status
   void assign_status(bool status) { status_ = status; }
@@ -136,88 +135,84 @@ class ParticleBase {
   virtual void initialise() = 0;
 
   //! Assign mass
-  virtual void assign_mass(unsigned phase, double mass) = 0;
+  virtual void assign_mass(double mass) = 0;
 
   //! Return mass
-  virtual double mass(unsigned phase) const = 0;
+  virtual double mass() const = 0;
 
   //! Return pressure
-  virtual double pressure(unsigned phase) const = 0;
+  virtual double pressure() const = 0;
 
   //! Compute strain
-  virtual void compute_strain(unsigned phase, double dt) = 0;
+  virtual void compute_strain(double dt) = 0;
 
   //! Strain
-  virtual Eigen::Matrix<double, 6, 1> strain(unsigned phase) const = 0;
+  virtual Eigen::Matrix<double, 6, 1> strain() const = 0;
 
   //! Strain rate
-  virtual Eigen::Matrix<double, 6, 1> strain_rate(unsigned phase) const = 0;
+  virtual Eigen::Matrix<double, 6, 1> strain_rate() const = 0;
 
   //! Volumetric strain of centroid
-  virtual double volumetric_strain_centroid(unsigned phase) const = 0;
+  virtual double volumetric_strain_centroid() const = 0;
 
   //! Initial stress
-  virtual void initial_stress(unsigned phase,
-                              const Eigen::Matrix<double, 6, 1>&) = 0;
+  virtual void initial_stress(const Eigen::Matrix<double, 6, 1>&) = 0;
 
   //! Compute stress
-  virtual bool compute_stress(unsigned phase) = 0;
+  virtual bool compute_stress() = 0;
 
   //! Return stress
-  virtual Eigen::Matrix<double, 6, 1> stress(unsigned phase) const = 0;
+  virtual Eigen::Matrix<double, 6, 1> stress() const = 0;
 
   //! Map body force
-  virtual void map_body_force(unsigned phase, const VectorDim& pgravity) = 0;
+  virtual void map_body_force(const VectorDim& pgravity) = 0;
 
   //! Map internal force
-  virtual bool map_internal_force(unsigned phase) = 0;
+  virtual bool map_internal_force() = 0;
 
   //! Update pressure of the particles
-  virtual bool update_pressure(unsigned phase, double dvolumetric_strain) = 0;
+  virtual bool update_pressure(double dvolumetric_strain) = 0;
 
   //! Map particle pressure to nodes
-  virtual bool map_pressure_to_nodes(unsigned phase) = 0;
+  virtual bool map_pressure_to_nodes() = 0;
 
   //! Compute pressure smoothing of the particle based on nodal pressure
-  virtual bool compute_pressure_smoothing(unsigned phase) = 0;
+  virtual bool compute_pressure_smoothing() = 0;
 
   //! Assign velocity
-  virtual bool assign_velocity(unsigned phase, const VectorDim& velocity) = 0;
+  virtual bool assign_velocity(const VectorDim& velocity) = 0;
 
   //! Return velocity
-  virtual VectorDim velocity(unsigned phase) const = 0;
+  virtual VectorDim velocity() const = 0;
 
   //! Return displacement of the particle
-  virtual VectorDim displacement(unsigned phase) const = 0;
+  virtual VectorDim displacement() const = 0;
 
   //! Assign traction
-  virtual bool assign_traction(unsigned phase, unsigned direction,
-                               double traction) = 0;
+  virtual bool assign_traction(unsigned direction, double traction) = 0;
 
   //! Return traction
-  virtual VectorDim traction(unsigned phase) const = 0;
+  virtual VectorDim traction() const = 0;
 
   //! Map traction force
-  virtual void map_traction_force(unsigned phase) = 0;
+  virtual void map_traction_force() = 0;
 
   //! Compute updated position
-  virtual bool compute_updated_position(unsigned phase, double dt) = 0;
+  virtual bool compute_updated_position(double dt) = 0;
 
   //! Compute updated position based on nodal velocity
-  virtual bool compute_updated_position_velocity(unsigned phase, double dt) = 0;
+  virtual bool compute_updated_position_velocity(double dt) = 0;
 
   //! Return a state variable
   virtual double state_variable(const std::string& var) const = 0;
 
   //! Return vector data of particles
-  //! \param[in] phase Index corresponding to the phase
   //! \param[in] property Property string
   //! \retval vecdata Vector data of particle property
-  virtual Eigen::VectorXd vector_data(unsigned phase,
-                                      const std::string& property) = 0;
+  virtual Eigen::VectorXd vector_data(const std::string& property) = 0;
 
   //! Assign particle velocity constraint
-  //! Directions can take values between 0 and Dim * Nphases
+  //! Directions can take values between 0 and Dim
   //! \param[in] dir Direction of particle velocity constraint
   //! \param[in] velocity Applied particle velocity constraint
   virtual bool assign_particle_velocity_constraint(unsigned dir,
@@ -240,7 +235,7 @@ class ParticleBase {
   //! Cell
   std::shared_ptr<Cell<Tdim>> cell_;
   //! Material
-  std::map<unsigned, std::shared_ptr<Material<Tdim>>> material_;
+  std::shared_ptr<Material<Tdim>> material_;
   //! Material state history variables
   mpm::dense_map state_variables_;
 };  // ParticleBase class

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -19,6 +19,9 @@ class Material;
 //! Global index type for the particleBase
 using Index = unsigned long long;
 
+//! Particle phases
+enum ParticlePhase : unsigned int { Solid = 0, Liquid = 1, Gas = 2 };
+
 //! ParticleBase class
 //! \brief Base class that stores the information about particleBases
 //! \details ParticleBase class: id_ and coordinates.

--- a/src/mpm.cc
+++ b/src/mpm.cc
@@ -5,18 +5,18 @@
 #include "mpm.h"
 #include "mpm_explicit.h"
 
-// 2D Explicit MPM USF
+namespace mpm {
+// Stress update method
+std::map<std::string, StressUpdate> stress_update = {
+    {"usf", StressUpdate::USF},
+    {"usl", StressUpdate::USL},
+    {"musl", StressUpdate::MUSL}};
+}  // namespace mpm
+
+// 2D Explicit MPM
 static Register<mpm::MPM, mpm::MPMExplicit<2>, std::unique_ptr<mpm::IO>&&>
-    mpm_explicit_usf_2d("MPMExplicitUSF2D");
+    mpm_explicit_2d("MPMExplicit2D");
 
-// 3D Explicit MPM USF
+// 3D Explicit MPM
 static Register<mpm::MPM, mpm::MPMExplicit<3>, std::unique_ptr<mpm::IO>&&>
-    mpm_explicit_usf_3d("MPMExplicitUSF3D");
-
-// 2D Explicit MPM USL
-static Register<mpm::MPM, mpm::MPMExplicit<2>, std::unique_ptr<mpm::IO>&&>
-    mpm_explicit_usl_2d("MPMExplicitUSL2D");
-
-// 3D Explicit MPM USL
-static Register<mpm::MPM, mpm::MPMExplicit<3>, std::unique_ptr<mpm::IO>&&>
-    mpm_explicit_usl_3d("MPMExplicitUSL3D");
+    mpm_explicit_3d("MPMExplicit3D");

--- a/src/particle.cc
+++ b/src/particle.cc
@@ -2,12 +2,12 @@
 #include "factory.h"
 #include "particle_base.h"
 
-// Particle2D (2 Dim, 1 Phase)
-static Register<mpm::ParticleBase<2>, mpm::Particle<2, 1>, mpm::Index,
+// Particle2D (2 Dim)
+static Register<mpm::ParticleBase<2>, mpm::Particle<2>, mpm::Index,
                 const Eigen::Matrix<double, 2, 1>&>
     particle2d("P2D");
 
-// Particle3D (3 DoF, 1 Phase)
-static Register<mpm::ParticleBase<3>, mpm::Particle<3, 1>, mpm::Index,
+// Particle3D (3 Dim)
+static Register<mpm::ParticleBase<3>, mpm::Particle<3>, mpm::Index,
                 const Eigen::Matrix<double, 3, 1>&>
     particle3d("P3D");

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -6,7 +6,7 @@ namespace mpm_test {
 
 // Write JSON Configuration file
 bool write_json(unsigned dim, bool resume, const std::string& analysis,
-                const std::string& file_name);
+                const std::string& stress_update, const std::string& file_name);
 
 // Write Mesh file in 2D
 bool write_mesh_2d();

--- a/tests/include/write_mesh_particles_unitcell.h
+++ b/tests/include/write_mesh_particles_unitcell.h
@@ -6,6 +6,7 @@ namespace mpm_test {
 
 // Write JSON Configuration file
 bool write_json_unitcell(unsigned dim, const std::string& analysis,
+                         const std::string& stress_update,
                          const std::string& file_name);
 
 // Write Mesh file in 2D

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -101,7 +101,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -141,9 +141,9 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -182,7 +182,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -227,9 +227,9 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -277,7 +277,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -322,9 +322,9 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -442,7 +442,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -498,9 +498,9 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -540,7 +540,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -601,9 +601,9 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -651,7 +651,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -712,9 +712,9 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -20,7 +20,7 @@ TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
   mpm::Index pid = 0;
   Eigen::Matrix<double, Dim, 1> coords;
   coords.setZero();
-  auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+  auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
   // Initialise material
   Json jmaterial;
@@ -181,7 +181,7 @@ TEST_CASE("LinearElastic is checked in 3D", "[material][linear_elastic][3D]") {
   mpm::Index pid = 0;
   Eigen::Matrix<double, Dim, 1> coords;
   coords.setZero();
-  auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+  auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
   // Initialise material
   Json jmaterial;

--- a/tests/material/newtonian_test.cc
+++ b/tests/material/newtonian_test.cc
@@ -92,7 +92,7 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -137,9 +137,9 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -248,7 +248,7 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     mpm::Index pid = 0;
     Eigen::Matrix<double, Dim, 1> coords;
     coords << 0.5, 0.5, 0.5;
-    auto particle = std::make_shared<mpm::Particle<Dim, 1>>(pid, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
     // Coordinates of nodes for the cell
     mpm::Index cell_id = 0;
@@ -309,9 +309,9 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     REQUIRE(cell->is_initialised() == true);
 
     particle->assign_cell(cell);
-    particle->assign_material(phase, material);
+    particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;

--- a/tests/mesh_cell_neighbours_test.cc
+++ b/tests/mesh_cell_neighbours_test.cc
@@ -141,7 +141,7 @@ TEST_CASE("Mesh cell neighbours 2D", "[MeshCell][2D]") {
       SECTION("Locate particles in mesh") {
         coords << 3., 1.5;
         std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-            std::make_shared<mpm::Particle<Dim, Nphases>>(1, coords);
+            std::make_shared<mpm::Particle<Dim>>(1, coords);
         // Add particle 1 and check
         REQUIRE(mesh->add_particle(particle1, false) == true);
 
@@ -329,7 +329,7 @@ TEST_CASE("Mesh cell neighbours 3D", "[MeshCell][3D]") {
       SECTION("Locate particles in mesh") {
         coords << 3., 1.5, 1.5;
         std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-            std::make_shared<mpm::Particle<Dim, Nphases>>(1, coords);
+            std::make_shared<mpm::Particle<Dim>>(1, coords);
         // Add particle 1 and check
         REQUIRE(mesh->add_particle(particle1, false) == true);
 

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -72,13 +72,13 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
     Eigen::Vector2d coords;
     coords.setZero();
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id1, coords);
+        std::make_shared<mpm::Particle<Dim>>(id1, coords);
 
     // Particle 2
     mpm::Index id2 = 1;
     coords << 2., 2.;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id2, coords);
+        std::make_shared<mpm::Particle<Dim>>(id2, coords);
 
     auto mesh = std::make_shared<mpm::Mesh<Dim>>(0);
     // Check mesh is active
@@ -430,12 +430,12 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
     // Particle 1
     coords << 1.0, 1.0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(0, coords);
+        std::make_shared<mpm::Particle<Dim>>(0, coords);
 
     // Particle 2
     coords << 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(1, coords);
+        std::make_shared<mpm::Particle<Dim>>(1, coords);
 
     // Add particle 1 and check
     REQUIRE(mesh->add_particle(particle1) == true);
@@ -687,7 +687,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
 
               mpm::Index pid = 100;
               std::shared_ptr<mpm::ParticleBase<Dim>> particle100 =
-                  std::make_shared<mpm::Particle<Dim, Nphases>>(pid, coords);
+                  std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
               // Add particle100 and check
               REQUIRE(mesh->add_particle(particle100) == false);
@@ -742,7 +742,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
               // Compute volume
               mesh->iterate_over_particles(
                   std::bind(&mpm::ParticleBase<Dim>::compute_volume,
-                            std::placeholders::_1, phase));
+                            std::placeholders::_1));
 
               REQUIRE(mesh->assign_particles_tractions(particles_tractions) ==
                       true);
@@ -984,13 +984,13 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     Eigen::Vector3d coords;
     coords.setZero();
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id1, coords);
+        std::make_shared<mpm::Particle<Dim>>(id1, coords);
 
     // Particle 2
     mpm::Index id2 = 1;
     coords << 2., 2., 2.;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id2, coords);
+        std::make_shared<mpm::Particle<Dim>>(id2, coords);
 
     auto mesh = std::make_shared<mpm::Mesh<Dim>>(0);
     // Check mesh is active
@@ -1386,12 +1386,12 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     // Particle 1
     coords << 1.0, 1.0, 1.0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(0, coords);
+        std::make_shared<mpm::Particle<Dim>>(0, coords);
 
     // Particle 2
     coords << 1.5, 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(1, coords);
+        std::make_shared<mpm::Particle<Dim>>(1, coords);
 
     // Add particle 1 and check
     REQUIRE(mesh->add_particle(particle1) == true);
@@ -1644,7 +1644,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
 
               mpm::Index pid = 100;
               std::shared_ptr<mpm::ParticleBase<Dim>> particle100 =
-                  std::make_shared<mpm::Particle<Dim, Nphases>>(pid, coords);
+                  std::make_shared<mpm::Particle<Dim>>(pid, coords);
 
               // Add particle100 and check
               REQUIRE(mesh->add_particle(particle100) == false);
@@ -1734,7 +1734,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
               // Compute volume
               mesh->iterate_over_particles(
                   std::bind(&mpm::ParticleBase<Dim>::compute_volume,
-                            std::placeholders::_1, phase));
+                            std::placeholders::_1));
 
               REQUIRE(mesh->assign_particles_tractions(particles_tractions) ==
                       true);

--- a/tests/mpm_explicit_usf_test.cc
+++ b/tests/mpm_explicit_usf_test.cc
@@ -15,9 +15,11 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  const std::string analysis = "MPMExplicitUSF2D";
+  const std::string analysis = "MPMExplicit2D";
+  const std::string stress_update = "usf";
   bool resume = false;
-  REQUIRE(mpm_test::write_json(2, resume, analysis, fname) == true);
+  REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d() == true);
@@ -68,9 +70,11 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usf";
-    const std::string analysis = "MPMExplicitUSF2D";
+    const std::string analysis = "MPMExplicit2D";
+    const std::string stress_update = "usf";
     bool resume = true;
-    REQUIRE(mpm_test::write_json(2, resume, analysis, fname) == true);
+    REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
+            true);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);
@@ -92,9 +96,11 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  const std::string analysis = "MPMExplicitUSF3D";
+  const std::string analysis = "MPMExplicit3D";
+  const std::string stress_update = "usf";
   const bool resume = false;
-  REQUIRE(mpm_test::write_json(3, resume, analysis, fname) == true);
+  REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d() == true);
@@ -145,9 +151,11 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usf";
-    const std::string analysis = "MPMExplicitUSF3D";
+    const std::string analysis = "MPMExplicit3D";
+    const std::string stress_update = "usf";
     bool resume = true;
-    REQUIRE(mpm_test::write_json(3, resume, analysis, fname) == true);
+    REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
+            true);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);

--- a/tests/mpm_explicit_usf_unitcell_test.cc
+++ b/tests/mpm_explicit_usf_unitcell_test.cc
@@ -15,8 +15,10 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  const std::string analysis = "MPMExplicitUSF2D";
-  REQUIRE(mpm_test::write_json_unitcell(2, analysis, fname) == true);
+  const std::string analysis = "MPMExplicit2D";
+  const std::string stress_update = "usf";
+  REQUIRE(mpm_test::write_json_unitcell(2, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d_unitcell() == true);
@@ -71,8 +73,10 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usf";
-  const std::string analysis = "MPMExplicitUSF3D";
-  REQUIRE(mpm_test::write_json_unitcell(3, analysis, fname) == true);
+  const std::string analysis = "MPMExplicit3D";
+  const std::string stress_update = "usf";
+  REQUIRE(mpm_test::write_json_unitcell(3, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d_unitcell() == true);

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -15,9 +15,11 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  const std::string analysis = "MPMExplicitUSL2D";
+  const std::string analysis = "MPMExplicit2D";
+  const std::string stress_update = "usl";
   const bool resume = false;
-  REQUIRE(mpm_test::write_json(2, resume, analysis, fname) == true);
+  REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d() == true);
@@ -68,9 +70,11 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usl";
-    const std::string analysis = "MPMExplicitUSL2D";
+    const std::string analysis = "MPMExplicit2D";
+    const std::string stress_update = "usl";
     bool resume = true;
-    REQUIRE(mpm_test::write_json(2, resume, analysis, fname) == true);
+    REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
+            true);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);
@@ -92,9 +96,11 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  const std::string analysis = "MPMExplicitUSL3D";
+  const std::string analysis = "MPMExplicit3D";
+  const std::string stress_update = "usl";
   const bool resume = false;
-  REQUIRE(mpm_test::write_json(3, resume, analysis, fname) == true);
+  REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d() == true);
@@ -145,9 +151,11 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
   SECTION("Check resume") {
     // Write JSON file
     const std::string fname = "mpm-explicit-usl";
-    const std::string analysis = "MPMExplicitUSL3D";
+    const std::string analysis = "MPMExplicit3D";
+    const std::string stress_update = "usl";
     bool resume = true;
-    REQUIRE(mpm_test::write_json(3, resume, analysis, fname) == true);
+    REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
+            true);
 
     // Create an IO object
     auto io = std::make_unique<mpm::IO>(argc, argv);

--- a/tests/mpm_explicit_usl_unitcell_test.cc
+++ b/tests/mpm_explicit_usl_unitcell_test.cc
@@ -15,8 +15,10 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  const std::string analysis = "MPMExplicitUSL2D";
-  REQUIRE(mpm_test::write_json_unitcell(2, analysis, fname) == true);
+  const std::string analysis = "MPMExplicit2D";
+  const std::string stress_update = "usl";
+  REQUIRE(mpm_test::write_json_unitcell(2, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d_unitcell() == true);
@@ -71,8 +73,10 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked in unitcells",
 
   // Write JSON file
   const std::string fname = "mpm-explicit-usl";
-  const std::string analysis = "MPMExplicitUSL3D";
-  REQUIRE(mpm_test::write_json_unitcell(3, analysis, fname) == true);
+  const std::string analysis = "MPMExplicit3D";
+  const std::string stress_update = "usl";
+  REQUIRE(mpm_test::write_json_unitcell(3, analysis, stress_update, fname) ==
+          true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d_unitcell() == true);

--- a/tests/particle_cell_crossing_test.cc
+++ b/tests/particle_cell_crossing_test.cc
@@ -106,22 +106,22 @@ TEST_CASE("Particle cell crossing is checked for 2D case",
   // Add particle
   id = 0;
   coords << 0.25, 0.25;
-  auto particle0 = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+  auto particle0 = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
   // Add particle
   id = 1;
   coords << 0.75, 0.25;
-  auto particle1 = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+  auto particle1 = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
   // Add particle
   id = 2;
   coords << 0.75, 0.75;
-  auto particle2 = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+  auto particle2 = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
   // Add particle
   id = 3;
   coords << 0.25, 0.75;
-  auto particle3 = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+  auto particle3 = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
   // Add particles and check status
   REQUIRE(mesh->add_particle(particle0) == true);
@@ -162,15 +162,15 @@ TEST_CASE("Particle cell crossing is checked for 2D case",
   // Iterate over each particle to assign material
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::assign_material, std::placeholders::_1,
-                Phase, material));
+                material));
 
   // Compute volume
   mesh->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Dim>::compute_volume, std::placeholders::_1, Phase));
+      &mpm::ParticleBase<Dim>::compute_volume, std::placeholders::_1));
 
   // Compute mass
-  mesh->iterate_over_particles(std::bind(&mpm::ParticleBase<Dim>::compute_mass,
-                                         std::placeholders::_1, Phase));
+  mesh->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Dim>::compute_mass, std::placeholders::_1));
 
   // Initialise nodes
   mesh->iterate_over_nodes(
@@ -192,7 +192,7 @@ TEST_CASE("Particle cell crossing is checked for 2D case",
   // Assign mass and momentum to nodes
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::map_mass_momentum_to_nodes,
-                std::placeholders::_1, Phase));
+                std::placeholders::_1));
 
   // Iterate over active nodes to compute acceleratation and velocity
   mesh->iterate_over_nodes_predicate(
@@ -203,7 +203,7 @@ TEST_CASE("Particle cell crossing is checked for 2D case",
   // Iterate over each particle to compute updated position
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::compute_updated_position,
-                std::placeholders::_1, Phase, dt));
+                std::placeholders::_1, dt));
 
   // Locate particles in a mesh
   particles = mesh->locate_particles_mesh();
@@ -353,28 +353,28 @@ TEST_CASE("Particle cell crossing is checked for 3D case",
 
   // Add particle
   coords << 0.25, 0.25, 0.25;
-  auto particle0 = std::make_shared<mpm::Particle<Dim, Nphases>>(0, coords);
+  auto particle0 = std::make_shared<mpm::Particle<Dim>>(0, coords);
 
   coords << 0.75, 0.25, 0.25;
-  auto particle1 = std::make_shared<mpm::Particle<Dim, Nphases>>(1, coords);
+  auto particle1 = std::make_shared<mpm::Particle<Dim>>(1, coords);
 
   coords << 0.25, 0.75, 0.25;
-  auto particle2 = std::make_shared<mpm::Particle<Dim, Nphases>>(2, coords);
+  auto particle2 = std::make_shared<mpm::Particle<Dim>>(2, coords);
 
   coords << 0.75, 0.75, 0.25;
-  auto particle3 = std::make_shared<mpm::Particle<Dim, Nphases>>(3, coords);
+  auto particle3 = std::make_shared<mpm::Particle<Dim>>(3, coords);
 
   coords << 0.25, 0.25, 0.75;
-  auto particle4 = std::make_shared<mpm::Particle<Dim, Nphases>>(4, coords);
+  auto particle4 = std::make_shared<mpm::Particle<Dim>>(4, coords);
 
   coords << 0.25, 0.25, 0.75;
-  auto particle5 = std::make_shared<mpm::Particle<Dim, Nphases>>(5, coords);
+  auto particle5 = std::make_shared<mpm::Particle<Dim>>(5, coords);
 
   coords << 0.75, 0.75, 0.75;
-  auto particle6 = std::make_shared<mpm::Particle<Dim, Nphases>>(6, coords);
+  auto particle6 = std::make_shared<mpm::Particle<Dim>>(6, coords);
 
   coords << 0.75, 0.75, 0.75;
-  auto particle7 = std::make_shared<mpm::Particle<Dim, Nphases>>(7, coords);
+  auto particle7 = std::make_shared<mpm::Particle<Dim>>(7, coords);
 
   // Add particles and check status
   REQUIRE(mesh->add_particle(particle0) == true);
@@ -418,15 +418,15 @@ TEST_CASE("Particle cell crossing is checked for 3D case",
   // Iterate over each particle to assign material
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::assign_material, std::placeholders::_1,
-                Phase, material));
+                material));
 
   // Compute volume
   mesh->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Dim>::compute_volume, std::placeholders::_1, Phase));
+      &mpm::ParticleBase<Dim>::compute_volume, std::placeholders::_1));
 
   // Compute mass
-  mesh->iterate_over_particles(std::bind(&mpm::ParticleBase<Dim>::compute_mass,
-                                         std::placeholders::_1, Phase));
+  mesh->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Dim>::compute_mass, std::placeholders::_1));
 
   // Initialise nodes
   mesh->iterate_over_nodes(
@@ -452,7 +452,7 @@ TEST_CASE("Particle cell crossing is checked for 3D case",
   // Assign mass and momentum to nodes
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::map_mass_momentum_to_nodes,
-                std::placeholders::_1, Phase));
+                std::placeholders::_1));
 
   // Iterate over active nodes to compute acceleratation and velocity
   mesh->iterate_over_nodes_predicate(
@@ -463,7 +463,7 @@ TEST_CASE("Particle cell crossing is checked for 3D case",
   // Iterate over each particle to compute updated position
   mesh->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Dim>::compute_updated_position,
-                std::placeholders::_1, Phase, dt));
+                std::placeholders::_1, dt));
 
   // Locate particles in a mesh
   particles = mesh->locate_particles_mesh();

--- a/tests/particle_container_test.cc
+++ b/tests/particle_container_test.cc
@@ -15,20 +15,17 @@ TEST_CASE("Particle container is checked for 2D case",
   const unsigned Dim = 2;
   // Tolerance
   const double Tolerance = 1.E-7;
-  // Phases
-  const unsigned Nphases = 1;
-
   // Particle 1
   mpm::Index id1 = 0;
   Eigen::Vector2d coords;
   coords.setZero();
   std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-      std::make_shared<mpm::Particle<Dim, Nphases>>(id1, coords);
+      std::make_shared<mpm::Particle<Dim>>(id1, coords);
 
   // Particle 2
   mpm::Index id2 = 1;
   std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-      std::make_shared<mpm::Particle<Dim, Nphases>>(id2, coords);
+      std::make_shared<mpm::Particle<Dim>>(id2, coords);
 
   // Particle container
   auto particlecontainer =
@@ -132,12 +129,12 @@ TEST_CASE("Particle container is checked for 3D case",
   Eigen::Vector3d coords;
   coords.setZero();
   std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-      std::make_shared<mpm::Particle<Dim, Nphases>>(id1, coords);
+      std::make_shared<mpm::Particle<Dim>>(id1, coords);
 
   // Particle 2
   mpm::Index id2 = 1;
   std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-      std::make_shared<mpm::Particle<Dim, Nphases>>(id2, coords);
+      std::make_shared<mpm::Particle<Dim>>(id2, coords);
 
   // Particle container
   auto particlecontainer =

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -17,10 +17,10 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
   const unsigned Dim = 1;
   // Dimension
   const unsigned Dof = 1;
-  // Phases
+  // Number of phases
   const unsigned Nphases = 1;
   // Phase
-  const unsigned Phase = 0;
+  const unsigned phase = 0;
 
   // Coordinates
   Eigen::Matrix<double, 1, 1> coords;
@@ -30,7 +30,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
   SECTION("Particle id is zero") {
     mpm::Index id = 0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == 0);
     REQUIRE(particle->status() == true);
   }
@@ -39,7 +39,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     //! Check for id is a positive value
     mpm::Index id = std::numeric_limits<mpm::Index>::max();
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == std::numeric_limits<mpm::Index>::max());
     REQUIRE(particle->status() == true);
   }
@@ -49,7 +49,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     mpm::Index id = 0;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     REQUIRE(particle->id() == 0);
     REQUIRE(particle->status() == true);
     particle->assign_status(false);
@@ -62,7 +62,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     const double Tolerance = 1.E-7;
 
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check for coordinates being zero
     auto coordinates = particle->coordinates();
@@ -97,17 +97,16 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     Eigen::Matrix<double, 6, 1> stress =
         Eigen::Matrix<double, 6, 1>::Constant(5.7);
-    const unsigned phase = 0;
-    particle->initial_stress(phase, stress);
-    REQUIRE(particle->stress(phase).size() == stress.size());
-    auto pstress = particle->stress(phase);
+    particle->initial_stress(stress);
+    REQUIRE(particle->stress().size() == stress.size());
+    auto pstress = particle->stress();
     for (unsigned i = 0; i < pstress.size(); ++i)
       REQUIRE(pstress[i] == Approx(stress[i]).epsilon(Tolerance));
 
-    auto pstress_data = particle->vector_data(phase, "stresses");
+    auto pstress_data = particle->vector_data("stresses");
     for (unsigned i = 0; i < pstress_data.size(); ++i)
       REQUIRE(pstress_data[i] == Approx(stress[i]).epsilon(Tolerance));
   }
@@ -118,8 +117,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
-    const unsigned phase = 0;
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     // Apply particles velocity constraints
     REQUIRE(particle->assign_particle_velocity_constraint(0, 10.5) == true);
     // Check out of bounds condition
@@ -129,27 +127,27 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     particle->apply_particle_velocity_constraints();
 
     // Check apply constraints
-    REQUIRE(particle->velocity(Phase)(0) == Approx(10.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(0) == Approx(10.5).epsilon(Tolerance));
   }
 
   SECTION("Check particle properties") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check mass
-    REQUIRE(particle->mass(Phase) == Approx(0.0).epsilon(Tolerance));
+    REQUIRE(particle->mass() == Approx(0.0).epsilon(Tolerance));
     double mass = 100.5;
-    particle->assign_mass(Phase, mass);
-    REQUIRE(particle->mass(Phase) == Approx(100.5).epsilon(Tolerance));
+    particle->assign_mass(mass);
+    REQUIRE(particle->mass() == Approx(100.5).epsilon(Tolerance));
 
     // Check stress
     Eigen::Matrix<double, 6, 1> stress;
     for (unsigned i = 0; i < stress.size(); ++i) stress(i) = 17.51;
 
     for (unsigned i = 0; i < stress.size(); ++i)
-      REQUIRE(particle->stress(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->stress()(i) == Approx(0.).epsilon(Tolerance));
 
     // Check velocity
     Eigen::VectorXd velocity;
@@ -157,50 +155,44 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     for (unsigned i = 0; i < velocity.size(); ++i) velocity(i) = 17.51;
 
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->velocity()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_velocity(Phase, velocity) == true);
+    REQUIRE(particle->assign_velocity(velocity) == true);
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(17.51).epsilon(Tolerance));
-
-    // Check for incorrect phase of velocity
-    unsigned bad_phase = 1;
-    REQUIRE(particle->assign_velocity(bad_phase, velocity) == false);
+      REQUIRE(particle->velocity()(i) == Approx(17.51).epsilon(Tolerance));
 
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(2.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(2.0).epsilon(Tolerance));
     // Traction
     double traction = 65.32;
     const unsigned Direction = 0;
     // Check traction
     for (unsigned i = 0; i < Dim; ++i)
-      REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_traction(Phase, Direction, traction) == true);
+    REQUIRE(particle->assign_traction(Direction, traction) == true);
 
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
 
-    // Check for incorrect direction / phase
+    // Check for incorrect direction
     const unsigned wrong_dir = 4;
-    REQUIRE(particle->assign_traction(Phase, wrong_dir, traction) == false);
+    REQUIRE(particle->assign_traction(wrong_dir, traction) == false);
 
     // Check again to ensure value hasn't been updated
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
   }
 
@@ -208,12 +200,11 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     mpm::HDF5Particle h5_particle;
     h5_particle.id = 13;
     h5_particle.mass = 501.5;
-    h5_particle.volume = 1.0;
 
     Eigen::Vector3d coords;
     coords << 1., 0., 0.;
@@ -263,18 +254,19 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
 
     h5_particle.cell_id = 1;
 
+    h5_particle.volume = 2.;
+
     // Reinitialise particle from HDF5 data
     REQUIRE(particle->initialise_particle(h5_particle) == true);
 
     // Check particle id
     REQUIRE(particle->id() == h5_particle.id);
     // Check particle mass
-    REQUIRE(particle->mass(Phase) == h5_particle.mass);
+    REQUIRE(particle->mass() == h5_particle.mass);
     // Check particle volume
-    REQUIRE(particle->volume(Phase) == h5_particle.volume);
+    REQUIRE(particle->volume() == h5_particle.volume);
     // Check particle mass density
-    REQUIRE(particle->mass_density(Phase) ==
-            h5_particle.mass / h5_particle.volume);
+    REQUIRE(particle->mass_density() == h5_particle.mass / h5_particle.volume);
     // Check particle status
     REQUIRE(particle->status() == h5_particle.status);
 
@@ -285,7 +277,7 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Check for displacement
-    auto pdisplacement = particle->displacement(Phase);
+    auto pdisplacement = particle->displacement();
     REQUIRE(pdisplacement.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pdisplacement(i) == Approx(displacement(i)).epsilon(Tolerance));
@@ -297,32 +289,31 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
       REQUIRE(size(i) == Approx(lsize(i)).epsilon(Tolerance));
 
     // Check velocity
-    auto pvelocity = particle->velocity(Phase);
+    auto pvelocity = particle->velocity();
     REQUIRE(pvelocity.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pvelocity(i) == Approx(velocity(i)).epsilon(Tolerance));
 
     // Check stress
-    auto pstress = particle->stress(Phase);
+    auto pstress = particle->stress();
     REQUIRE(pstress.size() == stress.size());
     for (unsigned i = 0; i < stress.size(); ++i)
       REQUIRE(pstress(i) == Approx(stress(i)).epsilon(Tolerance));
 
     // Check strain
-    auto pstrain = particle->strain(Phase);
+    auto pstrain = particle->strain();
     REQUIRE(pstrain.size() == strain.size());
     for (unsigned i = 0; i < strain.size(); ++i)
       REQUIRE(pstrain(i) == Approx(strain(i)).epsilon(Tolerance));
 
     // Check particle volumetric strain centroid
-    REQUIRE(particle->volumetric_strain_centroid(Phase) ==
-            h5_particle.epsilon_v);
+    REQUIRE(particle->volumetric_strain_centroid() == h5_particle.epsilon_v);
 
     // Check cell id
     REQUIRE(particle->cell_id() == h5_particle.cell_id);
 
     // Write Particle HDF5 data
-    const auto h5_test = particle->hdf5(Phase);
+    const auto h5_test = particle->hdf5();
 
     REQUIRE(h5_particle.id == h5_test.id);
     REQUIRE(h5_particle.mass == h5_test.mass);
@@ -385,12 +376,12 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
   const unsigned Dim = 2;
   // Degree of freedom
   const unsigned Dof = 2;
+  // Number of nodes per cell
+  const unsigned Nnodes = 4;
   // Number of phases
   const unsigned Nphases = 1;
   // Phase
-  const unsigned Phase = 0;
-  // Number of nodes per cell
-  const unsigned Nnodes = 4;
+  const unsigned phase = 0;
   // Tolerance
   const double Tolerance = 1.E-7;
   // Coordinates
@@ -400,21 +391,21 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
   //! Check for id = 0
   SECTION("Particle id is zero") {
     mpm::Index id = 0;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == 0);
   }
 
   SECTION("Particle id is positive") {
     //! Check for id is a positive value
     mpm::Index id = std::numeric_limits<mpm::Index>::max();
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == std::numeric_limits<mpm::Index>::max());
   }
 
   //! Test coordinates function
   SECTION("coordinates function is checked") {
     mpm::Index id = 0;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     //! Check for coordinates being zero
     auto coordinates = particle->coordinates();
@@ -448,7 +439,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // Add particle
     mpm::Index id = 0;
     coords << 0.75, 0.75;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check particle coordinates
     auto coordinates = particle->coordinates();
@@ -570,13 +561,12 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     Eigen::Matrix<double, 6, 1> stress =
         Eigen::Matrix<double, 6, 1>::Constant(5.7);
-    const unsigned phase = 0;
-    particle->initial_stress(phase, stress);
-    REQUIRE(particle->stress(phase).size() == stress.size());
-    auto pstress = particle->stress(phase);
+    particle->initial_stress(stress);
+    REQUIRE(particle->stress().size() == stress.size());
+    auto pstress = particle->stress();
     for (unsigned i = 0; i < pstress.size(); ++i)
       REQUIRE(pstress[i] == Approx(stress[i]).epsilon(Tolerance));
   }
@@ -587,8 +577,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
-    const unsigned phase = 0;
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
 
     // Apply particles velocity constraints
     REQUIRE(particle->assign_particle_velocity_constraint(0, 10.5) == true);
@@ -600,8 +589,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     particle->apply_particle_velocity_constraints();
 
     // Check apply constraints
-    REQUIRE(particle->velocity(Phase)(0) == Approx(10.5).epsilon(Tolerance));
-    REQUIRE(particle->velocity(Phase)(1) == Approx(-12.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(0) == Approx(10.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(1) == Approx(-12.5).epsilon(Tolerance));
   }
 
   //! Test particle, cell and node functions
@@ -609,10 +598,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // Add particle
     mpm::Index id = 0;
     coords << 0.75, 0.75;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
-    // Phase
-    const unsigned phase = 0;
     // Time-step
     const double dt = 0.1;
 
@@ -665,13 +652,13 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // Compute reference location should throw
     REQUIRE(particle->compute_reference_location() == false);
     // Compute updated particle location should fail
-    REQUIRE(particle->compute_updated_position(phase, dt) == false);
+    REQUIRE(particle->compute_updated_position(dt) == false);
     // Compute updated particle location from nodal velocity should fail
-    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
+    REQUIRE(particle->compute_updated_position_velocity(dt) == false);
     // Compute volume
-    REQUIRE(particle->compute_volume(phase) == false);
+    REQUIRE(particle->compute_volume() == false);
     // Update volume should fail
-    REQUIRE(particle->update_volume_strainrate(phase, dt) == false);
+    REQUIRE(particle->update_volume_strainrate(dt) == false);
 
     REQUIRE(particle->assign_cell(cell) == true);
     REQUIRE(cell->status() == true);
@@ -684,15 +671,15 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->compute_shapefn() == true);
 
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(2.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(2.0).epsilon(Tolerance));
     // Compute volume
-    REQUIRE(particle->compute_volume(Phase) == true);
+    REQUIRE(particle->compute_volume() == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(1.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(1.0).epsilon(Tolerance));
 
     // Check reference location
     coords << -0.5, -0.5;
@@ -714,31 +701,31 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
             "LinearElastic2D", std::move(mid), jmaterial);
 
     // Check compute mass before material and volume
-    REQUIRE(particle->compute_mass(phase) == false);
+    REQUIRE(particle->compute_mass() == false);
 
     // Test compute stress before material assignment
-    REQUIRE(particle->compute_stress(phase) == false);
+    REQUIRE(particle->compute_stress() == false);
 
     // Test compute internal force before material assignment
-    REQUIRE(particle->map_internal_force(phase) == false);
+    REQUIRE(particle->map_internal_force() == false);
 
     // Assign material properties
-    REQUIRE(particle->assign_material(phase, material) == true);
+    REQUIRE(particle->assign_material(material) == true);
 
     // Compute volume
-    REQUIRE(particle->compute_volume(Phase) == true);
+    REQUIRE(particle->compute_volume() == true);
 
     // Compute mass
-    REQUIRE(particle->compute_mass(phase) == true);
+    REQUIRE(particle->compute_mass() == true);
     // Mass
-    REQUIRE(particle->mass(phase) == Approx(1000.).epsilon(Tolerance));
+    REQUIRE(particle->mass() == Approx(1000.).epsilon(Tolerance));
 
     // Map particle mass to nodes
-    particle->assign_mass(phase, std::numeric_limits<double>::max());
-    REQUIRE(particle->map_mass_momentum_to_nodes(phase) == false);
+    particle->assign_mass(std::numeric_limits<double>::max());
+    REQUIRE(particle->map_mass_momentum_to_nodes() == false);
 
     // Map particle pressure to nodes
-    REQUIRE(particle->map_pressure_to_nodes(phase) == false);
+    REQUIRE(particle->map_pressure_to_nodes() == false);
 
     // Assign mass to nodes
     REQUIRE(particle->compute_reference_location() == true);
@@ -748,15 +735,15 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     Eigen::VectorXd velocity;
     velocity.resize(Dim);
     for (unsigned i = 0; i < velocity.size(); ++i) velocity(i) = i;
-    REQUIRE(particle->assign_velocity(Phase, velocity) == true);
+    REQUIRE(particle->assign_velocity(velocity) == true);
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(i).epsilon(Tolerance));
+      REQUIRE(particle->velocity()(i) == Approx(i).epsilon(Tolerance));
 
-    REQUIRE(particle->compute_mass(phase) == true);
-    REQUIRE(particle->map_mass_momentum_to_nodes(phase) == true);
+    REQUIRE(particle->compute_mass() == true);
+    REQUIRE(particle->map_mass_momentum_to_nodes() == true);
 
-    REQUIRE(particle->map_pressure_to_nodes(phase) == true);
-    REQUIRE(particle->compute_pressure_smoothing(phase) == true);
+    REQUIRE(particle->map_pressure_to_nodes() == true);
+    REQUIRE(particle->compute_pressure_smoothing() == true);
 
     // Values of nodal mass
     std::array<double, 4> nodal_mass{562.5, 187.5, 62.5, 187.5};
@@ -822,38 +809,34 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
                 Approx(nodal_velocity(i, j)).epsilon(Tolerance));
 
     // Check pressure
-    REQUIRE(particle->pressure(phase) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(particle->pressure() == Approx(0.).epsilon(Tolerance));
 
     // Compute strain
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0., 0.25, 0., 0.050, 0., 0.;
     // Check strains
     for (unsigned i = 0; i < strain.rows(); ++i)
-      REQUIRE(particle->strain(phase)(i) ==
-              Approx(strain(i)).epsilon(Tolerance));
+      REQUIRE(particle->strain()(i) == Approx(strain(i)).epsilon(Tolerance));
 
     // Check volumetric strain at centroid
     const double volumetric_strain = 0.2;
-    REQUIRE(particle->volumetric_strain_centroid(phase) ==
+    REQUIRE(particle->volumetric_strain_centroid() ==
             Approx(volumetric_strain).epsilon(Tolerance));
 
     // Check updated pressure
     const double K = 8333333.333333333;
-    REQUIRE(particle->pressure(phase) ==
+    REQUIRE(particle->pressure() ==
             Approx(-K * volumetric_strain).epsilon(Tolerance));
 
     // Update volume strain rate
-    REQUIRE(particle->volume(phase) == Approx(1.0).epsilon(Tolerance));
-    REQUIRE(particle->mass_density(phase) == Approx(1000).epsilon(Tolerance));
-    REQUIRE(particle->update_volume_strainrate(phase, dt) == true);
-    REQUIRE(particle->volume(phase) == Approx(1.2).epsilon(Tolerance));
-    REQUIRE(particle->mass_density(phase) ==
-            Approx(833.333333333).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(1.0).epsilon(Tolerance));
+    REQUIRE(particle->update_volume_strainrate(dt) == true);
+    REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE(particle->compute_stress(phase) == true);
+    REQUIRE(particle->compute_stress() == true);
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -866,14 +849,13 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // clang-format on
     // Check stress
     for (unsigned i = 0; i < stress.rows(); ++i)
-      REQUIRE(particle->stress(phase)(i) ==
-              Approx(stress(i)).epsilon(Tolerance));
+      REQUIRE(particle->stress()(i) == Approx(stress(i)).epsilon(Tolerance));
 
     // Check body force
     Eigen::Matrix<double, 2, 1> gravity;
     gravity << 0., -9.81;
 
-    particle->map_body_force(phase, gravity);
+    particle->map_body_force(gravity);
 
     // Body force
     Eigen::Matrix<double, 4, 2> body_force;
@@ -894,13 +876,13 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     double traction = 7.68;
     const unsigned direction = 1;
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Assign traction to particle
-    particle->assign_traction(phase, direction, traction);
+    particle->assign_traction(direction, traction);
     // Map traction force
-    particle->map_traction_force(phase);
+    particle->map_traction_force();
 
     // Traction force
     Eigen::Matrix<double, 4, 2> traction_force;
@@ -920,9 +902,9 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
         REQUIRE(nodes[i]->external_force(phase)[j] ==
                 Approx(traction_force(i, j)).epsilon(Tolerance));
     // Reset traction
-    particle->assign_traction(phase, direction, -traction);
+    particle->assign_traction(direction, -traction);
     // Map traction force
-    particle->map_traction_force(phase);
+    particle->map_traction_force();
     // Check nodal external force
     for (unsigned i = 0; i < traction_force.rows(); ++i)
       for (unsigned j = 0; j < traction_force.cols(); ++j)
@@ -939,8 +921,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // clang-format on
 
     // Map particle internal force
-    particle->assign_volume(Phase, 1.0);
-    REQUIRE(particle->map_internal_force(phase) == true);
+    particle->assign_volume(1.0);
+    REQUIRE(particle->map_internal_force() == true);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)
@@ -987,18 +969,18 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Compute updated particle location
-    REQUIRE(particle->compute_updated_position(phase, dt) == true);
+    REQUIRE(particle->compute_updated_position(dt) == true);
     // Check particle velocity
     velocity << 0., 0.019;
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) ==
+      REQUIRE(particle->velocity()(i) ==
               Approx(velocity(i)).epsilon(Tolerance));
 
     // Check particle displacement
     Eigen::Vector2d displacement;
     displacement << 0., 0.0894;
     for (unsigned i = 0; i < displacement.size(); ++i)
-      REQUIRE(particle->displacement(Phase)(i) ==
+      REQUIRE(particle->displacement()(i) ==
               Approx(displacement(i)).epsilon(Tolerance));
 
     // Updated particle coordinate
@@ -1009,17 +991,17 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Compute updated particle location from nodal velocity
-    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == true);
+    REQUIRE(particle->compute_updated_position_velocity(dt) == true);
     // Check particle velocity
     velocity << 0., 0.894;
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) ==
+      REQUIRE(particle->velocity()(i) ==
               Approx(velocity(i)).epsilon(Tolerance));
 
     // Check particle displacement
     displacement << 0., 0.1788;
     for (unsigned i = 0; i < displacement.size(); ++i)
-      REQUIRE(particle->displacement(Phase)(i) ==
+      REQUIRE(particle->displacement()(i) ==
               Approx(displacement(i)).epsilon(Tolerance));
 
     // Updated particle coordinate
@@ -1034,7 +1016,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     // Add particle
     mpm::Index id = 0;
     coords << 0.75, 0.75;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     unsigned mid = 0;
     // Initialise material
@@ -1049,30 +1031,30 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(material->id() == 0);
 
     // Check if particle can be assigned a material is null
-    REQUIRE(particle->assign_material(Phase, nullptr) == false);
+    REQUIRE(particle->assign_material(nullptr) == false);
 
     // Assign material to particle
-    REQUIRE(particle->assign_material(Phase, material) == true);
+    REQUIRE(particle->assign_material(material) == true);
   }
 
   SECTION("Check particle properties") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check mass
-    REQUIRE(particle->mass(Phase) == Approx(0.0).epsilon(Tolerance));
+    REQUIRE(particle->mass() == Approx(0.0).epsilon(Tolerance));
     double mass = 100.5;
-    particle->assign_mass(Phase, mass);
-    REQUIRE(particle->mass(Phase) == Approx(100.5).epsilon(Tolerance));
+    particle->assign_mass(mass);
+    REQUIRE(particle->mass() == Approx(100.5).epsilon(Tolerance));
 
     // Check stress
     Eigen::Matrix<double, 6, 1> stress;
     for (unsigned i = 0; i < stress.size(); ++i) stress(i) = 17.52;
 
     for (unsigned i = 0; i < stress.size(); ++i)
-      REQUIRE(particle->stress(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->stress()(i) == Approx(0.).epsilon(Tolerance));
 
     // Check velocity
     Eigen::VectorXd velocity;
@@ -1080,54 +1062,47 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     for (unsigned i = 0; i < velocity.size(); ++i) velocity(i) = 19.745;
 
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->velocity()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_velocity(Phase, velocity) == true);
+    REQUIRE(particle->assign_velocity(velocity) == true);
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) ==
-              Approx(19.745).epsilon(Tolerance));
-
-    // Check for incorrect phase in velocity
-    unsigned bad_phase = 1;
-    REQUIRE(particle->assign_velocity(bad_phase, velocity) == false);
+      REQUIRE(particle->velocity()(i) == Approx(19.745).epsilon(Tolerance));
 
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(2.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(2.0).epsilon(Tolerance));
     // Traction
     double traction = 65.32;
     const unsigned Direction = 1;
     // Check traction
     for (unsigned i = 0; i < Dim; ++i)
-      REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_traction(Phase, Direction, traction) == true);
+    REQUIRE(particle->assign_traction(Direction, traction) == true);
 
     // Calculate traction force = traction * volume / spacing
     traction *= 2.0 / (std::pow(2.0, 1. / Dim));
 
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
 
-    // Check for incorrect direction / phase
+    // Check for incorrect direction
     const unsigned wrong_dir = 4;
-    REQUIRE(particle->assign_traction(Phase, wrong_dir, traction) == false);
+    REQUIRE(particle->assign_traction(wrong_dir, traction) == false);
 
     // Check again to ensure value hasn't been updated
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
   }
 
@@ -1136,7 +1111,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     mpm::HDF5Particle h5_particle;
     h5_particle.id = 13;
@@ -1190,13 +1165,19 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     h5_particle.cell_id = 1;
 
+    h5_particle.volume = 2.;
+
     // Reinitialise particle from HDF5 data
     REQUIRE(particle->initialise_particle(h5_particle) == true);
 
     // Check particle id
     REQUIRE(particle->id() == h5_particle.id);
     // Check particle mass
-    REQUIRE(particle->mass(Phase) == h5_particle.mass);
+    REQUIRE(particle->mass() == h5_particle.mass);
+    // Check particle volume
+    REQUIRE(particle->volume() == h5_particle.volume);
+    // Check particle mass density
+    REQUIRE(particle->mass_density() == h5_particle.mass / h5_particle.volume);
     // Check particle status
     REQUIRE(particle->status() == h5_particle.status);
 
@@ -1207,7 +1188,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Check for displacement
-    auto pdisplacement = particle->displacement(Phase);
+    auto pdisplacement = particle->displacement();
     REQUIRE(pdisplacement.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pdisplacement(i) == Approx(displacement(i)).epsilon(Tolerance));
@@ -1219,32 +1200,31 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
       REQUIRE(size(i) == Approx(lsize(i)).epsilon(Tolerance));
 
     // Check velocity
-    auto pvelocity = particle->velocity(Phase);
+    auto pvelocity = particle->velocity();
     REQUIRE(pvelocity.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pvelocity(i) == Approx(velocity(i)).epsilon(Tolerance));
 
     // Check stress
-    auto pstress = particle->stress(Phase);
+    auto pstress = particle->stress();
     REQUIRE(pstress.size() == stress.size());
     for (unsigned i = 0; i < stress.size(); ++i)
       REQUIRE(pstress(i) == Approx(stress(i)).epsilon(Tolerance));
 
     // Check strain
-    auto pstrain = particle->strain(Phase);
+    auto pstrain = particle->strain();
     REQUIRE(pstrain.size() == strain.size());
     for (unsigned i = 0; i < strain.size(); ++i)
       REQUIRE(pstrain(i) == Approx(strain(i)).epsilon(Tolerance));
 
     // Check particle volumetric strain centroid
-    REQUIRE(particle->volumetric_strain_centroid(Phase) ==
-            h5_particle.epsilon_v);
+    REQUIRE(particle->volumetric_strain_centroid() == h5_particle.epsilon_v);
 
     // Check cell id
     REQUIRE(particle->cell_id() == h5_particle.cell_id);
 
     // Write Particle HDF5 data
-    const auto h5_test = particle->hdf5(Phase);
+    const auto h5_test = particle->hdf5();
 
     REQUIRE(h5_particle.id == h5_test.id);
     REQUIRE(h5_particle.mass == h5_test.mass);
@@ -1307,12 +1287,12 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
   const unsigned Dim = 3;
   // Dimension
   const unsigned Dof = 6;
-  // Nnumber of phases
-  const unsigned Nphases = 1;
-  // Phase
-  const unsigned Phase = 0;
   // Number of nodes per cell
   const unsigned Nnodes = 8;
+  // Number of phases
+  const unsigned Nphases = 1;
+  // Phase
+  const unsigned phase = 0;
   // Tolerance
   const double Tolerance = 1.E-7;
 
@@ -1324,7 +1304,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
   SECTION("Particle id is zero") {
     mpm::Index id = 0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == 0);
     REQUIRE(particle->status() == true);
   }
@@ -1333,7 +1313,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     //! Check for id is a positive value
     mpm::Index id = std::numeric_limits<mpm::Index>::max();
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == std::numeric_limits<mpm::Index>::max());
     REQUIRE(particle->status() == true);
   }
@@ -1343,7 +1323,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     mpm::Index id = 0;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     REQUIRE(particle->id() == 0);
     REQUIRE(particle->status() == true);
     particle->assign_status(false);
@@ -1355,7 +1335,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     mpm::Index id = 0;
     // Create particle
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     //! Check for coordinates being zero
     auto coordinates = particle->coordinates();
@@ -1390,7 +1370,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     mpm::Index id = 0;
     coords << 1.5, 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check particle coordinates
     auto coordinates = particle->coordinates();
@@ -1544,13 +1524,13 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
     Eigen::Matrix<double, 6, 1> stress =
         Eigen::Matrix<double, 6, 1>::Constant(5.7);
-    const unsigned phase = 0;
-    particle->initial_stress(phase, stress);
-    REQUIRE(particle->stress(phase).size() == stress.size());
-    auto pstress = particle->stress(phase);
+
+    particle->initial_stress(stress);
+    REQUIRE(particle->stress().size() == stress.size());
+    auto pstress = particle->stress();
     for (unsigned i = 0; i < pstress.size(); ++i)
       REQUIRE(pstress[i] == Approx(stress[i]).epsilon(Tolerance));
   }
@@ -1561,8 +1541,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     const double Tolerance = 1.E-7;
     bool status = true;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords, status);
-    const unsigned phase = 0;
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
 
     // Apply particles velocity constraints
     REQUIRE(particle->assign_particle_velocity_constraint(0, 10.5) == true);
@@ -1575,9 +1554,9 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     particle->apply_particle_velocity_constraints();
 
     // Check apply constraints
-    REQUIRE(particle->velocity(Phase)(0) == Approx(10.5).epsilon(Tolerance));
-    REQUIRE(particle->velocity(Phase)(1) == Approx(-12.5).epsilon(Tolerance));
-    REQUIRE(particle->velocity(Phase)(2) == Approx(14.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(0) == Approx(10.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(1) == Approx(-12.5).epsilon(Tolerance));
+    REQUIRE(particle->velocity()(2) == Approx(14.5).epsilon(Tolerance));
   }
 
   //! Test particle, cell and node functions
@@ -1586,10 +1565,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     mpm::Index id = 0;
     coords << 1.5, 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
-    // Phase
-    const unsigned phase = 0;
     // Time-step
     const double dt = 0.1;
 
@@ -1670,13 +1647,13 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Compute reference location should throw
     REQUIRE(particle->compute_reference_location() == false);
     // Compute updated particle location should fail
-    REQUIRE(particle->compute_updated_position(phase, dt) == false);
+    REQUIRE(particle->compute_updated_position(dt) == false);
     // Compute updated particle location from nodal velocity should fail
-    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == false);
+    REQUIRE(particle->compute_updated_position_velocity(dt) == false);
     // Compute volume
-    REQUIRE(particle->compute_volume(phase) == false);
+    REQUIRE(particle->compute_volume() == false);
     // Update volume should fail
-    REQUIRE(particle->update_volume_strainrate(phase, dt) == false);
+    REQUIRE(particle->update_volume_strainrate(dt) == false);
 
     REQUIRE(particle->assign_cell(cell) == true);
     REQUIRE(cell->status() == true);
@@ -1689,15 +1666,15 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(particle->compute_shapefn() == true);
 
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(2.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(2.0).epsilon(Tolerance));
     // Compute volume
-    REQUIRE(particle->compute_volume(Phase) == true);
+    REQUIRE(particle->compute_volume() == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(8.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(8.0).epsilon(Tolerance));
 
     // Check reference location
     coords << 0.5, 0.5, 0.5;
@@ -1719,31 +1696,31 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
             "LinearElastic3D", std::move(mid), jmaterial);
 
     // Check compute mass before material and volume
-    REQUIRE(particle->compute_mass(phase) == false);
+    REQUIRE(particle->compute_mass() == false);
 
     // Test compute stress before material assignment
-    REQUIRE(particle->compute_stress(phase) == false);
+    REQUIRE(particle->compute_stress() == false);
 
     // Test compute internal force before material assignment
-    REQUIRE(particle->map_internal_force(phase) == false);
+    REQUIRE(particle->map_internal_force() == false);
 
     // Assign material properties
-    REQUIRE(particle->assign_material(Phase, material) == true);
+    REQUIRE(particle->assign_material(material) == true);
 
     // Compute volume
-    REQUIRE(particle->compute_volume(phase) == true);
+    REQUIRE(particle->compute_volume() == true);
 
     // Compute mass
-    REQUIRE(particle->compute_mass(phase) == true);
+    REQUIRE(particle->compute_mass() == true);
     // Mass
-    REQUIRE(particle->mass(phase) == Approx(8000.).epsilon(Tolerance));
+    REQUIRE(particle->mass() == Approx(8000.).epsilon(Tolerance));
 
     // Map particle mass to nodes
-    particle->assign_mass(phase, std::numeric_limits<double>::max());
-    REQUIRE(particle->map_mass_momentum_to_nodes(phase) == false);
+    particle->assign_mass(std::numeric_limits<double>::max());
+    REQUIRE(particle->map_mass_momentum_to_nodes() == false);
 
     // Map particle pressure to nodes
-    REQUIRE(particle->map_pressure_to_nodes(phase) == false);
+    REQUIRE(particle->map_pressure_to_nodes() == false);
 
     // Assign mass to nodes
     REQUIRE(particle->compute_reference_location() == true);
@@ -1753,15 +1730,15 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     Eigen::VectorXd velocity;
     velocity.resize(Dim);
     for (unsigned i = 0; i < velocity.size(); ++i) velocity(i) = i;
-    REQUIRE(particle->assign_velocity(Phase, velocity) == true);
+    REQUIRE(particle->assign_velocity(velocity) == true);
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(i).epsilon(Tolerance));
+      REQUIRE(particle->velocity()(i) == Approx(i).epsilon(Tolerance));
 
-    REQUIRE(particle->compute_mass(phase) == true);
-    REQUIRE(particle->map_mass_momentum_to_nodes(phase) == true);
+    REQUIRE(particle->compute_mass() == true);
+    REQUIRE(particle->map_mass_momentum_to_nodes() == true);
 
-    REQUIRE(particle->map_pressure_to_nodes(phase) == true);
-    REQUIRE(particle->compute_pressure_smoothing(phase) == true);
+    REQUIRE(particle->map_pressure_to_nodes() == true);
+    REQUIRE(particle->compute_pressure_smoothing() == true);
 
     // Values of nodal mass
     std::array<double, 8> nodal_mass{125., 375.,  1125., 375.,
@@ -1846,39 +1823,35 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
                 Approx(nodal_velocity(i, j)).epsilon(Tolerance));
 
     // Check pressure
-    REQUIRE(particle->pressure(phase) == Approx(0.).epsilon(Tolerance));
+    REQUIRE(particle->pressure() == Approx(0.).epsilon(Tolerance));
 
     // Compute strain
-    particle->compute_strain(phase, dt);
+    particle->compute_strain(dt);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0.00000, 0.07500, 0.40000, -0.02500, 0.35000, -0.05000;
 
     // Check strains
     for (unsigned i = 0; i < strain.rows(); ++i)
-      REQUIRE(particle->strain(phase)(i) ==
-              Approx(strain(i)).epsilon(Tolerance));
+      REQUIRE(particle->strain()(i) == Approx(strain(i)).epsilon(Tolerance));
 
     // Check volumetric strain at centroid
     const double volumetric_strain = 0.5;
-    REQUIRE(particle->volumetric_strain_centroid(phase) ==
+    REQUIRE(particle->volumetric_strain_centroid() ==
             Approx(volumetric_strain).epsilon(Tolerance));
 
     // Check updated pressure
     const double K = 8333333.333333333;
-    REQUIRE(particle->pressure(phase) ==
+    REQUIRE(particle->pressure() ==
             Approx(-K * volumetric_strain).epsilon(Tolerance));
 
     // Update volume strain rate
-    REQUIRE(particle->volume(phase) == Approx(8.0).epsilon(Tolerance));
-    REQUIRE(particle->mass_density(phase) == Approx(1000).epsilon(Tolerance));
-    REQUIRE(particle->update_volume_strainrate(phase, dt) == true);
-    REQUIRE(particle->volume(phase) == Approx(12.0).epsilon(Tolerance));
-    REQUIRE(particle->mass_density(phase) ==
-            Approx(666.666667).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(8.0).epsilon(Tolerance));
+    REQUIRE(particle->update_volume_strainrate(dt) == true);
+    REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE(particle->compute_stress(phase) == true);
+    REQUIRE(particle->compute_stress() == true);
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -1891,14 +1864,13 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // clang-format on
     // Check stress
     for (unsigned i = 0; i < stress.rows(); ++i)
-      REQUIRE(particle->stress(phase)(i) ==
-              Approx(stress(i)).epsilon(Tolerance));
+      REQUIRE(particle->stress()(i) == Approx(stress(i)).epsilon(Tolerance));
 
     // Check body force
     Eigen::Matrix<double, 3, 1> gravity;
     gravity << 0., 0., -9.81;
 
-    particle->map_body_force(phase, gravity);
+    particle->map_body_force(gravity);
 
     // Body force
     Eigen::Matrix<double, 8, 3> body_force;
@@ -1923,13 +1895,13 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     double traction = 7.68;
     const unsigned direction = 2;
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Assign traction to particle
-    particle->assign_traction(phase, direction, traction);
+    particle->assign_traction(direction, traction);
     // Map traction force
-    particle->map_traction_force(phase);
+    particle->map_traction_force();
 
     // Traction force
     Eigen::Matrix<double, 8, 3> traction_force;
@@ -1953,9 +1925,9 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
         REQUIRE(nodes[i]->external_force(phase)[j] ==
                 Approx(traction_force(i, j)).epsilon(Tolerance));
     // Reset traction
-    particle->assign_traction(phase, direction, -traction);
+    particle->assign_traction(direction, -traction);
     // Map traction force
-    particle->map_traction_force(phase);
+    particle->map_traction_force();
     // Check nodal external force
     for (unsigned i = 0; i < traction_force.rows(); ++i)
       for (unsigned j = 0; j < traction_force.cols(); ++j)
@@ -1976,8 +1948,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // clang-format on
 
     // Map particle internal force
-    particle->assign_volume(Phase, 8.0);
-    REQUIRE(particle->map_internal_force(phase) == true);
+    particle->assign_volume(8.0);
+    REQUIRE(particle->map_internal_force() == true);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)
@@ -2032,18 +2004,18 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Compute updated particle location
-    REQUIRE(particle->compute_updated_position(phase, dt) == true);
+    REQUIRE(particle->compute_updated_position(dt) == true);
     // Check particle velocity
     velocity << 0., 1., 1.019;
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) ==
+      REQUIRE(particle->velocity()(i) ==
               Approx(velocity(i)).epsilon(Tolerance));
 
     // Check particle displacement
     Eigen::Vector3d displacement;
     displacement << 0.0, 0.5875, 1.0769;
     for (unsigned i = 0; i < displacement.size(); ++i)
-      REQUIRE(particle->displacement(Phase)(i) ==
+      REQUIRE(particle->displacement()(i) ==
               Approx(displacement(i)).epsilon(Tolerance));
 
     // Updated particle coordinate
@@ -2054,17 +2026,17 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
       REQUIRE(coordinates(i) == Approx(coords(i)).epsilon(Tolerance));
 
     // Compute updated particle location based on nodal velocity
-    REQUIRE(particle->compute_updated_position_velocity(phase, dt) == true);
+    REQUIRE(particle->compute_updated_position_velocity(dt) == true);
     // Check particle velocity
     velocity << 0., 5.875, 10.769;
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) ==
+      REQUIRE(particle->velocity()(i) ==
               Approx(velocity(i)).epsilon(Tolerance));
 
     // Check particle displacement
     displacement << 0.0, 1.175, 2.1538;
     for (unsigned i = 0; i < displacement.size(); ++i)
-      REQUIRE(particle->displacement(Phase)(i) ==
+      REQUIRE(particle->displacement()(i) ==
               Approx(displacement(i)).epsilon(Tolerance));
 
     // Updated particle coordinate
@@ -2079,7 +2051,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Add particle
     mpm::Index id = 0;
     coords << 0.75, 0.75, 0.75;
-    auto particle = std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+    auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     unsigned mid = 0;
     // Initialise material
@@ -2094,29 +2066,29 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(material->id() == 0);
 
     // Check if particle can be assigned a null material
-    REQUIRE(particle->assign_material(Phase, nullptr) == false);
+    REQUIRE(particle->assign_material(nullptr) == false);
     // Assign material to particle
-    REQUIRE(particle->assign_material(Phase, material) == true);
+    REQUIRE(particle->assign_material(material) == true);
   }
 
   SECTION("Check particle properties") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     // Check mass
-    REQUIRE(particle->mass(Phase) == Approx(0.0).epsilon(Tolerance));
+    REQUIRE(particle->mass() == Approx(0.0).epsilon(Tolerance));
     double mass = 100.5;
-    particle->assign_mass(Phase, mass);
-    REQUIRE(particle->mass(Phase) == Approx(100.5).epsilon(Tolerance));
+    particle->assign_mass(mass);
+    REQUIRE(particle->mass() == Approx(100.5).epsilon(Tolerance));
 
     // Check stress
     Eigen::Matrix<double, 6, 1> stress;
     for (unsigned i = 0; i < stress.size(); ++i) stress(i) = 1.;
 
     for (unsigned i = 0; i < stress.size(); ++i)
-      REQUIRE(particle->stress(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->stress()(i) == Approx(0.).epsilon(Tolerance));
 
     // Check velocity
     Eigen::VectorXd velocity;
@@ -2124,53 +2096,47 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     for (unsigned i = 0; i < velocity.size(); ++i) velocity(i) = 17.51;
 
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->velocity()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_velocity(Phase, velocity) == true);
+    REQUIRE(particle->assign_velocity(velocity) == true);
     for (unsigned i = 0; i < velocity.size(); ++i)
-      REQUIRE(particle->velocity(Phase)(i) == Approx(17.51).epsilon(Tolerance));
-
-    // Check for exception
-    unsigned bad_phase = 1;
-    REQUIRE(particle->assign_velocity(bad_phase, velocity) == false);
+      REQUIRE(particle->velocity()(i) == Approx(17.51).epsilon(Tolerance));
 
     // Assign volume
-    REQUIRE(particle->assign_volume(Phase, 0.0) == false);
-    REQUIRE(particle->assign_volume(Phase, -5.0) == false);
-    REQUIRE(particle->assign_volume(Phase, 2.0) == true);
+    REQUIRE(particle->assign_volume(0.0) == false);
+    REQUIRE(particle->assign_volume(-5.0) == false);
+    REQUIRE(particle->assign_volume(2.0) == true);
     // Check volume
-    REQUIRE(particle->volume(Phase) == Approx(2.0).epsilon(Tolerance));
+    REQUIRE(particle->volume() == Approx(2.0).epsilon(Tolerance));
     // Traction
     double traction = 65.32;
     const unsigned Direction = 1;
     // Check traction
     for (unsigned i = 0; i < Dim; ++i)
-      REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+      REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
 
-    REQUIRE(particle->assign_traction(Phase, Direction, traction) == true);
+    REQUIRE(particle->assign_traction(Direction, traction) == true);
 
     // Calculate traction force = traction * volume / spacing
     traction *= 2.0 / (std::pow(2.0, 1. / Dim));
 
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
 
-    // Check for incorrect direction / phase
+    // Check for incorrect direction
     const unsigned wrong_dir = 4;
-    REQUIRE(particle->assign_traction(Phase, wrong_dir, traction) == false);
+    REQUIRE(particle->assign_traction(wrong_dir, traction) == false);
 
     // Check again to ensure value hasn't been updated
     for (unsigned i = 0; i < Dim; ++i) {
       if (i == Direction)
-        REQUIRE(particle->traction(Phase)(i) ==
-                Approx(traction).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(traction).epsilon(Tolerance));
       else
-        REQUIRE(particle->traction(Phase)(i) == Approx(0.).epsilon(Tolerance));
+        REQUIRE(particle->traction()(i) == Approx(0.).epsilon(Tolerance));
     }
   }
 
@@ -2179,7 +2145,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     mpm::Index id = 0;
     const double Tolerance = 1.E-7;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::Particle<Dim, Nphases>>(id, coords);
+        std::make_shared<mpm::Particle<Dim>>(id, coords);
 
     mpm::HDF5Particle h5_particle;
     h5_particle.id = 13;
@@ -2233,13 +2199,19 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     h5_particle.cell_id = 1;
 
+    h5_particle.volume = 2.;
+
     // Reinitialise particle from HDF5 data
     REQUIRE(particle->initialise_particle(h5_particle) == true);
 
     // Check particle id
     REQUIRE(particle->id() == h5_particle.id);
     // Check particle mass
-    REQUIRE(particle->mass(Phase) == h5_particle.mass);
+    REQUIRE(particle->mass() == h5_particle.mass);
+    // Check particle volume
+    REQUIRE(particle->volume() == h5_particle.volume);
+    // Check particle mass density
+    REQUIRE(particle->mass_density() == h5_particle.mass / h5_particle.volume);
     // Check particle status
     REQUIRE(particle->status() == h5_particle.status);
 
@@ -2251,7 +2223,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(coordinates.size() == Dim);
 
     // Check for displacement
-    auto pdisplacement = particle->displacement(Phase);
+    auto pdisplacement = particle->displacement();
     REQUIRE(pdisplacement.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pdisplacement(i) == Approx(displacement(i)).epsilon(Tolerance));
@@ -2263,32 +2235,31 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
       REQUIRE(size(i) == Approx(lsize(i)).epsilon(Tolerance));
 
     // Check velocity
-    auto pvelocity = particle->velocity(Phase);
+    auto pvelocity = particle->velocity();
     REQUIRE(pvelocity.size() == Dim);
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(pvelocity(i) == Approx(velocity(i)).epsilon(Tolerance));
 
     // Check stress
-    auto pstress = particle->stress(Phase);
+    auto pstress = particle->stress();
     REQUIRE(pstress.size() == stress.size());
     for (unsigned i = 0; i < stress.size(); ++i)
       REQUIRE(pstress(i) == Approx(stress(i)).epsilon(Tolerance));
 
     // Check strain
-    auto pstrain = particle->strain(Phase);
+    auto pstrain = particle->strain();
     REQUIRE(pstrain.size() == strain.size());
     for (unsigned i = 0; i < strain.size(); ++i)
       REQUIRE(pstrain(i) == Approx(strain(i)).epsilon(Tolerance));
 
     // Check particle volumetric strain centroid
-    REQUIRE(particle->volumetric_strain_centroid(Phase) ==
-            h5_particle.epsilon_v);
+    REQUIRE(particle->volumetric_strain_centroid() == h5_particle.epsilon_v);
 
     // Check cell id
     REQUIRE(particle->cell_id() == h5_particle.cell_id);
 
     // Write Particle HDF5 data
-    const auto h5_test = particle->hdf5(Phase);
+    const auto h5_test = particle->hdf5();
 
     REQUIRE(h5_particle.id == h5_test.id);
     REQUIRE(h5_particle.mass == h5_test.mass);

--- a/tests/write_mesh_particles.cc
+++ b/tests/write_mesh_particles.cc
@@ -4,6 +4,7 @@ namespace mpm_test {
 
 // Write JSON Configuration file
 bool write_json(unsigned dim, bool resume, const std::string& analysis,
+                const std::string& stress_update,
                 const std::string& file_name) {
   // Make json object with input files
   // 2D
@@ -52,6 +53,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
          {"poisson_ratio", 0.25}}}},
       {"analysis",
        {{"type", analysis},
+        {"stress_update", stress_update},
         {"dt", 0.001},
         {"uuid", file_name + "-" + dimension},
         {"nsteps", 10},

--- a/tests/write_mesh_particles_unitcell.cc
+++ b/tests/write_mesh_particles_unitcell.cc
@@ -4,6 +4,7 @@ namespace mpm_test {
 
 // Write JSON Configuration file
 bool write_json_unitcell(unsigned dim, const std::string& analysis,
+                         const std::string& stress_update,
                          const std::string& file_name) {
   // Make json object with input files
   // 2D
@@ -55,6 +56,7 @@ bool write_json_unitcell(unsigned dim, const std::string& analysis,
          {"poisson_ratio", 0.25}}}},
       {"analysis",
        {{"type", analysis},
+        {"stress_update", stress_update},
         {"dt", 0.001},
         {"nsteps", 10},
         {"gravity", gravity},


### PR DESCRIPTION
Refactor and remove template argument phases in the MPM Particle class to facilitate deriving particles of different phases and this helps with the MPI process as well.

Additionally, we have refactored MPMExplicitUSF2D/3D and MPMExplicitUSL2D/3D to MPMExplicit2D/3D
```
"analysis" : {
    "stress_update": "usf",
    "type": "MPMExplicit3D"
}
```
By default, it will perform usf.