### PR TITLE
:computer: CMake/build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             export MODULEPATH=$MODULEPATH:/usr/share/modulefiles
             module load mpi/openmpi-x86_64
             export CXX_COMPILER=mpicxx
-            cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_EXPORT_COMPILE_COMMANDS=On ..
+            cmake -GNinja -DMPM_BUILD_LIB=On -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_EXPORT_COMPILE_COMMANDS=On ..
             ninja -j2
             ctest -VV
             mpirun -n 2 ./mpmtest [hdf5]
@@ -32,7 +32,7 @@ jobs:
             mkdir -p build
             [ "$(ls -A build)" ] && rm -rf build/*
             cd build
-            scan-build cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=On ..
+            scan-build cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DMPM_BUILD_LIB=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=On ..
             scan-build -k -V ninja -j2
             ctest -VV
   cppcheck:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ SET(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # General compile settings
 IF (NOT CMAKE_BUILD_TYPE)
- SET(CMAKE_BUILD_TYPE "Debug")
- #SET(CMAKE_BUILD_TYPE "Release")
+ #SET(CMAKE_BUILD_TYPE "Debug")
+ SET(CMAKE_BUILD_TYPE "Release")
 ENDIF (NOT CMAKE_BUILD_TYPE)
 
 # GNU specific settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 # so we provide an option similar to BUILD_TESTING, but just for MPM.
 option(MPM_BUILD_TESTING "enable testing for mpm" ON)
 
+# CMake option for building mpm as a shared library for CI
+option(MPM_BUILD_LIB "enable libmpm" OFF)
+
 # CMake Modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -132,10 +135,13 @@ SET(mpm_src
   ${mpm_SOURCE_DIR}/src/element.cc
 )
 
+if(MPM_BUILD_LIB)
 add_library(lmpm SHARED ${mpm_src} ${mpm_vtk})
-
 add_executable(mpm ${mpm_SOURCE_DIR}/src/main.cc)
 target_link_libraries(mpm lmpm)
+else()
+add_executable(mpm ${mpm_SOURCE_DIR}/src/main.cc ${mpm_src} ${mpm_vtk})  
+endif()
 
 # Unit test
 if(MPM_BUILD_TESTING)
@@ -177,10 +183,16 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
     ${mpm_SOURCE_DIR}/tests/elements/hexahedron_gimp_element_test.cc
   )
-  add_executable(mpmtest ${test_src})
-  target_link_libraries(mpmtest lmpm)
-  add_test(NAME mpmtest COMMAND $<TARGET_FILE:mpmtest>)
-  enable_testing()
+  if(MPM_BUILD_LIB)
+    add_executable(mpmtest ${test_src})
+    target_link_libraries(mpmtest lmpm)
+    add_test(NAME mpmtest COMMAND $<TARGET_FILE:mpmtest>)
+    enable_testing()
+  else()
+    add_executable(mpmtest ${test_src} ${mpm_src} ${mpm_vtk})
+    add_test(NAME mpmtest COMMAND $<TARGET_FILE:mpmtest>)
+    enable_testing()
+  endif()
 endif()
 
 # Coverage

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Please refer to [CB-Geo MPM Documentation](https://cb-geo.github.io/mpm-doc) for
 
 If you have any issues running or compiling the MPM code please open a issue on the [CB-Geo Discourse forum](https://forum.cb-geo.com/c/mpm). 
 
-## Install dependencies
+## Running code on Docker
 
 * Docker image for CB-Geo mpm code [https://hub.docker.com/r/cbgeo/mpm](https://hub.docker.com/r/cbgeo/mpm)
 
 * Instructions for running mpm docker container: [https://github.com/cb-geo/docker-mpm/blob/master/README.md](https://github.com/cb-geo/mpm-container/blob/master/README.md).
+
+## Running code locally
 
 ### Prerequisite packages
 > The following prerequisite packages can be found in the docker image:
@@ -105,7 +107,7 @@ wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz &&
 ## Compile
 > See https://mpm-doc.cb-geo.com/ for more detailed instructions. 
 
-0. Run `mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ ..`.
+0. Run `mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ ..`.
 
 1. Run `make clean && make -jN` (where N is the number of cores).
 
@@ -115,11 +117,32 @@ wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz &&
 
 ### Compile without tests [Editing CMake options]
 
-To compile without tests run: `mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DMPM_BUILD_TESTING=Off  -DCMAKE_CXX_COMPILER=g++ ..`.
+To compile without tests run: `mkdir build && cd build && cmake -DMPM_BUILD_TESTING=Off  -DCMAKE_CXX_COMPILER=g++ ..`.
 
-## Compile with Ninja build system
+## Compile with MPI (Running on a cluster)
 
-0. Run `mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ ..`.
+The CB-Geo mpm code can be compiled with `MPI` to distribute the workload across compute nodes in a cluster.
+
+Additional steps to load `OpenMPI` on Fedora:
+
+```
+source /etc/profile.d/modules.sh
+export MODULEPATH=$MODULEPATH:/usr/share/modulefiles
+module load mpi/openmpi-x86_64
+```
+
+Compile with OpenMPI:
+
+```
+mkdir build && cd build 
+export CXX_COMPILER=mpicxx
+cmake -DCMAKE_BUILD_TYPE=Release -DMETIS_DIR=~/workspace/metis/ -DPARMETIS_DIR=~/workspace/parmetis/ ..
+make -jN
+```
+
+### Compile with Ninja build system [Alternative to Make]
+
+0. Run `mkdir build && cd build && cmake -GNinja -DCMAKE_CXX_COMPILER=g++ ..`.
 
 1. Run `ninja`
 
@@ -164,27 +187,6 @@ Where:
 
    -h,  --help
      Displays usage information and exits.
-```
-
-## Compile with MPI (Running on a cluster)
-
-The CB-Geo mpm code can be compiled with `MPI` to distribute the workload across compute nodes in a cluster.
-
-Additional steps to load `OpenMPI` on Fedora:
-
-```
-source /etc/profile.d/modules.sh
-export MODULEPATH=$MODULEPATH:/usr/share/modulefiles
-module load mpi/openmpi-x86_64
-```
-
-Compile with OpenMPI:
-
-```
-mkdir build && cd build 
-export CXX_COMPILER=mpicxx
-cmake -DCMAKE_BUILD_TYPE=Release -DMETIS_DIR=~/workspace/metis/ -DPARMETIS_DIR=~/workspace/parmetis/ ..
-make -jN
 ```
 
 ### Running the code with MPI


### PR DESCRIPTION
Setting the default option of build to `release`. Compiling the `mpm` code directly instead of a shared library. On CI we still use the library approach for faster runtimes.