### PR TITLE
:art: Write a parallel vtp file that fetches all vector attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/factory_test.cc
     ${mpm_SOURCE_DIR}/tests/geometry_test.cc
     ${mpm_SOURCE_DIR}/tests/elements/hexahedron_element_test.cc
+    ${mpm_SOURCE_DIR}/tests/elements/hexahedron_gimp_element_test.cc
     ${mpm_SOURCE_DIR}/tests/elements/hexahedron_quadrature_test.cc
     ${mpm_SOURCE_DIR}/tests/elements/quadrilateral_element_test.cc
     ${mpm_SOURCE_DIR}/tests/elements/quadrilateral_gimp_element_test.cc
@@ -179,9 +180,9 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/particle_test.cc
     ${mpm_SOURCE_DIR}/tests/point_in_cell_test.cc
     ${mpm_SOURCE_DIR}/tests/read_mesh_ascii_test.cc
+    ${mpm_SOURCE_DIR}/tests/vtk_writer_test.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles.cc
     ${mpm_SOURCE_DIR}/tests/write_mesh_particles_unitcell.cc
-    ${mpm_SOURCE_DIR}/tests/elements/hexahedron_gimp_element_test.cc
   )
   if(MPM_BUILD_LIB)
     add_executable(mpmtest ${test_src})

--- a/include/io.h
+++ b/include/io.h
@@ -75,11 +75,13 @@ class IO {
   //! \param[in] file_extension File Extension (*.vtk or *.vtp)
   //! \param[in] step Current step
   //! \param[in] max_steps Total number of steps to be solved
+  //! \param[in] parallel Write output as parallel file system
   //! \return file_name File name with the correct attribute and a VTK extension
   boost::filesystem::path output_file(const std::string& attribute,
                                       const std::string& file_extension,
                                       const std::string& analysis_id,
-                                      unsigned step, unsigned max_steps);
+                                      unsigned step, unsigned max_steps,
+                                      bool parallel = true);
 
  private:
   //! Number of parallel threads

--- a/include/vtk_writer.h
+++ b/include/vtk_writer.h
@@ -17,6 +17,7 @@
 #include <vtkXMLPolyDataWriter.h>
 #include <vtkZLibDataCompressor.h>
 
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -44,6 +45,11 @@ class VtkWriter {
   void write_mesh(const std::string& filename,
                   const std::vector<Eigen::Vector3d>& coordinates,
                   const std::vector<std::array<mpm::Index, 2>>& node_pairs);
+
+  //! Write Parallel VTK file
+  void write_parallel_vtk(const std::string& filename,
+                          const std::string& attribute, int mpi_size,
+                          unsigned step, unsigned max_steps);
 
  private:
   //! Vector of nodal coordinates

--- a/src/io.cc
+++ b/src/io.cc
@@ -101,8 +101,8 @@ bool mpm::IO::check_file(const std::string& filename) {
 boost::filesystem::path mpm::IO::output_file(const std::string& attribute,
                                              const std::string& file_extension,
                                              const std::string& analysis_id,
-                                             unsigned step,
-                                             unsigned max_steps) {
+                                             unsigned step, unsigned max_steps,
+                                             bool parallel) {
   std::stringstream file_name;
   std::string path = this->output_folder();
 
@@ -116,7 +116,7 @@ boost::filesystem::path mpm::IO::output_file(const std::string& attribute,
   int mpi_size;
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-  if (mpi_size > 1) {
+  if (mpi_size > 1 && parallel) {
     const std::string rank_size =
         "-" + std::to_string(mpi_rank) + "_" + std::to_string(mpi_size) + "-";
     file_name << rank_size;

--- a/tests/vtk_writer_test.cc
+++ b/tests/vtk_writer_test.cc
@@ -20,6 +20,37 @@ TEST_CASE("VTK Writer is checked", "[vtk][writer]") {
     vtk_writer->write_parallel_vtk(parallel_vtk_file, attribute, mpi_size, step,
                                    max_steps);
 
+    // Check file data
+    std::string ppolydata =
+        "<?xml version=\"1.0\"?>\n<VTKFile type=\"PPolyData\" version=\"0.1\" "
+        "byte_order=\"LittleEndian\" "
+        "compressor=\"vtkZLibDataCompressor\">\n<PPolyData "
+        "GhostLevel=\"0\">\n\t<PPointData Vectors=\"" +
+        attribute +
+        "\">\n\t\t<PDataArray "
+        "type=\"Float64\" Name=\"" +
+        attribute +
+        "\" "
+        "NumberOfComponents=\"3\"/>\n\t</"
+        "PPointData>\n\n\t<PPoints>\n\t\t<PDataArray "
+        "type=\"Float32\" Name=\"Points\" "
+        "NumberOfComponents=\"3\"/>\n\t</PPoints>\n";
+
+    for (unsigned i = 0; i < mpi_size; ++i)
+      ppolydata += "\n\t<Piece Source=\"stress-" + std::to_string(i) + "_" +
+                   std::to_string(mpi_size) + "-01000.vtp\"/>";
+
+    ppolydata += "\n</PPolyData>\n\n</VTKFile>";
+
+    // Check if file exists
     REQUIRE(boost::filesystem::exists(parallel_vtk_file) == true);
+
+    std::ifstream ifs(parallel_vtk_file);
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+
+    // Check file content
+    REQUIRE(content.length() == ppolydata.length());
+    REQUIRE(content == ppolydata);
   }
 }

--- a/tests/vtk_writer_test.cc
+++ b/tests/vtk_writer_test.cc
@@ -1,0 +1,25 @@
+#include <boost/filesystem.hpp>
+
+#include "catch.hpp"
+
+#include "vtk_writer.h"
+
+// Check ReadMeshAscii
+TEST_CASE("VTK Writer is checked", "[vtk][writer]") {
+
+  SECTION("Check parallel vtk file ") {
+    std::vector<Eigen::Matrix<double, 3, 1>> coordinates;
+    // VTK PolyData writer
+    auto vtk_writer = std::make_unique<VtkWriter>(coordinates);
+
+    const std::string parallel_vtk_file = "parallel_vtk.pvtp";
+    const std::string attribute = "stress";
+    int mpi_size = 2;
+    unsigned step = 1000;
+    unsigned max_steps = 10000;
+    vtk_writer->write_parallel_vtk(parallel_vtk_file, attribute, mpi_size, step,
+                                   max_steps);
+
+    REQUIRE(boost::filesystem::exists(parallel_vtk_file) == true);
+  }
+}


### PR DESCRIPTION
When running an MPI process, the VTP file outputs are split across multiple processors and are named based on their MPI rank. ParaView `pvtp` stitches all the files together and can be loaded easily, instead of multiple MPI rank `vtp` files.