### PR TITLE
:computer: Fixes #512 Generate material points and add to mesh directly

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -290,8 +290,10 @@ class Mesh {
 
   //! Generate points
   //! \param[in] nquadratures Number of points per direction in cell
+  //! \param[in] particle_type Particle type
   //! \retval point Material point coordinates
-  std::vector<VectorDim> generate_material_points(unsigned nquadratures = 1);
+  void generate_material_points(unsigned nquadratures,
+                                const std::string& particle_type);
 
   //! Initialise material models
   //! \param[in] materials Material models

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -409,33 +409,43 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
 
     // Initialize cell
     REQUIRE(cell1->initialise() == true);
+    // Particle type 2D
+    const std::string particle_type = "P2D";
 
     // Generate material points in cell
-    auto points = mesh->generate_material_points(1);
-    REQUIRE(points.size() == 0);
+    REQUIRE(mesh->nparticles() == 0);
+
+    mesh->generate_material_points(1, particle_type);
+    REQUIRE(mesh->nparticles() == 0);
 
     // Add cell 1 and check
     REQUIRE(mesh->add_cell(cell1) == true);
 
-    // Generate material points in cell
-    points = mesh->generate_material_points(1);
-    REQUIRE(points.size() == 1);
+    SECTION("Check generating 1 particle / cell") {
+      // Generate material points in cell
+      mesh->generate_material_points(1, particle_type);
+      REQUIRE(mesh->nparticles() == 1);
+    }
 
-    points = mesh->generate_material_points(2);
-    REQUIRE(points.size() == 4);
+    SECTION("Check generating 2 particle / cell") {
+      mesh->generate_material_points(2, particle_type);
+      REQUIRE(mesh->nparticles() == 4);
+    }
 
-    points = mesh->generate_material_points(3);
-    REQUIRE(points.size() == 9);
+    SECTION("Check generating 3 particle / cell") {
+      mesh->generate_material_points(3, particle_type);
+      REQUIRE(mesh->nparticles() == 9);
+    }
 
     // Particle 1
     coords << 1.0, 1.0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim>>(0, coords);
+        std::make_shared<mpm::Particle<Dim>>(100, coords);
 
     // Particle 2
     coords << 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim>>(1, coords);
+        std::make_shared<mpm::Particle<Dim>>(101, coords);
 
     // Add particle 1 and check
     REQUIRE(mesh->add_particle(particle1) == true);
@@ -1379,32 +1389,41 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     // Initialise cell and compute volume
     REQUIRE(cell1->initialise() == true);
 
+    // Particle type 2D
+    const std::string particle_type = "P3D";
+
     // Generate material points in cell
-    auto points = mesh->generate_material_points(1);
-    REQUIRE(points.size() == 0);
+    mesh->generate_material_points(1, particle_type);
+    REQUIRE(mesh->nparticles() == 0);
 
     // Add cell 1 and check
     REQUIRE(mesh->add_cell(cell1) == true);
 
-    // Generate material points in cell
-    points = mesh->generate_material_points(1);
-    REQUIRE(points.size() == 1);
+    SECTION("Check generating 1 particle / cell") {
+      // Generate material points in cell
+      mesh->generate_material_points(1, particle_type);
+      REQUIRE(mesh->nparticles() == 1);
+    }
 
-    points = mesh->generate_material_points(2);
-    REQUIRE(points.size() == 8);
+    SECTION("Check generating 2 particle / cell") {
+      mesh->generate_material_points(2, particle_type);
+      REQUIRE(mesh->nparticles() == 8);
+    }
 
-    points = mesh->generate_material_points(3);
-    REQUIRE(points.size() == 27);
+    SECTION("Check generating 3 particle / cell") {
+      mesh->generate_material_points(3, particle_type);
+      REQUIRE(mesh->nparticles() == 27);
+    }
 
     // Particle 1
     coords << 1.0, 1.0, 1.0;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle1 =
-        std::make_shared<mpm::Particle<Dim>>(0, coords);
+        std::make_shared<mpm::Particle<Dim>>(100, coords);
 
     // Particle 2
     coords << 1.5, 1.5, 1.5;
     std::shared_ptr<mpm::ParticleBase<Dim>> particle2 =
-        std::make_shared<mpm::Particle<Dim>>(1, coords);
+        std::make_shared<mpm::Particle<Dim>>(101, coords);
 
     // Add particle 1 and check
     REQUIRE(mesh->add_particle(particle1) == true);

--- a/tests/mpm_explicit_usf_test.cc
+++ b/tests/mpm_explicit_usf_test.cc
@@ -50,7 +50,6 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);
@@ -129,9 +128,8 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
     // Initialise materials
     REQUIRE(mpm->initialise_materials() == true);
 
-    // Reinitialise mesh and particles
+    // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);

--- a/tests/mpm_explicit_usf_unitcell_test.cc
+++ b/tests/mpm_explicit_usf_unitcell_test.cc
@@ -49,7 +49,6 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked in unitcells",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);
@@ -107,7 +106,6 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked in unitcells",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -50,7 +50,6 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);
@@ -131,7 +130,6 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);

--- a/tests/mpm_explicit_usl_unitcell_test.cc
+++ b/tests/mpm_explicit_usl_unitcell_test.cc
@@ -49,7 +49,6 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked in unitcells",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);
@@ -107,7 +106,6 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked in unitcells",
 
     // Reinitialise mesh
     REQUIRE(mpm->initialise_mesh() == false);
-    REQUIRE(mpm->initialise_particles() == false);
 
     // Renitialise materials
     REQUIRE(mpm->initialise_materials() == false);


### PR DESCRIPTION
Add particle to mesh directly when generated instead of going through the process of locating the particles again.