### PR TITLE
Refactor pressure computation to material

### DIFF
--- a/include/material/bingham.h
+++ b/include/material/bingham.h
@@ -42,11 +42,6 @@ class Bingham : public Material<Tdim> {
     return state_vars;
   }
 
-  //! Thermodynamic pressure
-  //! \param[in] volumetric_strain dVolumetric_strain
-  //! \retval pressure Pressure for volumetric strain
-  double thermodynamic_pressure(double volumetric_strain) const override;
-
   //! Compute stress
   //! \param[in] stress Stress
   //! \param[in] dstrain Strain
@@ -66,6 +61,11 @@ class Bingham : public Material<Tdim> {
   using Material<Tdim>::console_;
 
  private:
+  //! Thermodynamic pressure
+  //! \param[in] volumetric_strain dVolumetric_strain
+  //! \retval pressure Pressure for volumetric strain
+  double thermodynamic_pressure(double volumetric_strain) const;
+
   //! Dirac delta function in Voigt notation
   Eigen::Matrix<double, 6, 1> dirac_delta() const;
 

--- a/include/material/bingham.h
+++ b/include/material/bingham.h
@@ -38,7 +38,7 @@ class Bingham : public Material<Tdim> {
   //! Initialise history variables
   //! \retval state_vars State variables with history
   mpm::dense_map initialise_state_variables() override {
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = {{"pressure", 0.0}};
     return state_vars;
   }
 

--- a/include/material/bingham.h
+++ b/include/material/bingham.h
@@ -37,10 +37,7 @@ class Bingham : public Material<Tdim> {
 
   //! Initialise history variables
   //! \retval state_vars State variables with history
-  mpm::dense_map initialise_state_variables() override {
-    mpm::dense_map state_vars = {{"pressure", 0.0}};
-    return state_vars;
-  }
+  mpm::dense_map initialise_state_variables() override;
 
   //! Compute stress
   //! \param[in] stress Stress

--- a/include/material/bingham.tcc
+++ b/include/material/bingham.tcc
@@ -83,7 +83,7 @@ Eigen::Matrix<double, 6, 1> mpm::Bingham<Tdim>::compute_stress(
   // stress = -thermodynamic_pressure I + tau, where I is identity matrix or
   // direc_delta in Voigt notation
   const Eigen::Matrix<double, 6, 1> updated_stress =
-      -ptr->pressure() * this->dirac_delta() + tau;
+      -(*state_vars).at("pressure") * this->dirac_delta() + tau;
 
   return updated_stress;
 }

--- a/include/material/bingham.tcc
+++ b/include/material/bingham.tcc
@@ -22,6 +22,13 @@ mpm::Bingham<Tdim>::Bingham(unsigned id, const Json& material_properties)
   }
 }
 
+//! Initialise history variables
+template <unsigned Tdim>
+mpm::dense_map mpm::Bingham<Tdim>::initialise_state_variables() {
+  mpm::dense_map state_vars = {{"pressure", 0.0}};
+  return state_vars;
+}
+
 //! Compute pressure
 template <unsigned Tdim>
 double mpm::Bingham<Tdim>::thermodynamic_pressure(

--- a/include/material/bingham.tcc
+++ b/include/material/bingham.tcc
@@ -74,6 +74,10 @@ Eigen::Matrix<double, 6, 1> mpm::Bingham<Tdim>::compute_stress(
   const double trace_invariant2 = 0.5 * (tau.head(3)).dot(tau.head(3));
   if (trace_invariant2 < (tau0_ * tau0_)) tau.setZero();
 
+  // Update pressure
+  (*state_vars).at("pressure") +=
+      this->thermodynamic_pressure(ptr->dvolumetric_strain());
+
   // Update volumetric and deviatoric stress
   // thermodynamic pressure is from material point
   // stress = -thermodynamic_pressure I + tau, where I is identity matrix or

--- a/include/material/linear_elastic.h
+++ b/include/material/linear_elastic.h
@@ -41,11 +41,6 @@ class LinearElastic : public Material<Tdim> {
     return state_vars;
   }
 
-  //! Thermodynamic pressure
-  //! \param[in] volumetric_strain dVolumetric_strain
-  //! \retval pressure Pressure for volumetric strain
-  double thermodynamic_pressure(double volumetric_strain) const override;
-
   //! Compute stress
   //! \param[in] stress Stress
   //! \param[in] dstrain Strain

--- a/include/material/linear_elastic.tcc
+++ b/include/material/linear_elastic.tcc
@@ -21,14 +21,6 @@ mpm::LinearElastic<Tdim>::LinearElastic(unsigned id,
   }
 }
 
-//! Compute pressure
-template <unsigned Tdim>
-double mpm::LinearElastic<Tdim>::thermodynamic_pressure(
-    double volumetric_strain) const {
-  // Bulk modulus
-  return (-bulk_modulus_ * volumetric_strain);
-}
-
 //! Return elastic tensor
 template <unsigned Tdim>
 bool mpm::LinearElastic<Tdim>::compute_elastic_tensor() {

--- a/include/material/material.h
+++ b/include/material/material.h
@@ -63,11 +63,6 @@ class Material {
   //! Initialise history variables
   virtual mpm::dense_map initialise_state_variables() = 0;
 
-  //! Compute thermodynamic pressure
-  //! \param[in] volumetric_strain dVolumetric_strain
-  //! \retval pressure Thermodynamic pressure for volumetric strain
-  virtual double thermodynamic_pressure(double volumetric_strain) const = 0;
-
   //! Compute stress
   //! \param[in] stress Stress
   //! \param[in] dstrain Strain

--- a/include/material/newtonian.h
+++ b/include/material/newtonian.h
@@ -38,7 +38,7 @@ class Newtonian : public Material<Tdim> {
   //! Initialise history variables
   //! \retval state_vars State variables with history
   mpm::dense_map initialise_state_variables() override {
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = {{"pressure", 0.0}};
     return state_vars;
   }
 

--- a/include/material/newtonian.h
+++ b/include/material/newtonian.h
@@ -42,11 +42,6 @@ class Newtonian : public Material<Tdim> {
     return state_vars;
   }
 
-  //! Thermodynamic pressure
-  //! \param[in] volumetric_strain dVolumetric_strain
-  //! \retval pressure Pressure for volumetric strain
-  double thermodynamic_pressure(double volumetric_strain) const override;
-
   //! Compute stress
   //! \param[in] stress Stress
   //! \param[in] dstrain Strain
@@ -66,6 +61,11 @@ class Newtonian : public Material<Tdim> {
   using Material<Tdim>::console_;
 
  private:
+  //! Thermodynamic pressure
+  //! \param[in] volumetric_strain dVolumetric_strain
+  //! \retval pressure Pressure for volumetric strain
+  double thermodynamic_pressure(double volumetric_strain) const;
+
   //! Density
   double density_{std::numeric_limits<double>::max()};
   //! Bulk modulus

--- a/include/material/newtonian.h
+++ b/include/material/newtonian.h
@@ -37,10 +37,7 @@ class Newtonian : public Material<Tdim> {
 
   //! Initialise history variables
   //! \retval state_vars State variables with history
-  mpm::dense_map initialise_state_variables() override {
-    mpm::dense_map state_vars = {{"pressure", 0.0}};
-    return state_vars;
-  }
+  mpm::dense_map initialise_state_variables() override;
 
   //! Compute stress
   //! \param[in] stress Stress

--- a/include/material/newtonian.tcc
+++ b/include/material/newtonian.tcc
@@ -1,5 +1,3 @@
-#include <iostream>
-
 //! Constructor with material properties
 template <unsigned Tdim>
 mpm::Newtonian<Tdim>::Newtonian(unsigned id, const Json& material_properties)
@@ -15,6 +13,13 @@ mpm::Newtonian<Tdim>::Newtonian(unsigned id, const Json& material_properties)
     console_->error("Material parameter not set: {} {}\n", except.what(),
                     except.id);
   }
+}
+
+//! Initialise history variables
+template <unsigned Tdim>
+mpm::dense_map mpm::Newtonian<Tdim>::initialise_state_variables() {
+  mpm::dense_map state_vars = {{"pressure", 0.0}};
+  return state_vars;
 }
 
 //! Compute pressure

--- a/include/material/newtonian.tcc
+++ b/include/material/newtonian.tcc
@@ -1,3 +1,5 @@
+#include <iostream>
+
 //! Constructor with material properties
 template <unsigned Tdim>
 mpm::Newtonian<Tdim>::Newtonian(unsigned id, const Json& material_properties)
@@ -29,7 +31,11 @@ Eigen::Matrix<double, 6, 1> mpm::Newtonian<2>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain, const ParticleBase<2>* ptr,
     mpm::dense_map* state_vars) {
 
-  const double pressure = ptr->pressure();
+  // const double pressure = ptr->pressure();
+  // Update pressure
+  (*state_vars).at("pressure") +=
+      this->thermodynamic_pressure(ptr->dvolumetric_strain());
+  const double pressure = (*state_vars).at("pressure");
 
   const double volumetric_strain = dstrain(0) + dstrain(1);
 
@@ -53,7 +59,10 @@ Eigen::Matrix<double, 6, 1> mpm::Newtonian<3>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain, const ParticleBase<3>* ptr,
     mpm::dense_map* state_vars) {
 
-  const double pressure = ptr->pressure();
+  // Update pressure
+  (*state_vars).at("pressure") +=
+      this->thermodynamic_pressure(ptr->dvolumetric_strain());
+  const double pressure = (*state_vars).at("pressure");
 
   const double volumetric_strain = dstrain(0) + dstrain(1) + dstrain(2);
 

--- a/include/particle.h
+++ b/include/particle.h
@@ -230,11 +230,15 @@ class Particle : public ParticleBase<Tdim> {
   bool map_pressure_to_nodes() override;
 
   //! Compute pressure smoothing of the particle based on nodal pressure
+  //! $$\hat{p}_p = \sum_{i = 1}^{n_n} N_i(x_p) p_i$$
   bool compute_pressure_smoothing() override;
 
   //! Return pressure of the particles
-  //! $$\hat{p}_p = \sum_{i = 1}^{n_n} N_i(x_p) p_i$$
-  double pressure() const override { return pressure_; }
+  double pressure() const override {
+    return (state_variables_.find("pressure") != state_variables_.end())
+               ? state_variables_.at("pressure")
+               : 0.;
+  }
 
   //! Return vector data of particles
   //! \param[in] property Property string

--- a/include/particle.h
+++ b/include/particle.h
@@ -279,8 +279,6 @@ class Particle : public ParticleBase<Tdim> {
   Eigen::Matrix<double, 1, Tdim> size_;
   //! Size of particle in natural coordinates
   Eigen::Matrix<double, 1, Tdim> natural_size_;
-  //! Pressure
-  double pressure_;
   //! Stresses
   Eigen::Matrix<double, 6, 1> stress_;
   //! Strains

--- a/include/particle.h
+++ b/include/particle.h
@@ -222,10 +222,6 @@ class Particle : public ParticleBase<Tdim> {
     return state_variables_.at(var);
   }
 
-  //! Update pressure of the particles
-  //! \param[in] dvolumetric_strain dvolumetric strain in a cell
-  bool update_pressure(double dvolumetric_strain) override;
-
   //! Map particle pressure to nodes
   bool map_pressure_to_nodes() override;
 

--- a/include/particle.tcc
+++ b/include/particle.tcc
@@ -542,9 +542,6 @@ void mpm::Particle<Tdim>::compute_strain(double dt) {
   // Assign volumetric strain at centroid
   dvolumetric_strain_ = dt * strain_rate_centroid.head(Tdim).sum();
   volumetric_strain_centroid_ += dvolumetric_strain_;
-
-  // Update thermodynamic pressure
-  // this->update_pressure(dvolumetric_strain_);
 }
 
 // Compute stress
@@ -681,25 +678,6 @@ bool mpm::Particle<Tdim>::compute_updated_position(double dt,
       throw std::runtime_error(
           "Cell is not initialised! "
           "cannot compute updated coordinates of the particle");
-    }
-  } catch (std::exception& exception) {
-    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
-    status = false;
-  }
-  return status;
-}
-
-// Update pressure
-template <unsigned Tdim>
-bool mpm::Particle<Tdim>::update_pressure(double dvolumetric_strain) {
-  bool status = true;
-  try {
-    // Check if material ptr is valid
-    if (material_ != nullptr) {
-      // Update pressure
-      this->pressure_ += material_->thermodynamic_pressure(dvolumetric_strain);
-    } else {
-      throw std::runtime_error("Material is invalid");
     }
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());

--- a/include/particle_base.h
+++ b/include/particle_base.h
@@ -186,9 +186,6 @@ class ParticleBase {
   //! Map internal force
   virtual bool map_internal_force() = 0;
 
-  //! Update pressure of the particles
-  virtual bool update_pressure(double dvolumetric_strain) = 0;
-
   //! Map particle pressure to nodes
   virtual bool map_pressure_to_nodes() = 0;
 

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -86,7 +86,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
-      REQUIRE(state_variables.empty() == true);
+      REQUIRE(state_variables.size() == 1);
     }
   }
 
@@ -155,7 +155,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     dstrain(5) = 0.0000000;
 
     // Compute updated stress
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = material->initialise_state_variables();
     mpm::Material<Dim>::Vector6d stress;
     stress.setZero();
     auto check_stress =
@@ -241,7 +241,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     dstrain(5) = 0.0000000;
 
     // Compute updated stress
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = material->initialise_state_variables();
     mpm::Material<Dim>::Vector6d stress;
     stress.setZero();
     auto check_stress =
@@ -336,8 +336,8 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     dstrain(5) = 0.0000000;
 
     // Compute updated stress
+    mpm::dense_map state_vars = material->initialise_state_variables();
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);
@@ -426,7 +426,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
-      REQUIRE(state_variables.empty() == true);
+      REQUIRE(state_variables.size() == 1);
     }
   }
 
@@ -513,7 +513,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
 
     // Compute updated stress
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = material->initialise_state_variables();
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);
@@ -616,7 +616,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
 
     // Compute updated stress
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = material->initialise_state_variables();
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);
@@ -727,7 +727,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
 
     // Compute updated stress
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
+    mpm::dense_map state_vars = material->initialise_state_variables();
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -350,6 +350,14 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(check_stress(3) == Approx(-233.778008402801).epsilon(Tolerance));
     REQUIRE(check_stress(4) == Approx(0.000e+00).epsilon(Tolerance));
     REQUIRE(check_stress(5) == Approx(0.000e+00).epsilon(Tolerance));
+
+    // Calculate modulus values
+    const double K = 1.0E+7 / (3.0 * (1. - 2. * 0.3));
+    const double volumetric_strain = -0.625;
+    REQUIRE(particle->dvolumetric_strain() ==
+            Approx(volumetric_strain).epsilon(Tolerance));
+    REQUIRE(state_vars.at("pressure") ==
+            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 }
 
@@ -737,7 +745,9 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     // Calculate modulus values
     const double K = 1.0E+7 / (3.0 * (1. - 2. * 0.3));
     // Calculate pressure
-    const double volumetric_strain = 0.;
+    const double volumetric_strain = -0.1875;
+    REQUIRE(particle->dvolumetric_strain() ==
+            Approx(volumetric_strain).epsilon(Tolerance));
     REQUIRE(state_vars.at("pressure") ==
             Approx(-K * volumetric_strain).epsilon(Tolerance));
   }

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -80,6 +80,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
       REQUIRE(state_variables.size() == 1);
+      REQUIRE(state_variables.at("pressure") == 0.0);
     }
   }
 
@@ -428,6 +429,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
       REQUIRE(state_variables.size() == 1);
+      REQUIRE(state_variables.at("pressure") == 0.0);
     }
   }
 

--- a/tests/material/bingham_test.cc
+++ b/tests/material/bingham_test.cc
@@ -76,13 +76,6 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(material->template property<double>("poisson_ratio") ==
             Approx(jmaterial["poisson_ratio"]).epsilon(Tolerance));
 
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
-
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
@@ -169,6 +162,13 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     REQUIRE(check_stress(3) == Approx(0.000e+00).epsilon(Tolerance));
     REQUIRE(check_stress(4) == Approx(0.000e+00).epsilon(Tolerance));
     REQUIRE(check_stress(5) == Approx(0.000e+00).epsilon(Tolerance));
+
+    // Calculate modulus values
+    const double K = 1.0E+7 / (3.0 * (1. - 2. * 0.3));
+    // Calculate pressure
+    const double volumetric_strain = 0.;
+    REQUIRE(state_vars.at("pressure") ==
+            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 
   SECTION("Bingham check stresses with strain rate, no yield") {
@@ -415,13 +415,6 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
             Approx(jmaterial["youngs_modulus"]).epsilon(Tolerance));
     REQUIRE(material->template property<double>("poisson_ratio") ==
             Approx(jmaterial["poisson_ratio"]).epsilon(Tolerance));
-
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
 
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
@@ -740,5 +733,12 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     REQUIRE(check_stress(3) == Approx(-59.8955052203).epsilon(Tolerance));
     REQUIRE(check_stress(4) == Approx(-19.9651684068).epsilon(Tolerance));
     REQUIRE(check_stress(5) == Approx(-199.6516840678).epsilon(Tolerance));
+
+    // Calculate modulus values
+    const double K = 1.0E+7 / (3.0 * (1. - 2. * 0.3));
+    // Calculate pressure
+    const double volumetric_strain = 0.;
+    REQUIRE(state_vars.at("pressure") ==
+            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 }

--- a/tests/material/linear_elastic_test.cc
+++ b/tests/material/linear_elastic_test.cc
@@ -81,30 +81,6 @@ TEST_CASE("LinearElastic is checked in 2D", "[material][linear_elastic][2D]") {
     }
   }
 
-  //! Check thermodynamic pressure
-  SECTION("LinearElastic check thermodynamic pressure") {
-    unsigned id = 0;
-    auto material =
-        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
-            "LinearElastic2D", std::move(id), jmaterial);
-    REQUIRE(material->id() == 0);
-
-    // Get material properties
-    REQUIRE(material->template property<double>("density") ==
-            Approx(jmaterial["density"]).epsilon(Tolerance));
-
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    const double G = 3846153.846153846;
-    const double a1 = 13461538.461566667;
-    const double a2 = 5769230.769166667;
-
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
-  }
-
   SECTION("LinearElastic check stresses") {
     unsigned id = 0;
     auto material =
@@ -240,30 +216,6 @@ TEST_CASE("LinearElastic is checked in 3D", "[material][linear_elastic][3D]") {
       mpm::dense_map state_variables = material->initialise_state_variables();
       REQUIRE(state_variables.empty() == true);
     }
-  }
-
-  //! Check thermodynamic pressure
-  SECTION("LinearElastic check thermodynamic pressure") {
-    unsigned id = 0;
-    auto material =
-        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
-            "LinearElastic3D", std::move(id), jmaterial);
-    REQUIRE(material->id() == 0);
-
-    // Get material properties
-    REQUIRE(material->template property<double>("density") ==
-            Approx(jmaterial["density"]).epsilon(Tolerance));
-
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    const double G = 3846153.846153846;
-    const double a1 = 13461538.461566667;
-    const double a2 = 5769230.769166667;
-
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 
   SECTION("LinearElastic check stresses") {

--- a/tests/material/newtonian_test.cc
+++ b/tests/material/newtonian_test.cc
@@ -67,13 +67,6 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     REQUIRE(material->template property<double>("density") ==
             Approx(jmaterial["density"]).epsilon(Tolerance));
 
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
-
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
@@ -165,6 +158,13 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     REQUIRE(check_stress(3) == Approx(0.000002255).epsilon(Tolerance));
     REQUIRE(check_stress(4) == Approx(0.000e+00).epsilon(Tolerance));
     REQUIRE(check_stress(5) == Approx(0.000e+00).epsilon(Tolerance));
+
+    // Calculate modulus values
+    const double K = 8333333.333333333;
+    // Calculate pressure
+    const double volumetric_strain = 0.;
+    REQUIRE(state_vars.at("pressure") ==
+            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 }
 
@@ -221,13 +221,6 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     // Get material properties
     REQUIRE(material->template property<double>("density") ==
             Approx(jmaterial["density"]).epsilon(Tolerance));
-
-    // Calculate modulus values
-    const double K = 8333333.333333333;
-    // Calculate pressure
-    const double volumetric_strain = 1.0E-5;
-    REQUIRE(material->thermodynamic_pressure(volumetric_strain) ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
 
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
@@ -337,5 +330,12 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     REQUIRE(check_stress(3) == Approx(0.000000451).epsilon(Tolerance));
     REQUIRE(check_stress(4) == Approx(0.000000902).epsilon(Tolerance));
     REQUIRE(check_stress(5) == Approx(0.000001353).epsilon(Tolerance));
+
+    // Calculate modulus values
+    const double K = 8333333.333333333;
+    // Calculate pressure
+    const double volumetric_strain = 0.;
+    REQUIRE(state_vars.at("pressure") ==
+            Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
 }

--- a/tests/material/newtonian_test.cc
+++ b/tests/material/newtonian_test.cc
@@ -71,6 +71,7 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
       REQUIRE(state_variables.size() == 1);
+      REQUIRE(state_variables.at("pressure") == 0.0);
     }
   }
 
@@ -228,6 +229,7 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
       REQUIRE(state_variables.size() == 1);
+      REQUIRE(state_variables.at("pressure") == 0.0);
     }
   }
 

--- a/tests/material/newtonian_test.cc
+++ b/tests/material/newtonian_test.cc
@@ -162,7 +162,9 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     // Calculate modulus values
     const double K = 8333333.333333333;
     // Calculate pressure
-    const double volumetric_strain = 0.;
+    const double volumetric_strain = -0.00625;
+    REQUIRE(particle->dvolumetric_strain() ==
+            Approx(volumetric_strain).epsilon(Tolerance));
     REQUIRE(state_vars.at("pressure") ==
             Approx(-K * volumetric_strain).epsilon(Tolerance));
   }
@@ -334,7 +336,9 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     // Calculate modulus values
     const double K = 8333333.333333333;
     // Calculate pressure
-    const double volumetric_strain = 0.;
+    const double volumetric_strain = -0.001875;
+    REQUIRE(particle->dvolumetric_strain() ==
+            Approx(volumetric_strain).epsilon(Tolerance));
     REQUIRE(state_vars.at("pressure") ==
             Approx(-K * volumetric_strain).epsilon(Tolerance));
   }

--- a/tests/material/newtonian_test.cc
+++ b/tests/material/newtonian_test.cc
@@ -77,7 +77,7 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
-      REQUIRE(state_variables.empty() == true);
+      REQUIRE(state_variables.size() == 1);
     }
   }
 
@@ -151,8 +151,8 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     dstrain(5) = 0.0000000;
 
     // Compute updated stress
+    mpm::dense_map state_vars = material->initialise_state_variables();
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);
@@ -232,7 +232,7 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
       mpm::dense_map state_variables = material->initialise_state_variables();
-      REQUIRE(state_variables.empty() == true);
+      REQUIRE(state_variables.size() == 1);
     }
   }
 
@@ -323,8 +323,8 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     dstrain(5) = 0.0000300;
 
     // Compute updated stress
+    mpm::dense_map state_vars = material->initialise_state_variables();
     mpm::Material<Dim>::Vector6d stress;
-    mpm::dense_map state_vars;
     stress.setZero();
     auto check_stress =
         material->compute_stress(stress, dstrain, particle.get(), &state_vars);

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -850,8 +850,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Check updated pressure
     const double K = 8333333.333333333;
-    REQUIRE(particle->pressure() ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
+    REQUIRE(particle->pressure() == 0.0);
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(1.0).epsilon(Tolerance));
@@ -1876,8 +1875,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(particle->compute_mass() == true);
     REQUIRE(particle->map_mass_momentum_to_nodes() == true);
 
-    REQUIRE(particle->map_pressure_to_nodes() == true);
-    REQUIRE(particle->compute_pressure_smoothing() == true);
+    REQUIRE(particle->map_pressure_to_nodes() == false);
+    REQUIRE(particle->compute_pressure_smoothing() == false);
 
     // Values of nodal mass
     std::array<double, 8> nodal_mass{125., 375.,  1125., 375.,
@@ -1980,9 +1979,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
             Approx(volumetric_strain).epsilon(Tolerance));
 
     // Check updated pressure
-    const double K = 8333333.333333333;
-    REQUIRE(particle->pressure() ==
-            Approx(-K * volumetric_strain).epsilon(Tolerance));
+    REQUIRE(particle->pressure() == 0.0);
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(8.0).epsilon(Tolerance));

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -765,8 +765,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->compute_mass() == true);
     REQUIRE(particle->map_mass_momentum_to_nodes() == true);
 
-    REQUIRE(particle->map_pressure_to_nodes() == true);
-    REQUIRE(particle->compute_pressure_smoothing() == true);
+    REQUIRE(particle->map_pressure_to_nodes() == false);
+    REQUIRE(particle->compute_pressure_smoothing() == false);
 
     // Values of nodal mass
     std::array<double, 4> nodal_mass{562.5, 187.5, 62.5, 187.5};


### PR DESCRIPTION
Refactor to move pressure computation from particle to material. The pressure is stored as a state variable and is modified in the material class. The material API no longer has thermodynamic pressure computation.