### PR TITLE
Refactor remove particles when transferring MPI processes

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -192,6 +192,10 @@ class Mesh {
   //! Remove a particle by id
   bool remove_particle_by_id(mpm::Index id);
 
+  //! Remove a particle from the mesh
+  //! \param[in] pids Vector of particle ids
+  void remove_particles(const std::vector<mpm::Index>& pids);
+
   //! Remove all particles in a cell in nonlocal rank
   void remove_all_nonrank_particles();
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -428,7 +428,7 @@ class Mesh {
   //! Container of particles ids and cell ids
   std::map<mpm::Index, mpm::Index> particles_cell_ids_;
   //! Container of particle sets
-  tsl::robin_map<unsigned, Container<ParticleBase<Tdim>>> particle_sets_;
+  tsl::robin_map<unsigned, tbb::concurrent_vector<mpm::Index>> particle_sets_;
   //! Map of particles for fast retrieval
   Map<ParticleBase<Tdim>> map_particles_;
   //! Container of nodes

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -223,7 +223,7 @@ class Mesh {
   //! \tparam Toper Callable object typically a baseclass functor
   //! \param[in] set_id particle set id
   template <typename Toper>
-  void iterate_over_particle_set(unsigned set_id, Toper oper);
+  void iterate_over_particle_set(int set_id, Toper oper);
 
   //! Return coordinates of particles
   std::vector<Eigen::Matrix<double, 3, 1>> particle_coordinates();

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -526,15 +526,13 @@ void mpm::Mesh<Tdim>::transfer_nonrank_particles() {
       // Create a vector of h5_particles
       std::vector<mpm::HDF5Particle> h5_particles;
       auto particle_ids = (*citr)->particles();
+      // Create a vector of HDF5 data of particles to send
+      // delete particle
       for (auto& id : particle_ids) {
-        // Send and delete particle
-        auto send_particle = map_particles_[id];
         // Append to vector of particles
-        h5_particles.emplace_back(send_particle->hdf5());
+        h5_particles.emplace_back(map_particles_[id]->hdf5());
         // Clear particle in current rank
-        send_particle->remove_cell();
-        particles_.remove(send_particle);
-        map_particles_.remove(id);
+        this->remove_particle_by_id(id);
       }
       (*citr)->clear_particle_ids();
 

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -218,6 +218,18 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
     // Check number of particles in mesh
     REQUIRE(mesh->nparticles() == 0);
 
+    // Add and use remove all particles
+    REQUIRE(mesh->add_particle(particle1) == true);
+    REQUIRE(mesh->add_particle(particle2) == true);
+
+    // Check number of particles in mesh
+    REQUIRE(mesh->nparticles() == 2);
+    std::vector<mpm::Index> remove_pids = {{0, 1}};
+    // Remove all particles
+    mesh->remove_particles(remove_pids);
+    // Check number of particles in mesh
+    REQUIRE(mesh->nparticles() == 0);
+
     // Test assign node concentrated force
     SECTION("Check assign node concentrated force") {
       unsigned Nphase = 0;
@@ -1338,6 +1350,18 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
 
     // Remove all non-rank particles in mesh
     mesh->remove_all_nonrank_particles();
+    // Check number of particles in mesh
+    REQUIRE(mesh->nparticles() == 0);
+
+    // Add and use remove all particles
+    REQUIRE(mesh->add_particle(particle1) == true);
+    REQUIRE(mesh->add_particle(particle2) == true);
+
+    // Check number of particles in mesh
+    REQUIRE(mesh->nparticles() == 2);
+    std::vector<mpm::Index> remove_pids = {{0, 1}};
+    // Remove all particles
+    mesh->remove_particles(remove_pids);
     // Check number of particles in mesh
     REQUIRE(mesh->nparticles() == 0);
 


### PR DESCRIPTION
Remove the redundant implementation of iterating over particle sets .

Fixes the issue of particle sets being defined on the whole set of particle ids. This causes an issue when particles move from one MPI rank to another, this fixes the problem.