### PR TITLE
:rocket: Improve node-node halo region MPI communication

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -468,6 +468,8 @@ class Mesh {
   std::unique_ptr<spdlog::logger> console_;
   //! TBB grain size
   int tbb_grain_size_{100};
+  //! node MPI comms
+  unsigned ncomms_{0};
 };  // Mesh class
 }  // namespace mpm
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -118,13 +118,15 @@ class Mesh {
   void iterate_over_active_nodes(Toper oper);
 
 #ifdef USE_MPI
-  //! All reduce over nodal vector property
+  //! Share nodal property in the halo region
+  //! \tparam Ttype Type of property to accumulate
+  //! \tparam Tnparam Size of individual property
   //! \tparam Tgetfunctor Functor for getter
   //! \tparam Tsetfunctor Functor for setter
   //! \param[in] getter Getter function
   template <typename Ttype, unsigned Tnparam, typename Tgetfunctor,
             typename Tsetfunctor>
-  void nodal_halo_property(Tgetfunctor getter, Tsetfunctor setter);
+  void share_halo_nodal_property(Tgetfunctor getter, Tsetfunctor setter);
 #endif
 
   //! Create cells from list of nodes

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -118,21 +118,13 @@ class Mesh {
   void iterate_over_active_nodes(Toper oper);
 
 #ifdef USE_MPI
-  //! All reduce over nodal scalar property
-  //! \tparam Tgetfunctor Functor for getter
-  //! \tparam Tsetfunctor Functor for setter
-  //! \param[in] getter Getter function
-  template <typename Tgetfunctor, typename Tsetfunctor>
-  void allreduce_nodal_scalar_property(Tgetfunctor getter, Tsetfunctor setter);
-#endif
-
-#ifdef USE_MPI
   //! All reduce over nodal vector property
   //! \tparam Tgetfunctor Functor for getter
   //! \tparam Tsetfunctor Functor for setter
   //! \param[in] getter Getter function
-  template <typename Tgetfunctor, typename Tsetfunctor>
-  void allreduce_nodal_vector_property(Tgetfunctor getter, Tsetfunctor setter);
+  template <typename Ttype, unsigned Tnparam, typename Tgetfunctor,
+            typename Tsetfunctor>
+  void nodal_halo_property(Tgetfunctor getter, Tsetfunctor setter);
 #endif
 
   //! Create cells from list of nodes

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -662,12 +662,11 @@ void mpm::Mesh<Tdim>::find_domain_shared_nodes() {
   ncomms_ = 0;
   for (auto nitr = nodes_.cbegin(); nitr != nodes_.cend(); ++nitr) {
     // If node has more than 1 MPI rank
-    std::set<unsigned> mpi_ranks = (*nitr)->mpi_ranks();
-    if (mpi_ranks.size() > 1) {
-      if (mpi_ranks.find(mpi_rank) != mpi_ranks.end()) {
-        (*nitr)->ghost_id(domain_shared_nodes_.size());
+    std::set<unsigned> nodal_mpi_ranks = (*nitr)->mpi_ranks();
+    if (nodal_mpi_ranks.size() > 1) {
+      if (nodal_mpi_ranks.find(mpi_rank) != nodal_mpi_ranks.end()) {
         domain_shared_nodes_.add(*nitr);
-        ncomms_ += mpi_ranks.size() - 1;
+        ncomms_ += nodal_mpi_ranks.size() - 1;
       }
     }
   }

--- a/include/node.h
+++ b/include/node.h
@@ -230,19 +230,11 @@ class Node : public NodeBase<Tdim> {
   //! Clear MPI rank
   void clear_mpi_ranks() override { mpi_ranks_.clear(); }
 
-  //! Return ghost id
-  Index ghost_id() const override { return ghost_id_; }
-
-  //! Set ghost id
-  void ghost_id(Index gid) override { ghost_id_ = gid; }
-
  private:
   //! Mutex
   std::mutex node_mutex_;
   //! nodebase id
   Index id_{std::numeric_limits<Index>::max()};
-  //! shared ghost id
-  Index ghost_id_{std::numeric_limits<Index>::max()};
   //! nodal coordinates
   VectorDim coordinates_;
   //! Degrees of freedom

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -220,12 +220,6 @@ class NodeBase {
   //! Clear MPI ranks on node
   virtual void clear_mpi_ranks() = 0;
 
-  //! Return ghost id
-  virtual Index ghost_id() const = 0;
-
-  //! Set ghost id
-  virtual void ghost_id(Index gid) = 0;
-
 };  // NodeBase class
 }  // namespace mpm
 

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -75,7 +75,7 @@ void mpm::MPMExplicit<Tdim>::pressure_smoothing(unsigned phase) {
   // Run if there is more than a single MPI task
   if (mpi_size > 1) {
     // MPI all reduce nodal pressure
-    mesh_->template nodal_halo_property<double, 1>(
+    mesh_->template share_halo_nodal_property<double, 1>(
         std::bind(&mpm::NodeBase<Tdim>::pressure, std::placeholders::_1, phase),
         std::bind(&mpm::NodeBase<Tdim>::assign_pressure, std::placeholders::_1,
                   phase, std::placeholders::_2));
@@ -223,12 +223,13 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Run if there is more than a single MPI task
     if (mpi_size > 1) {
       // MPI all reduce nodal mass
-      mesh_->template nodal_halo_property<double, 1>(
+      mesh_->template share_halo_nodal_property<double, 1>(
           std::bind(&mpm::NodeBase<Tdim>::mass, std::placeholders::_1, phase),
           std::bind(&mpm::NodeBase<Tdim>::update_mass, std::placeholders::_1,
                     false, phase, std::placeholders::_2));
       // MPI all reduce nodal momentum
-      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+      mesh_->template share_halo_nodal_property<Eigen::Matrix<double, Tdim, 1>,
+                                                Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::momentum, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_momentum,
@@ -276,14 +277,16 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Run if there is more than a single MPI task
     if (mpi_size > 1) {
       // MPI all reduce external force
-      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+      mesh_->template share_halo_nodal_property<Eigen::Matrix<double, Tdim, 1>,
+                                                Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::external_force, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_external_force,
                     std::placeholders::_1, false, phase,
                     std::placeholders::_2));
       // MPI all reduce internal force
-      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+      mesh_->template share_halo_nodal_property<Eigen::Matrix<double, Tdim, 1>,
+                                                Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::internal_force, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_internal_force,

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -75,7 +75,7 @@ void mpm::MPMExplicit<Tdim>::pressure_smoothing(unsigned phase) {
   // Run if there is more than a single MPI task
   if (mpi_size > 1) {
     // MPI all reduce nodal pressure
-    mesh_->allreduce_nodal_scalar_property(
+    mesh_->template nodal_halo_property<double, 1>(
         std::bind(&mpm::NodeBase<Tdim>::pressure, std::placeholders::_1, phase),
         std::bind(&mpm::NodeBase<Tdim>::assign_pressure, std::placeholders::_1,
                   phase, std::placeholders::_2));
@@ -223,12 +223,12 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Run if there is more than a single MPI task
     if (mpi_size > 1) {
       // MPI all reduce nodal mass
-      mesh_->allreduce_nodal_scalar_property(
+      mesh_->template nodal_halo_property<double, 1>(
           std::bind(&mpm::NodeBase<Tdim>::mass, std::placeholders::_1, phase),
           std::bind(&mpm::NodeBase<Tdim>::update_mass, std::placeholders::_1,
                     false, phase, std::placeholders::_2));
       // MPI all reduce nodal momentum
-      mesh_->allreduce_nodal_vector_property(
+      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::momentum, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_momentum,
@@ -276,14 +276,14 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Run if there is more than a single MPI task
     if (mpi_size > 1) {
       // MPI all reduce external force
-      mesh_->allreduce_nodal_vector_property(
+      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::external_force, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_external_force,
                     std::placeholders::_1, false, phase,
                     std::placeholders::_2));
       // MPI all reduce internal force
-      mesh_->allreduce_nodal_vector_property(
+      mesh_->template nodal_halo_property<Eigen::Matrix<double, Tdim, 1>, Tdim>(
           std::bind(&mpm::NodeBase<Tdim>::internal_force, std::placeholders::_1,
                     phase),
           std::bind(&mpm::NodeBase<Tdim>::update_internal_force,

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -1569,12 +1569,13 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     if (mpi_size == 1) {
       // Run if there is more than a single MPI task
       // MPI all reduce nodal mass
-      mesh->template nodal_halo_property<double, 1>(
+      mesh->template share_halo_nodal_property<double, 1>(
           std::bind(&mpm::NodeBase<Dim>::mass, std::placeholders::_1, 0),
           std::bind(&mpm::NodeBase<Dim>::update_mass, std::placeholders::_1,
                     false, 0, std::placeholders::_2));
       // MPI all reduce nodal momentum
-      mesh->template nodal_halo_property<Eigen::Matrix<double, Dim, 1>, Dim>(
+      mesh->template share_halo_nodal_property<Eigen::Matrix<double, Dim, 1>,
+                                               Dim>(
           std::bind(&mpm::NodeBase<Dim>::coordinates, std::placeholders::_1),
           std::bind(&mpm::NodeBase<Dim>::assign_coordinates,
                     std::placeholders::_1, std::placeholders::_2));

--- a/tests/mesh_test.cc
+++ b/tests/mesh_test.cc
@@ -1569,12 +1569,12 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
     if (mpi_size == 1) {
       // Run if there is more than a single MPI task
       // MPI all reduce nodal mass
-      mesh->allreduce_nodal_scalar_property(
+      mesh->template nodal_halo_property<double, 1>(
           std::bind(&mpm::NodeBase<Dim>::mass, std::placeholders::_1, 0),
           std::bind(&mpm::NodeBase<Dim>::update_mass, std::placeholders::_1,
                     false, 0, std::placeholders::_2));
       // MPI all reduce nodal momentum
-      mesh->allreduce_nodal_vector_property(
+      mesh->template nodal_halo_property<Eigen::Matrix<double, Dim, 1>, Dim>(
           std::bind(&mpm::NodeBase<Dim>::coordinates, std::placeholders::_1),
           std::bind(&mpm::NodeBase<Dim>::assign_coordinates,
                     std::placeholders::_1, std::placeholders::_2));

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -52,14 +52,6 @@ TEST_CASE("Node is checked for 1D case", "[node][1D]") {
     REQUIRE(node->status() == true);
   }
 
-  SECTION("Boundary ghost id") {
-    mpm::Index id = 0;
-    std::shared_ptr<mpm::NodeBase<Dim>> node =
-        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(id, coords);
-    node->ghost_id(5);
-    REQUIRE(node->ghost_id() == 5);
-  }
-
   // Check MPI Rank
   SECTION("Check MPI Rank") {
     mpm::Index id = 0;
@@ -554,14 +546,6 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
     REQUIRE(node->status() == false);
     node->assign_status(true);
     REQUIRE(node->status() == true);
-  }
-
-  SECTION("Boundary ghost id") {
-    mpm::Index id = 0;
-    std::shared_ptr<mpm::NodeBase<Dim>> node =
-        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(id, coords);
-    node->ghost_id(5);
-    REQUIRE(node->ghost_id() == 5);
   }
 
   // Check MPI Rank
@@ -1182,14 +1166,6 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
     REQUIRE(node->status() == false);
     node->assign_status(true);
     REQUIRE(node->status() == true);
-  }
-
-  SECTION("Boundary ghost id") {
-    mpm::Index id = 0;
-    std::shared_ptr<mpm::NodeBase<Dim>> node =
-        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(id, coords);
-    node->ghost_id(5);
-    REQUIRE(node->ghost_id() == 5);
   }
 
   // Check MPI Rank


### PR DESCRIPTION
Uses point-to-point communication instead of MPI_Allreduce. This improves the performance of the code by 20%