### PR TITLE
:hammer: Fixes compilation use due to std namespace ofstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sudo apt-get install freeglut3-dev libxt-dev
 
 > VTK
 ```
-git clone git://vtk.org/VTK.git VTK
+git clone https://gitlab.kitware.com/vtk/vtk.git VTK
 cd VTK && mkdir build && cd build/
 cmake -DCMAKE_BUILD_TYPE:STRING=Release ..
 make -j

--- a/src/io/vtk_writer.cc
+++ b/src/io/vtk_writer.cc
@@ -216,7 +216,7 @@ void VtkWriter::write_parallel_vtk(const std::string& filename,
   ppolydata += "\n</PPolyData>\n\n</VTKFile>";
 
   // Write parallel VTK file
-  ofstream pvtk;
+  std::ofstream pvtk;
   pvtk.open(filename);
   pvtk << ppolydata;
   pvtk.close();


### PR DESCRIPTION
`ofstream` should be `std::ofstream`