### PR TITLE
:bug: Fix missing include stdexcept in factory

### DIFF
--- a/include/factory.h
+++ b/include/factory.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Factory function needs `<stdexcept>` include to be able to throw