### PR TITLE
Generate random particles

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -62,7 +62,7 @@ class Cell {
   bool is_initialised() const;
 
   //! Assign quadrature
-  void assign_quadrature(unsigned nquadratures);
+  void assign_quadrature(unsigned nquadratures, const std::string& generator_type= "gauss");
 
   //! Generate points
   std::vector<Eigen::Matrix<double, Tdim, 1>> generate_points();

--- a/include/cell.tcc
+++ b/include/cell.tcc
@@ -78,11 +78,11 @@ bool mpm::Cell<Tdim>::is_initialised() const {
 
 //! Assign quadrature
 template <unsigned Tdim>
-void mpm::Cell<Tdim>::assign_quadrature(unsigned nquadratures) {
-  this->quadrature_ = element_->quadrature(nquadratures);
+void mpm::Cell<Tdim>::assign_quadrature(unsigned nquadratures, const std::string& generator_type) { 
+  this->quadrature_ = element_->quadrature(nquadratures, generator_type);
 }
 
-//! Assign quadrature
+//! Generate particles using quadratures
 template <unsigned Tdim>
 std::vector<Eigen::Matrix<double, Tdim, 1>> mpm::Cell<Tdim>::generate_points() {
   // Assign a default quadrature of 1

--- a/include/elements/2d/quadrilateral_element.h
+++ b/include/elements/2d/quadrilateral_element.h
@@ -207,7 +207,7 @@ class QuadrilateralElement : public Element<Tdim> {
 
   //! Return quadrature of the element
   std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
-      unsigned nquadratures = 1) const override;
+      unsigned nquadratures = 1, const std::string& generator_type = "gauss") const override;
 
   //! Compute volume
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell

--- a/include/elements/2d/quadrilateral_element.tcc
+++ b/include/elements/2d/quadrilateral_element.tcc
@@ -512,24 +512,50 @@ inline Eigen::VectorXi
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::shared_ptr<mpm::Quadrature<Tdim>>
     mpm::QuadrilateralElement<Tdim, Tnfunctions>::quadrature(
-        unsigned nquadratures) const {
-  switch (nquadratures) {
-    case 1:
-      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ1");
-      break;
-    case 2:
-      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ2");
-      break;
-    case 3:
-      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ3");
-      break;
-    case 4:
-      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ4");
-      break;
-    default:
-      return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ1");
-      break;
+        unsigned nquadratures, const std::string& generator_type) const {
+
+  if (generator_type == "gauss") {
+    switch (nquadratures) {
+      case 1:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ1");
+        break;
+      case 2:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ2");
+        break;
+      case 3:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ3");
+        break;
+      case 4:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ4");
+        break;
+      default:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QQ1");
+        break;
+    }  
+  } else {
+    switch (nquadratures) {
+      case 1:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ1");
+        break;
+      case 4:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ4");
+        break;
+      case 9:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ9");
+        break;
+      case 16:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ16");
+        break;
+      case 25:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ25");
+        break;
+      default:
+        return Factory<mpm::Quadrature<Tdim>>::instance()->create("QRQ1");
+        break;
+    }  
   }
+
+
 }
 
 //! Compute volume

--- a/include/elements/2d/quadrilateral_random_quadrature.h
+++ b/include/elements/2d/quadrilateral_random_quadrature.h
@@ -1,0 +1,41 @@
+#ifndef MPM_QUADRILATERAL_RANDOM_QUADRATURE_H_
+#define MPM_QUADRILATERAL_RANDOM_QUADRATURE_H_
+
+#include <exception>
+
+#include <Eigen/Dense>
+
+#include "quadrature.h"
+
+//! MPM namespace
+namespace mpm {
+
+// Quadrilateral random quadrature class derived from Quadrature base class
+//! \brief Quadrature (random points) for a quadrilateral element
+//! \tparam Tdim Dimension
+//! \tparam Tnquadratures number of quadratures
+template <unsigned Tdim, unsigned Tnquadratures>
+class QuadrilateralRandomQuadrature : public Quadrature<Tdim> {
+
+ public:
+  QuadrilateralRandomQuadrature() : Quadrature<Tdim>() {
+    static_assert(Tdim == 2, "Invalid dimension for a quadrilateral element");
+    static_assert(((Tnquadratures == 1) || (Tnquadratures == 4) ||
+                   (Tnquadratures == 9) || (Tnquadratures == 16) || 
+    			   (Tnquadratures == 25)),
+                  "Invalid number of quadratures");  }
+
+  //! Return quadrature points
+  //! \param[out] qpoints Quadrature points in local coordinates
+  Eigen::MatrixXd quadratures() const override;
+
+  //! Return weights
+  //! \param[out] weights Weights for quadrature points
+  Eigen::VectorXd weights() const override;
+};
+
+}  // namespace mpm
+
+#include "quadrilateral_random_quadrature.tcc"
+
+#endif  // MPM_QUADRILATERAL_RANDOM_QUADRATURE_H_

--- a/include/elements/2d/quadrilateral_random_quadrature.tcc
+++ b/include/elements/2d/quadrilateral_random_quadrature.tcc
@@ -1,0 +1,144 @@
+// Getting the quadratures for Tnquadratures = 1
+template <>
+inline Eigen::MatrixXd mpm::QuadrilateralRandomQuadrature<2, 1>::quadratures() const {
+
+  Eigen::Matrix<double, 2, 1> quadratures;
+
+  for (unsigned i = 0; i < 1; ++i) {
+    // Generate random quadratures in the interval (-0.99, +0.99)
+    quadratures(0, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+    quadratures(1, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+  }
+
+  return quadratures;
+}
+
+// Getting the quadratures for Tnquadratures = 4
+template <>
+inline Eigen::MatrixXd mpm::QuadrilateralRandomQuadrature<2, 4>::quadratures() const {
+
+  Eigen::Matrix<double, 2, 4> quadratures;
+
+  for (unsigned i = 0; i < 4; ++i) {
+    // Generate random quadratures in the interval (-0.99, +0.99)
+    quadratures(0, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+    quadratures(1, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+  }
+
+  return quadratures;
+}
+
+// Getting the quadratures for Tnquadratures = 9
+template <>
+inline Eigen::MatrixXd mpm::QuadrilateralRandomQuadrature<2, 9>::quadratures() const {
+
+  Eigen::Matrix<double, 2, 9> quadratures;
+
+  for (unsigned i = 0; i < 9; ++i) {
+    // Generate random quadratures in the interval (-0.99, +0.99)
+    quadratures(0, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+    quadratures(1, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+  }
+
+  return quadratures;
+}
+
+// Getting the quadratures for Tnquadratures = 16
+template <>
+inline Eigen::MatrixXd mpm::QuadrilateralRandomQuadrature<2, 16>::quadratures() const {
+
+  Eigen::Matrix<double, 2, 16> quadratures;
+
+  for (unsigned i = 0; i < 16; ++i) {
+    // Generate random quadratures in the interval (-0.99, +0.99)
+    quadratures(0, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+    quadratures(1, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+  }
+
+  return quadratures;
+}
+
+// Getting the quadratures for Tnquadratures = 25
+template <>
+inline Eigen::MatrixXd mpm::QuadrilateralRandomQuadrature<2, 25>::quadratures() const {
+
+  Eigen::Matrix<double, 2, 25> quadratures;
+
+  for (unsigned i = 0; i < 25; ++i) {
+    // Generate random quadratures in the interval (-0.99, +0.99)
+    quadratures(0, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+    quadratures(1, i) = 1.98 * (double(std::rand()) / (double(RAND_MAX) + 1.0)) - 0.99;
+  }
+
+  return quadratures;
+}
+
+// Getting the weights for Tnquadratures = 1
+template <>
+inline Eigen::VectorXd mpm::QuadrilateralRandomQuadrature<2, 1>::weights() const {
+ 
+  Eigen::Matrix<double, 1, 1> weights;
+
+  for (unsigned i = 0; i < 1; ++i) {
+    // Compute weights (TO DO)
+    weights(i) = 1.;
+  }
+
+  return weights;
+}
+
+// Getting the weights for Tnquadratures = 4
+template <>
+inline Eigen::VectorXd mpm::QuadrilateralRandomQuadrature<2, 4>::weights() const {
+ 
+  Eigen::Matrix<double, 4, 1> weights;
+
+  for (unsigned i = 0; i < 4; ++i) {
+    // Compute weights (TO DO)
+    weights(i) = 1.;
+  }
+
+  return weights;
+}
+
+// Getting the weights for Tnquadratures = 9
+template <>
+inline Eigen::VectorXd mpm::QuadrilateralRandomQuadrature<2, 9>::weights() const {
+ 
+  Eigen::Matrix<double, 9, 1> weights;
+
+  for (unsigned i = 0; i < 9; ++i) {
+    // Compute weights (TO DO)
+    weights(i) = 1.;
+  }
+
+  return weights;
+}
+
+// Getting the weights for Tnquadratures = 16
+template <>
+inline Eigen::VectorXd mpm::QuadrilateralRandomQuadrature<2, 16>::weights() const {
+ 
+  Eigen::Matrix<double, 16, 1> weights;
+
+  for (unsigned i = 0; i < 16; ++i) {
+    // Compute weights (TO DO)
+    weights(i) = 1.;
+  }
+
+  return weights;
+}
+
+// Getting the weights for Tnquadratures = 25
+template <>
+inline Eigen::VectorXd mpm::QuadrilateralRandomQuadrature<2, 25>::weights() const {
+ 
+  Eigen::Matrix<double, 25, 1> weights;
+
+  for (unsigned i = 0; i < 25; ++i) {
+    // Compute weights (TO DO)
+    weights(i) = 1.;
+  }
+
+  return weights;
+}

--- a/include/elements/2d/triangle_element.h
+++ b/include/elements/2d/triangle_element.h
@@ -177,7 +177,7 @@ class TriangleElement : public Element<Tdim> {
 
   //! Return quadrature of the element
   std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
-      unsigned nquadratures = 1) const override;
+      unsigned nquadratures = 1, const std::string& generator_type = "gauss") const override;
 
   //! Compute volume
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell

--- a/include/elements/2d/triangle_element.tcc
+++ b/include/elements/2d/triangle_element.tcc
@@ -383,7 +383,7 @@ inline Eigen::VectorXi
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::shared_ptr<mpm::Quadrature<Tdim>>
     mpm::TriangleElement<Tdim, Tnfunctions>::quadrature(
-        unsigned nquadratures) const {
+        unsigned nquadratures, const std::string& generator_type) const {
   switch (nquadratures) {
     case 1:
       return Factory<mpm::Quadrature<Tdim>>::instance()->create("QT1");

--- a/include/elements/3d/hexahedron_element.h
+++ b/include/elements/3d/hexahedron_element.h
@@ -245,7 +245,7 @@ class HexahedronElement : public Element<Tdim> {
 
   //! Return quadrature of the element
   std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
-      unsigned nquadratures = 1) const override;
+      unsigned nquadratures = 1, const std::string& generator_type = "gauss") const override;
 
   //! Compute volume
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell

--- a/include/elements/3d/hexahedron_element.tcc
+++ b/include/elements/3d/hexahedron_element.tcc
@@ -604,7 +604,7 @@ inline Eigen::VectorXi
 template <unsigned Tdim, unsigned Tnfunctions>
 inline std::shared_ptr<mpm::Quadrature<Tdim>>
     mpm::HexahedronElement<Tdim, Tnfunctions>::quadrature(
-        unsigned nquadratures) const {
+        unsigned nquadratures, const std::string& generator_type) const {
   switch (nquadratures) {
     case 1:
       return Factory<mpm::Quadrature<Tdim>>::instance()->create("QH1");

--- a/include/elements/element.h
+++ b/include/elements/element.h
@@ -153,7 +153,7 @@ class Element {
 
   //! Return quadrature of the element
   virtual std::shared_ptr<mpm::Quadrature<Tdim>> quadrature(
-      unsigned nquadratures) const = 0;
+      unsigned nquadratures, const std::string& generator_type) const = 0;
 
   //! Compute volume
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -327,12 +327,14 @@ class Mesh {
 
   //! Generate points
   //! \param[in] nquadratures Number of points per direction in cell
+  //! \param[in] generator_type Generator type
   //! \param[in] particle_type Particle type
   //! \param[in] material_id ID of the material
   //! \param[in] cset_id Set ID of the cell [-1 for all cells]
   //! \param[in] pset_id Set ID of the particles
   //! \retval point Material point coordinates
   bool generate_material_points(unsigned nquadratures,
+                                const std::string& generator_type,
                                 const std::string& particle_type,
                                 unsigned material_id, int cset_id,
                                 unsigned pset_id);

--- a/src/quadrature.cc
+++ b/src/quadrature.cc
@@ -2,6 +2,7 @@
 #include "factory.h"
 #include "hexahedron_quadrature.h"
 #include "quadrilateral_quadrature.h"
+#include "quadrilateral_random_quadrature.h"
 #include "triangle_quadrature.h"
 
 // Triangle 1
@@ -27,6 +28,26 @@ static Register<mpm::Quadrature<2>, mpm::QuadrilateralQuadrature<2, 9>>
 // Quadrilateral 16
 static Register<mpm::Quadrature<2>, mpm::QuadrilateralQuadrature<2, 16>>
     quadrilateral16("QQ4");
+
+// Quadrilateral Random 1
+static Register<mpm::Quadrature<2>, mpm::QuadrilateralRandomQuadrature<2, 1>>
+    quadrilateralrandom1("QRQ1");
+
+// Quadrilateral Random 4
+static Register<mpm::Quadrature<2>, mpm::QuadrilateralRandomQuadrature<2, 4>>
+    quadrilateralrandom4("QRQ4");
+
+// Quadrilateral Random 9
+static Register<mpm::Quadrature<2>, mpm::QuadrilateralRandomQuadrature<2, 9>>
+    quadrilateralrandom9("QRQ9");
+
+// Quadrilateral Random 16
+static Register<mpm::Quadrature<2>, mpm::QuadrilateralRandomQuadrature<2, 16>>
+    quadrilateralrandom16("QRQ16");
+
+// Quadrilateral Random 25
+static Register<mpm::Quadrature<2>, mpm::QuadrilateralRandomQuadrature<2, 25>>
+    quadrilateralrandom25("QRQ25");
 
 // Hexahedron 1
 static Register<mpm::Quadrature<3>, mpm::HexahedronQuadrature<3, 1>>


### PR DESCRIPTION
**Describe the PR**
Generate random particles within an element as first step to solve Issue #609.

General design of the random generator:
- Make a new class called `QuadrilateralRandomQuadratures` 
- Update `assign_quadrilateral` in `cell` to include `generator_type` with default string value of "gauss"

Alternative design:
- Generate random quadratures in `geometry` but the design of the code would be rather messy

Things to do in this PR (this will notsolve issue #609 entirely)
- [x] Implement for 1, 4, 9, 16 and 25 particles per cell for quadrilateral element
- [ ] Implement for triangular and hexahedron (for completion) 
- [ ] Test functions (note that random generator cannot be tested for locations of particles, but only the number of particles within the cell)

Things to do in next PR (to complete issue #609)
- [ ] Compute accurate gauss weights for each randomly generated particles
- [ ] Test functions on the computed weights

Example of generation of 25 particles per cell: 
![image](https://user-images.githubusercontent.com/22064721/80657580-d4ba4400-8a38-11ea-88d8-b0ead8637a26.png)

Example of generation of 4 particles per cell:
![image](https://user-images.githubusercontent.com/22064721/80657628-f87d8a00-8a38-11ea-9eab-a35a32236f04.png)


