### PR TITLE
:wrench: Use default MPI_TAG to avoid mpi_tag overflow fixes #620

### DIFF
--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -145,9 +145,8 @@ void mpm::Mesh<Tdim>::nodal_halo_exchange(Tgetfunctor getter,
       std::set<unsigned> node_mpi_ranks = domain_shared_nodes_[i]->mpi_ranks();
       for (auto& node_rank : node_mpi_ranks) {
         if (node_rank != mpi_rank) {
-          MPI_Isend(&property, Tnparam, MPI_DOUBLE, node_rank,
-                    domain_shared_nodes_[i]->id(), MPI_COMM_WORLD,
-                    &send_requests[j]);
+          MPI_Isend(&property, Tnparam, MPI_DOUBLE, node_rank, 0,
+                    MPI_COMM_WORLD, &send_requests[j]);
           ++j;
         }
       }
@@ -166,8 +165,7 @@ void mpm::Mesh<Tdim>::nodal_halo_exchange(Tgetfunctor getter,
       for (auto& node_rank : node_mpi_ranks) {
         if (node_rank != mpi_rank) {
           Ttype value;
-          MPI_Recv(&value, Tnparam, MPI_DOUBLE, node_rank,
-                   domain_shared_nodes_[i]->id(), MPI_COMM_WORLD,
+          MPI_Recv(&value, Tnparam, MPI_DOUBLE, node_rank, 0, MPI_COMM_WORLD,
                    MPI_STATUS_IGNORE);
           property += value;
         }


### PR DESCRIPTION
**Describe the PR**
Using node id as the `mpi_tag` causes an overflow. Instead, we use the default tag of 0.

**Related Issues/PRs**
This fixes #620 by using the default `mpi_tag` of 0. This OK because MPI guarantees the order of send, and we won't need the tag to identify the information. `Order Messages are non-overtaking`https://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node41.html.