### PR TITLE
Resume bug

### DIFF
--- a/include/containers/map.h
+++ b/include/containers/map.h
@@ -36,6 +36,9 @@ class Map {
   //! \param[in] id Global/local index of the pointer
   bool remove(Index id);
 
+  //! Clear all entities
+  void clear() { elements_.clear(); }
+
   //! Return number of elements in the container
   std::size_t size() const { return elements_.size(); }
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -388,7 +388,7 @@ class Mesh {
   std::vector<Eigen::Matrix<double, 3, 1>> nodal_coordinates() const;
 
   //! Return node pairs
-  std::vector<std::array<mpm::Index, 2>> node_pairs() const;
+  std::vector<std::array<mpm::Index, 2>> node_pairs(bool active = false) const;
 
   //! Create map of vector of particles in sets
   //! \param[in] map of particles ids in sets

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1346,29 +1346,50 @@ bool mpm::Mesh<Tdim>::read_particles_hdf5(unsigned phase,
   if (file_id < 0) throw std::runtime_error("HDF5 particle file is not found");
 
   // Calculate the size and the offsets of our struct members in memory
-  const unsigned nparticles = this->nparticles();
-  const hsize_t NRECORDS = nparticles;
+  hsize_t nrecords = 0;
+  hsize_t nfields = 0;
+  auto err = H5TBget_table_info(file_id, "table", &nfields, &nrecords);
 
-  const hsize_t NFIELDS = mpm::hdf5::particle::NFIELDS;
+  if (nfields != mpm::hdf5::particle::NFIELDS)
+    throw std::runtime_error("HDF5 table has incorrect number of fields");
 
   std::vector<HDF5Particle> dst_buf;
-  dst_buf.reserve(nparticles);
+  dst_buf.reserve(nrecords);
   // Read the table
   H5TBread_table(file_id, "table", mpm::hdf5::particle::dst_size,
                  mpm::hdf5::particle::dst_offset,
                  mpm::hdf5::particle::dst_sizes, dst_buf.data());
 
+  // Vector of particles
+  Vector<ParticleBase<Tdim>> particles;
+
+  // Clear map of particles
+  map_particles_.clear();
+
   unsigned i = 0;
   for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr) {
-    HDF5Particle particle = dst_buf[i];
-    // Get particle's material from list of materials
-    auto material = materials_.at(particle.material_id);
-    // Initialise particle with HDF5 data
-    (*pitr)->initialise_particle(particle, material);
-    ++i;
+    if (i < nrecords) {
+      HDF5Particle particle = dst_buf[i];
+      // Get particle's material from list of materials
+      auto material = materials_.at(particle.material_id);
+      // Initialise particle with HDF5 data
+      (*pitr)->initialise_particle(particle, material);
+      // Add particle to map
+      map_particles_.insert(particle.id, *pitr);
+      particles.add(*pitr);
+      ++i;
+    }
   }
   // close the file
   H5Fclose(file_id);
+
+  // Overwrite particles container
+  this->particles_ = particles;
+
+  // Remove associated cell for the particle
+  for (auto citr = this->cells_.cbegin(); citr != this->cells_.cend(); ++citr)
+    (*citr)->clear_particle_ids();
+
   return true;
 }
 

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -38,7 +38,7 @@ bool mpm::Particle<Tdim>::initialise_particle(const HDF5Particle& particle) {
   // Mass
   this->mass_ = particle.mass;
   // Volume
-  this->assign_volume(particle.volume);
+  this->volume_ = particle.volume;
   // Mass Density
   this->mass_density_ = particle.mass / particle.volume;
   // Set local size of particle

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -413,28 +413,21 @@ bool mpm::MPMBase<Tdim>::checkpoint_resume() {
         io_->output_file(attribute, extension, uuid_, step_, this->nsteps_)
             .string();
 
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
     // Load particle information from file
     mesh_->read_particles_hdf5(phase, particles_file);
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
 
     // Clear all particle ids
     mesh_->iterate_over_cells(
         std::bind(&mpm::Cell<Tdim>::clear_particle_ids, std::placeholders::_1));
 
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
     // Locate particles
     auto unlocatable_particles = mesh_->locate_particles_mesh();
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
 
     if (!unlocatable_particles.empty())
       throw std::runtime_error("Particle outside the mesh domain");
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
 
     // Increament step
     ++this->step_;
-
-    console_->info("{} {} {}", mpi_rank, __FILE__, __LINE__);
     console_->info("Checkpoint resume at step {} of {}", this->step_,
                    this->nsteps_);
 

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -470,10 +470,11 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
   auto vtk_writer = std::make_unique<VtkWriter>(mesh_->particle_coordinates());
 
   // Write mesh on step 0
+  // Get active node pairs use true
   if (step == 0)
     vtk_writer->write_mesh(
         io_->output_file("mesh", ".vtp", uuid_, step, max_steps).string(),
-        mesh_->nodal_coordinates(), mesh_->node_pairs());
+        mesh_->nodal_coordinates(), mesh_->node_pairs(false));
 
   // Write input geometry to vtk file
   const std::string extension = ".vtp";

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -121,12 +121,12 @@ bool mpm::MPMExplicit<Tdim>::solve() {
   mesh_->iterate_over_particles(
       std::bind(&mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1));
 
-  // Domain decompose
-  bool initial_step = true;
-  this->mpi_domain_decompose(initial_step);
-
   // Check point resume
   if (resume) this->checkpoint_resume();
+
+  // Domain decompose
+  bool initial_step = (resume == true) ? false : true;
+  this->mpi_domain_decompose(initial_step);
 
   auto solver_begin = std::chrono::steady_clock::now();
   // Main loop

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -281,9 +281,8 @@ bool mpm::MPMExplicit<Tdim>::solve() {
 #ifdef USE_MPI
 #ifdef USE_GRAPH_PARTITIONING
     // Run load balancer at a specified frequency
-    if (step_ % nload_balance_steps_ == 0 && step_ != 0)
-      this->mpi_domain_decompose(false);
-
+    // if (step_ % nload_balance_steps_ == 0 && step_ != 0)
+    //   this->mpi_domain_decompose(false);
     mesh_->transfer_nonrank_particles();
 #endif
 #endif

--- a/tests/node_map_test.cc
+++ b/tests/node_map_test.cc
@@ -56,6 +56,10 @@ TEST_CASE("Node map is checked for 2D case", "[nodemap][2D]") {
     REQUIRE(nodemap->remove(node3->id()) == false);
     // Check size of node hanlder
     REQUIRE(nodemap->size() == 2);
+    // Clear node map
+    REQUIRE_NOTHROW(nodemap->clear());
+    // Check size of node hanlder
+    REQUIRE(nodemap->size() == 0);
   }
 
   SECTION("Check operator []") {
@@ -177,6 +181,10 @@ TEST_CASE("Node map is checked for 3D case", "[nodemap][3D]") {
     REQUIRE(nodemap->remove(node3->id()) == false);
     // Check size of node hanlder
     REQUIRE(nodemap->size() == 2);
+    // Clear node map
+    REQUIRE_NOTHROW(nodemap->clear());
+    // Check size of node hanlder
+    REQUIRE(nodemap->size() == 0);
   }
 
   SECTION("Check operator []") {


### PR DESCRIPTION
**Describe the PR**
Resume from HDF5 fails on MPI processes because after reading all the particles initially, we don't remove them. This causes a failed pointer issue. This PR reads the HDF5 particle, gets info on the number of rows (particles), and uses this information to accurately resume the process.

**Additional context**
Dynamic load balancing fails when there is significant particle movement. Will open an issue to describe the issue. This PR temporarily disables dynamic load balancing.