### PR TITLE
:wrench: Add include guards to protect against NOKAHIP mpi compilation

### DIFF
--- a/tests/mpi_transfer_particle_test.cc
+++ b/tests/mpi_transfer_particle_test.cc
@@ -15,6 +15,8 @@
 #include "particle.h"
 #include "quadrilateral_element.h"
 
+#ifdef USE_MPI
+#ifdef USE_KAHIP
 //! Check transfer of particles across MPI tasks
 TEST_CASE("MPI transfer particle is checked in 2D",
           "[particle][mpi][transfer][2D]") {
@@ -721,3 +723,5 @@ TEST_CASE("MPI Transfer Particle is checked in 3D",
     }
   }
 }
+#endif
+#endif


### PR DESCRIPTION
**Describe the PR**
Add include guards to avoid compilation error when KAHIP is set to false or `NOKAHIP` option is selected. In this case, MPI and graph partitioning tests shouldn't run.

**Related Issues/PRs**
https://cb-geo.discourse.group/t/mpm-graph-test-compilation-failing/176/2
