### PR TITLE
:wrench: Fixes #644 use MPI_STATUS_IGNORE when recv status is not used

### DIFF
--- a/include/graph.tcc
+++ b/include/graph.tcc
@@ -140,7 +140,6 @@ std::vector<mpm::Index> mpm::Graph<Tdim>::collect_partitions(int mpi_size,
                                                              int mpi_rank,
                                                              MPI_Comm* comm) {
   //! allocate space to partition
-  MPI_Status status;
   mpm::Index ncells = this->cells_.size();
   std::vector<mpm::Index> partition(ncells, 0);
   // ID of cells, which should transfer particles
@@ -157,7 +156,7 @@ std::vector<mpm::Index> mpm::Graph<Tdim>::collect_partitions(int mpi_size,
       std::vector<idxtype> rpart(rnvtxs);
       //! penum is the source process
       MPI_Recv(rpart.data(), rnvtxs, MPI_UNSIGNED_LONG_LONG, penum, 1, *comm,
-               &status);
+               MPI_STATUS_IGNORE);
 
       for (int i = 0; i < rnvtxs; ++i) {
         partition[par] = rpart[i];
@@ -174,7 +173,7 @@ std::vector<mpm::Index> mpm::Graph<Tdim>::collect_partitions(int mpi_size,
              this->vtxdist_[mpi_rank + 1] - this->vtxdist_[mpi_rank],
              MPI_UNSIGNED_LONG_LONG, 0, 1, *comm);
     MPI_Recv(partition.data(), ncells, MPI_UNSIGNED_LONG_LONG, 0, 1, *comm,
-             &status);
+             MPI_STATUS_IGNORE);
   }
 
   // Assign partition to cells

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -777,23 +777,20 @@ void mpm::Mesh<Tdim>::transfer_halo_particles() {
           ghost_cells_neighbour_ranks_[(*citr)->id()];
 
       for (unsigned i = 0; i < neighbour_ranks.size(); ++i) {
-        // MPI status
-        MPI_Status recv_status;
         // Receive number of particles
         unsigned nrecv_particles;
         MPI_Recv(&nrecv_particles, 1, MPI_UNSIGNED, neighbour_ranks[i], 0,
-                 MPI_COMM_WORLD, &recv_status);
+                 MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
         if (nrecv_particles != 0) {
           std::vector<mpm::HDF5Particle> recv_particles;
           recv_particles.resize(nrecv_particles);
           // Receive the vector of particles
           mpm::HDF5Particle received;
-          MPI_Status status_recv;
           MPI_Datatype particle_type =
               mpm::register_mpi_particle_type(received);
           MPI_Recv(recv_particles.data(), nrecv_particles, particle_type,
-                   neighbour_ranks[i], 0, MPI_COMM_WORLD, &status_recv);
+                   neighbour_ranks[i], 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
           mpm::deregister_mpi_particle_type(particle_type);
 
           // Iterate through n number of received particles
@@ -889,23 +886,21 @@ void mpm::Mesh<Tdim>::transfer_nonrank_particles(
       // If the current rank is the MPI rank receive particles
       if ((cell->rank() != cell->previous_mpirank()) &&
           (cell->rank() == mpi_rank)) {
-        // MPI status
-        MPI_Status recv_status;
         // Receive number of particles
         unsigned nrecv_particles;
         MPI_Recv(&nrecv_particles, 1, MPI_UNSIGNED, cell->previous_mpirank(), 0,
-                 MPI_COMM_WORLD, &recv_status);
+                 MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
         if (nrecv_particles != 0) {
           std::vector<mpm::HDF5Particle> recv_particles;
           recv_particles.resize(nrecv_particles);
           // Receive the vector of particles
           mpm::HDF5Particle received;
-          MPI_Status status_recv;
           MPI_Datatype particle_type =
               mpm::register_mpi_particle_type(received);
           MPI_Recv(recv_particles.data(), nrecv_particles, particle_type,
-                   cell->previous_mpirank(), 0, MPI_COMM_WORLD, &status_recv);
+                   cell->previous_mpirank(), 0, MPI_COMM_WORLD,
+                   MPI_STATUS_IGNORE);
           mpm::deregister_mpi_particle_type(particle_type);
 
           // Iterate through n number of received particles


### PR DESCRIPTION
**Describe the PR**
 Use MPI_STATUS_IGNORE when not performing checks on recv status

**Related Issues/PRs**
Fixes issue #644