### PR TITLE
:hammer: Assign material during initialize particle fix key not found fixes #651

### DIFF
--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -110,7 +110,8 @@ bool mpm::Particle<Tdim>::initialise_particle(
   if (material != nullptr) {
     if (this->material_id_ == material->id() ||
         this->material_id_ == std::numeric_limits<unsigned>::max()) {
-      material_ = material;
+      bool assign_mat = this->assign_material(material);
+      if (!assign_mat) throw std::runtime_error("Material assignment failed");
       // Reinitialize state variables
       auto mat_state_vars = material_->initialise_state_variables();
       if (mat_state_vars.size() == particle.nstate_vars) {


### PR DESCRIPTION
**Describe the PR**
Particle initialization with material and state variables fail, as the material is not being properly initialized. This error happens both during MPI transfer and during resume. 

**Related Issues/PRs**
#651 was failing with key not found error. This helps fix the issue

**Additional context**

New implementation uses `assign_material` function call instead of copying pointer.