### PR TITLE
Remove fedora command in partio installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ sudo make install
 ### Partio for Houdini SFX Visualization
 
 ```shell
-sudo dnf install -y libnsl freeglut freeglut-devel
 mkdir -p ~/workspace && cd ~/workspace/ && git clone https://github.com/wdas/partio.git && \
     cd partio && cmake . && make
 ```


### PR DESCRIPTION
**Describe the PR**
Just cleaning up installation commands to exclude one fedora installation line in ubuntu installation guide.