### PR TITLE
:construction: OpenMP compilation with set

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you have any issues running or compiling the MPM code please open a issue on 
 #### Optional
 * [MKL](https://software.intel.com/en-us/mkl)
 * [MPI](https://www.open-mpi.org/)
-* [OpenMP 4](
+* [OpenMP 5.0](https://www.openmp.org/specifications/)
 * [KaHIP](https://github.com/schulzchristian/KaHIP)
 * [Partio](https://github.com/wdas/partio)
 * [VTK](https://www.vtk.org/)

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ If you have any issues running or compiling the MPM code please open a issue on 
 #### Optional
 * [MKL](https://software.intel.com/en-us/mkl)
 * [MPI](https://www.open-mpi.org/)
+* [OpenMP 4](
 * [KaHIP](https://github.com/schulzchristian/KaHIP)
 * [Partio](https://github.com/wdas/partio)
 * [VTK](https://www.vtk.org/)
 
-### Fedora installation
+### Fedora installation (recommended)
 
 Please run the following command:
 
@@ -56,14 +57,19 @@ dnf install -y boost boost-devel clang clang-analyzer clang-tools-extra cmake cp
 Please run the following commands to install dependencies:
 
 ```
-sudo apt-get install -y gcc git libboost-all-dev libeigen3-dev libhdf5-serial-dev libopenmpi-dev
+sudo apt update
+sudo apt upgrade
+sudo apt install -y gcc git libboost-all-dev libeigen3-dev libhdf5-serial-dev libopenmpi-dev libomp-dev
+sudo apt install software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt install gcc-9 g++-9
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
 
 ```
 
 To install other dependencies:
 > CMake 3.15
 ```
-sudo apt-get install software-properties-common
 sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 sudo apt update
 sudo apt upgrade

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Please run the following commands to install dependencies:
 sudo apt update
 sudo apt upgrade
 sudo apt install -y gcc git libboost-all-dev libeigen3-dev libhdf5-serial-dev libopenmpi-dev libomp-dev
+```
+
+If you are running Ubuntu 18.04 or below, you may want to update the GCC version to 9 to have OpenMP 5 specifications
+support.
+
+```
 sudo apt install software-properties-common
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt install gcc-9 g++-9

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1027,18 +1027,11 @@ void mpm::Mesh<Tdim>::iterate_over_particle_set(int set_id, Toper oper) {
   } else {
     // Iterate over the particle set
     auto set = particle_sets_.at(set_id);
-#pragma omp parallel
-#pragma omp single
-    {
-      for (auto sitr = set.begin(); sitr != set.cend(); ++sitr) {
-#pragma omp task firstprivate(sitr)
-        {
-          unsigned pid = (*sitr);
-          if (map_particles_.find(pid) != map_particles_.end())
-            oper(map_particles_[pid]);
-        }
-      }
-#pragma omp taskwait
+#pragma omp parallel for
+    for (auto sitr = set.begin(); sitr != set.cend(); ++sitr) {
+      unsigned pid = (*sitr);
+      if (map_particles_.find(pid) != map_particles_.end())
+        oper(map_particles_[pid]);
     }
   }
 }

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1027,11 +1027,18 @@ void mpm::Mesh<Tdim>::iterate_over_particle_set(int set_id, Toper oper) {
   } else {
     // Iterate over the particle set
     auto set = particle_sets_.at(set_id);
-#pragma omp parallel for
-    for (auto sitr = set.begin(); sitr != set.cend(); ++sitr) {
-      unsigned pid = (*sitr);
-      if (map_particles_.find(pid) != map_particles_.end())
-        oper(map_particles_[pid]);
+#pragma omp parallel
+#pragma omp single
+    {
+      for (auto sitr = set.begin(); sitr != set.cend(); ++sitr) {
+#pragma omp task firstprivate(sitr)
+        {
+          unsigned pid = (*sitr);
+          if (map_particles_.find(pid) != map_particles_.end())
+            oper(map_particles_[pid]);
+        }
+      }
+#pragma omp taskwait
     }
   }
 }


### PR DESCRIPTION
**Describe the PR**
Add appropriate flags in OpenMP to enable parallelization on C++ sets

**Related Issues/PRs**
https://cb-geo.discourse.group/t/openmp-compilation-issue/185/2

**Additional context**

OpenMP fails with: 
```
error: invalid controlling predicate
     for (auto sitr = set.begin(); sitr != set.cend(); ++sitr) {
     ^~~
```

However, this error does not occur on newer versions of OpenMP/GCC or in Fedora. The error seems to be specific to older versions of Ubuntu.