### PR TITLE
Hotfix/circleci nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
           command: |
             cd /home/cbgeo/project/build
             pip3 install tables --user
+            export OMP_NUM_THREADS=2
             mpirun -n 4 ./mpm -f ./benchmarks/2d/sliding_block_inclined_boundary/
             python3 ./benchmarks/2d/sliding_block_inclined_boundary/test_benchmark.py
       # Stress
@@ -129,6 +130,7 @@ workflows:
             - clang
             - cppcheck
             - codecov
+            - benchmarks
     nightly:
         jobs:
             - benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
           name: Uniaxial traction
           command: |
             cd /home/cbgeo/project/build
+            export OMP_NUM_THREADS=2
             ./mpm -f ./benchmarks/2d/uniaxial_traction/ -i mpm-nodal-forces.json
             ./mpm -f ./benchmarks/2d/uniaxial_traction/ -i mpm-particle-traction.json
             python3 ./benchmarks/2d/uniaxial_stress/test_benchmark.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ workflows:
             - clang
             - cppcheck
             - codecov
-            - benchmarks
     nightly:
         jobs:
             - benchmarks


### PR DESCRIPTION
**Describe the PR**
Nightly builds were failing due to timeouts. This PR enables 2 parallel OpenMP threads to fix the time-out issue.

**Additional context**
https://app.circleci.com/pipelines/github/cb-geo/mpm/945/workflows/7efd8314-25c6-46be-9405-7fee5d66407e/jobs/5380
Benchmarks now run in 12 minutes.