### PR TITLE
:fire: :art: Refactor nested namespace - to avoid needing c++17 

### DIFF
--- a/include/hdf5_particle.h
+++ b/include/hdf5_particle.h
@@ -46,7 +46,8 @@ typedef struct HDF5Particle {
   double svars[20] = {0};
 } HDF5Particle;
 
-namespace hdf5::particle {
+namespace hdf5 {
+namespace particle {
 const hsize_t NFIELDS = 53;
 
 const size_t dst_size = sizeof(HDF5Particle);
@@ -63,7 +64,8 @@ extern const char* field_names[NFIELDS];
 // Initialize field types
 extern const hid_t field_type[NFIELDS];
 
-}  // namespace hdf5::particle
+}  // namespace particle
+}  // namespace hdf5
 
 }  // namespace mpm
 

--- a/src/hdf5_particle.cc
+++ b/src/hdf5_particle.cc
@@ -1,6 +1,7 @@
 #include "hdf5_particle.h"
 namespace mpm {
-namespace hdf5::particle {
+namespace hdf5 {
+namespace particle {
 const size_t dst_offset[NFIELDS] = {
     HOFFSET(HDF5Particle, id),
     HOFFSET(HDF5Particle, mass),
@@ -188,5 +189,6 @@ const hid_t field_type[NFIELDS] = {
     H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE,
     H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE,
     H5T_NATIVE_DOUBLE};
-}  // namespace hdf5::particle
+}  // namespace particle
+}  // namespace hdf5
 }  // namespace mpm


### PR DESCRIPTION
**Describe the PR**
The nested namespace is a supported feature in C++17. However, older versions of Intel doesn't support this feature and has issues on Stampede2. Hence, refactoring this to not need nested namespace.

**Related Issues/PRs**
Discourse issue on compilation on Stampede2 with OpenMP: https://cb-geo.discourse.group/t/compilation-issue-on-tacc-invalid-controlling-predicate/186

