### PR TITLE
Feature/material_id

### DIFF
--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -330,19 +330,9 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
                        .count());
 
     // Material id update using particle sets
-    bool update_materials = false;
-    try {
-      update_materials = mesh_props["update_materials"].template get<bool>();
-    } catch (std::exception& exception) {
-      console_->warn(
-          "{} #{}: Update materials, not specified setting default as false",
-          __FILE__, __LINE__, exception.what());
-      update_materials = false;
-    }
-
     try {
       auto material_sets = io_->json_object("material_sets");
-      if (!material_sets.empty() && update_materials) {
+      if (!material_sets.empty()) {
         for (const auto& material_set : material_sets) {
           unsigned material_id =
               material_set["material_id"].template get<unsigned>();

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -269,6 +269,11 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
 
     // Get material sets
     auto material_sets = io_->json_object("material_sets");
+    
+    if(!material_sets.empty())
+      for(const auto& material_set : material_sets){
+
+      }
 
     auto particles_gen_end = std::chrono::steady_clock::now();
     console_->info("Rank {} Generate particles: {} ms", mpi_rank,

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -267,6 +267,9 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
       if (!gen_status) status = false;
     }
 
+    // Get material sets
+    auto material_sets = io_->json_object("material_sets");
+
     auto particles_gen_end = std::chrono::steady_clock::now();
     console_->info("Rank {} Generate particles: {} ms", mpi_rank,
                    std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -272,7 +272,10 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
     
     if(!material_sets.empty())
       for(const auto& material_set : material_sets){
-
+        // Update material_id for particles in each pset
+        mesh_->iterate_over_particle_set(material_set["pset_id"], 
+          std::bind(&mpm::ParticleBase<Tdim>::assign_material,
+          std::placeholders::_1, materials_.at(material_set["material_id"])));
       }
 
     auto particles_gen_end = std::chrono::steady_clock::now();

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -272,10 +272,12 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
     
     if(!material_sets.empty() && mesh_props["update_materials"] == true) 
       for(const auto& material_set : material_sets){
+        unsigned material_id = material_set["material_id"].template get<unsigned>();
+        unsigned pset_id = material_set["pset_id"].template get<unsigned>();
         // Update material_id for particles in each pset
-        mesh_->iterate_over_particle_set(material_set["pset_id"], 
+        mesh_->iterate_over_particle_set(pset_id,
           std::bind(&mpm::ParticleBase<Tdim>::assign_material,
-          std::placeholders::_1, materials_.at(material_set["material_id"])));
+          std::placeholders::_1, materials_.at(material_id)));
       }
 
     auto particles_gen_end = std::chrono::steady_clock::now();

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -355,7 +355,7 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
         }
       }
     } catch (std::exception& exception) {
-      console_->warn("{} #{}: Material sets, not specified", __FILE__, __LINE__,
+      console_->warn("{} #{}: Material sets are not specified", __FILE__, __LINE__,
                      exception.what());
     }
 

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -329,7 +329,7 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
                        particles_volume_end - particles_volume_begin)
                        .count());
 
-    // Get material sets
+    // Material id update using particle sets
     bool update_materials = false;
     try {
       update_materials = mesh_props["update_materials"].template get<bool>();

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -270,7 +270,7 @@ bool mpm::MPMBase<Tdim>::initialise_particles() {
     // Get material sets
     auto material_sets = io_->json_object("material_sets");
     
-    if(!material_sets.empty())
+    if(!material_sets.empty() && mesh_props["update_materials"] == true) 
       for(const auto& material_set : material_sets){
         // Update material_id for particles in each pset
         mesh_->iterate_over_particle_set(material_set["pset_id"], 

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -8,6 +8,9 @@ namespace mpm_test {
 bool write_json(unsigned dim, bool resume, const std::string& analysis,
                 const std::string& stress_update, const std::string& file_name);
 
+// Write JSON Entity Set
+bool write_entity_set();
+
 // Write Mesh file in 2D
 bool write_mesh_2d();
 // Write particles file in 2D

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -15,7 +15,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
   auto io_type = "Ascii2D";
   std::string material = "LinearElastic2D";
   std::vector<double> gravity{{0., -9.81}};
-  unsigned material_id = 1;
+  unsigned material_id = 0;
   std::vector<double> xvalues{{0.0, 0.5, 1.0}};
   std::vector<double> fxvalues{{0.0, 1.0, 1.0}};
 
@@ -64,6 +64,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
          {"density", 2300.},
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},
+      {"material_sets", {{{"material_id", 1}, {"pset_id", 0}}}},
       {"external_loading_conditions",
        {{"gravity", gravity},
         {"particle_surface_traction",

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -35,6 +35,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
       {"title", "Example JSON Input for MPM"},
       {"mesh",
        {{"mesh", "mesh-" + dimension + ".txt"},
+        {"entity_sets", "entity_sets_0.json"},
         {"io_type", io_type},
         {"check_duplicates", true},
         {"isoparametric", false},
@@ -64,7 +65,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
          {"density", 2300.},
          {"youngs_modulus", 1.5E+6},
          {"poisson_ratio", 0.25}}}},
-      {"material_sets", {{{"material_id", 1}, {"pset_id", 0}}}},
+      {"material_sets", {{{"material_id", 1}, {"pset_id", 2}}}},
       {"external_loading_conditions",
        {{"gravity", gravity},
         {"particle_surface_traction",
@@ -105,6 +106,23 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
   // Dump JSON as an input file to be read
   std::ofstream file;
   file.open((file_name + "-" + dimension + ".json").c_str());
+  file << json_file.dump(2);
+  file.close();
+
+  return true;
+}
+
+// Write JSON Entity Set
+bool write_entity_set() {
+  // JSON Entity Sets
+  Json json_file = {
+      {"particle_sets",
+       {{{"id", 2},
+         {"set", {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}}}}}};
+
+  // Dump JSON as an input file to be read
+  std::ofstream file;
+  file.open("entity_sets_0.json");
   file << json_file.dump(2);
   file.close();
 

--- a/tests/mpm_explicit_usf_test.cc
+++ b/tests/mpm_explicit_usf_test.cc
@@ -21,6 +21,9 @@ TEST_CASE("MPM 2D Explicit implementation is checked",
   REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
           true);
 
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
+
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d() == true);
 
@@ -100,6 +103,9 @@ TEST_CASE("MPM 3D Explicit implementation is checked",
   const bool resume = false;
   REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
           true);
+
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
 
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d() == true);

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -104,6 +104,9 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
   REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
           true);
 
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
+
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_3d() == true);
 

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -21,6 +21,9 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
   REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
           true);
 
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
+
   // Write Mesh
   REQUIRE(mpm_test::write_mesh_2d() == true);
 


### PR DESCRIPTION
**Describe the PR**
Adding the option to update `material_id` based on `pset_id` for a single input file (i.e. `particles.txt`).

**Related Issues/PRs**
https://github.com/cb-geo/mpm/issues/671 

**Additional context**
Input `JSON` must include new section **"material_sets"**:
```
"material_sets":[
    {
      "material_id": 0,
      "pset_id": 0
    },
    {
      "material_id": 1,
      "pset_id": 1
    }
]
```
And the **"mesh:"** section must include:
```
"update_materials": true
```