### PR TITLE
Improve lock performance with SpinMutex and OpenMP static scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The CB-Geo MPM code uses a `JSON` file for input configuration. To run the mpm c
 For example:
 
 ```
+export OMP_SCHEDULE="static, 4"
 ./mpm -f /path/to/input-dir/ -i mpm-usf-3d.json -p 8
 ```
 

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,0 +1,32 @@
+#ifndef _MUTEX_
+#define _MUTEX_
+
+#include <atomic>
+
+class SpinMutex {
+ private:
+  std::atomic_flag _lock = ATOMIC_FLAG_INIT;
+  std::atomic<std::size_t> _spin_pred{0};
+
+ public:
+  bool try_lock() { return !_lock.test_and_set(std::memory_order_acquire); }
+
+  void lock() {
+    std::size_t spin_count{0};
+    while (!try_lock()) {
+      ++spin_count;
+
+      if (spin_count < _spin_pred * 2) continue;
+
+      // REVISIT (fbrereto) : Iff sleep_for is guaranteed to block even
+      // when the duration is 0, then std::chrono::nanoseconds(0) will
+      // suffice here.
+      std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+    }
+
+    _spin_pred += (spin_count - _spin_pred) / 8;
+  }
+
+  void unlock() { _lock.clear(std::memory_order_release); }
+};
+#endif

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -3,30 +3,35 @@
 
 #include <atomic>
 
+//! Hybrid SpinMutex class
+//! \brief SpinMutex class that offers a fast locking and unlocking mechanism
 class SpinMutex {
- private:
-  std::atomic_flag _lock = ATOMIC_FLAG_INIT;
-  std::atomic<std::size_t> _spin_pred{0};
 
  public:
-  bool try_lock() { return !_lock.test_and_set(std::memory_order_acquire); }
+  //! Attempt locking
+  bool try_lock() { return !lock_.test_and_set(std::memory_order_acquire); }
 
+  //! Call lock 
   void lock() {
     std::size_t spin_count{0};
     while (!try_lock()) {
       ++spin_count;
 
-      if (spin_count < _spin_pred * 2) continue;
+      if (spin_count < spin_pred_ * 2) continue;
 
-      // REVISIT (fbrereto) : Iff sleep_for is guaranteed to block even
-      // when the duration is 0, then std::chrono::nanoseconds(0) will
-      // suffice here.
       std::this_thread::sleep_for(std::chrono::nanoseconds(1));
     }
 
-    _spin_pred += (spin_count - _spin_pred) / 8;
+    spin_pred_ += (spin_count - spin_pred_) / 8;
   }
 
-  void unlock() { _lock.clear(std::memory_order_release); }
+  //! Call unlock
+  void unlock() { lock_.clear(std::memory_order_release); }
+
+ private:
+  //! Lock variable
+  std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
+  //! Spin prediction
+  std::atomic<std::size_t> spin_pred_{0};
 };
-#endif
+#endif  // _MUTEX_

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,8 +1,9 @@
-#ifndef _MUTEX_
-#define _MUTEX_
+#ifndef MPM_MUTEX_H_
+#define MPM_MUTEX_H_
 
 #include <atomic>
 
+namespace mpm {
 //! Hybrid SpinMutex class
 //! \brief SpinMutex class that offers a fast locking and unlocking mechanism
 class SpinMutex {
@@ -34,4 +35,5 @@ class SpinMutex {
   //! Spin prediction
   std::atomic<std::size_t> spin_pred_{0};
 };
-#endif  // _MUTEX_
+}  // namespace mpm
+#endif  // MPM_MUTEX_H_

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -11,7 +11,7 @@ class SpinMutex {
   //! Attempt locking
   bool try_lock() { return !lock_.test_and_set(std::memory_order_acquire); }
 
-  //! Call lock 
+  //! Call lock
   void lock() {
     std::size_t spin_count{0};
     while (!try_lock()) {

--- a/include/node.h
+++ b/include/node.h
@@ -4,6 +4,7 @@
 #include "logger.h"
 #include "nodal_properties.h"
 #include "node_base.h"
+#include "mutex.h"
 
 namespace mpm {
 
@@ -265,7 +266,7 @@ class Node : public NodeBase<Tdim> {
 
  private:
   //! Mutex
-  std::mutex node_mutex_;
+  SpinMutex node_mutex_;
   //! nodebase id
   Index id_{std::numeric_limits<Index>::max()};
   //! nodal property id

--- a/include/node.h
+++ b/include/node.h
@@ -2,9 +2,9 @@
 #define MPM_NODE_H_
 
 #include "logger.h"
+#include "mutex.h"
 #include "nodal_properties.h"
 #include "node_base.h"
-#include "mutex.h"
 
 namespace mpm {
 

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -54,8 +54,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_mass(bool update, unsigned phase,
   const double factor = (update == true) ? 1. : 0.;
 
   // Update/assign mass
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   mass_(phase) = (mass_(phase) * factor) + mass;
+  node_mutex_.unlock();
 }
 
 //! Update volume at the nodes from particle
@@ -66,8 +67,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_volume(bool update, unsigned phase,
   const double factor = (update == true) ? 1. : 0.;
 
   // Update/assign volume
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   volume_(phase) = volume_(phase) * factor + volume;
+  node_mutex_.unlock();
 }
 
 // Assign concentrated force to the node
@@ -115,8 +117,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_external_force(
   const double factor = (update == true) ? 1. : 0.;
 
   // Update/assign external force
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   external_force_.col(phase) = external_force_.col(phase) * factor + force;
+  node_mutex_.unlock();
 }
 
 //! Update internal force (body force / traction force)
@@ -131,8 +134,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_internal_force(
   const double factor = (update == true) ? 1. : 0.;
 
   // Update/assign internal force
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   internal_force_.col(phase) = internal_force_.col(phase) * factor + force;
+  node_mutex_.unlock();
 }
 
 //! Assign nodal momentum
@@ -147,8 +151,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_momentum(
   const double factor = (update == true) ? 1. : 0.;
 
   // Update/assign momentum
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   momentum_.col(phase) = momentum_.col(phase) * factor + momentum;
+  node_mutex_.unlock();
 }
 
 //! Update pressure at the nodes from particle
@@ -161,8 +166,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_mass_pressure(
   const double tolerance = 1.E-16;
   // Compute pressure from mass*pressure
   if (mass_(phase) > tolerance) {
-    std::lock_guard<std::mutex> guard(node_mutex_);
+    node_mutex_.lock();
     pressure_(phase) += mass_pressure / mass_(phase);
+    node_mutex_.unlock();
   }
 }
 
@@ -171,8 +177,9 @@ template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof, Tnphases>::assign_pressure(unsigned phase,
                                                       double pressure) {
   // Compute pressure from mass*pressure
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   pressure_(phase) = pressure;
+  node_mutex_.unlock();
 }
 
 //! Compute velocity from momentum
@@ -207,8 +214,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_acceleration(
   const double factor = (update == true) ? 1. : 0.;
 
   //! Update/assign acceleration
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   acceleration_.col(phase) = acceleration_.col(phase) * factor + acceleration;
+  node_mutex_.unlock();
 }
 
 //! Compute acceleration and velocity
@@ -515,15 +523,17 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_friction_constraints(double dt) {
 //! Add material id from material points to material_ids_
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof, Tnphases>::append_material_id(unsigned id) {
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   material_ids_.emplace(id);
+  node_mutex_.unlock();
 }
 
 // Assign MPI rank to node
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 bool mpm::Node<Tdim, Tdof, Tnphases>::mpi_rank(unsigned rank) {
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   auto status = this->mpi_ranks_.insert(rank);
+  node_mutex_.unlock();
   return status.second;
 }
 
@@ -534,9 +544,10 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_property(
     const Eigen::MatrixXd& property_value, unsigned mat_id,
     unsigned nprops) noexcept {
   // Update/assign property
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   property_handle_->update_property(property, prop_id_, mat_id, property_value,
                                     nprops);
+  node_mutex_.unlock();
 }
 
 //! Compute multimaterial change in momentum
@@ -545,7 +556,7 @@ void mpm::Node<Tdim, Tdof,
                Tnphases>::compute_multimaterial_change_in_momentum() {
   // iterate over all materials in the material_ids set and update the change in
   // momentum
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   for (auto mitr = material_ids_.begin(); mitr != material_ids_.end(); ++mitr) {
     const Eigen::Matrix<double, 1, 1> mass =
         property_handle_->property("masses", prop_id_, *mitr);
@@ -556,6 +567,7 @@ void mpm::Node<Tdim, Tdof,
     property_handle_->update_property("change_in_momenta", prop_id_, *mitr,
                                       change_in_momenta, Tdim);
   }
+  node_mutex_.unlock();
 }
 
 //! Compute multimaterial separation vector
@@ -565,7 +577,7 @@ void mpm::Node<Tdim, Tdof,
   // iterate over all materials in the material_ids set, update the
   // displacements and calculate the displacement of the center of mass for this
   // node
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   for (auto mitr = material_ids_.begin(); mitr != material_ids_.end(); ++mitr) {
     const auto& material_displacement =
         property_handle_->property("displacements", prop_id_, *mitr, Tdim);
@@ -596,6 +608,7 @@ void mpm::Node<Tdim, Tdof,
     property_handle_->update_property("separation_vectors", prop_id_, *mitr,
                                       separation_vector, Tdim);
   }
+  node_mutex_.unlock();
 }
 
 //! Compute multimaterial normal unit vector
@@ -603,7 +616,7 @@ template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof,
                Tnphases>::compute_multimaterial_normal_unit_vector() {
   // Iterate over all materials in the material_ids set
-  std::lock_guard<std::mutex> guard(node_mutex_);
+  node_mutex_.lock();
   for (auto mitr = material_ids_.begin(); mitr != material_ids_.end(); ++mitr) {
     // calculte the normal unit vector
     VectorDim domain_gradient =
@@ -616,4 +629,5 @@ void mpm::Node<Tdim, Tdof,
     property_handle_->assign_property("normal_unit_vectors", prop_id_, *mitr,
                                       normal_unit_vector, Tdim);
   }
+  node_mutex_.unlock();
 }

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -811,8 +811,9 @@ void mpm::MPMBase<Tdim>::nodal_velocity_constraints(
           // Add velocity constraint to mesh
           auto velocity_constraint =
               std::make_shared<mpm::VelocityConstraint>(nset_id, dir, velocity);
-          bool velocity_constraints = constraints_->assign_nodal_velocity_constraint(
-              nset_id, velocity_constraint);
+          bool velocity_constraints =
+              constraints_->assign_nodal_velocity_constraint(
+                  nset_id, velocity_constraint);
           if (!velocity_constraints)
             throw std::runtime_error(
                 "Nodal velocity constraint is not properly assigned");


### PR DESCRIPTION
**Describe the PR**
Mutex locks take a significant amount of time in OpenMP parallel versions of the code. This update is to reduce the lock by trying a spinlock and reduce the wait times across threads. 

Enable setting the chunk size in OpenMP schedule using
```
export OMP_SCHEDULE="static, 4"
```
This allows for a finer control without having to recompile for different chunk sizes when running different problems. If the variable is not set, the code will still run.

**Additional context**
Spinlocks vs mutexes are a computational bottleneck. However, we cannot use std::atomic, so this is a good workaround the lack of std::atomic support for Eigen and Vector containers. The speed is improved by about 4 - 5 % for the 3D hydrostatic column.

| **OMP Schedule static chunk size** | **Time (s)** | **Speedup** |
|--------------------------------|----------|---------|
| no schedule                    | 742      | 1       |
| 4                              | 725.3    | 1.023   |
| **16**                             | 721.5    | **1.028**   |
| 128                            | 735.2    | 1.009   |
| 512                            | 736.7    | 1.007   |
| 1000                           | 760      | 0.976   |
| **SpinMutex with Chunk-4**         | 711      | **1.044**   |
