### PR TITLE
[Hotfix] Assign material state variables

### DIFF
--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -262,16 +262,16 @@ void mpm::Particle<Tdim>::initialise_material(unsigned phase_size) {
   std::fill(state_variables_.begin(), state_variables_.end(), mpm::dense_map());
 }
 
-//! Assign material state variables from neighbour particle
+//! Assign material history variables
 template <unsigned Tdim>
 bool mpm::Particle<Tdim>::assign_material_state_vars(
     const mpm::dense_map& state_vars,
     const std::shared_ptr<mpm::Material<Tdim>>& material, unsigned phase) {
   bool status = false;
-  if (material != nullptr && this->material() != nullptr &&
-      this->material_id() == material->id()) {
+  if (material != nullptr && this->material(phase) != nullptr &&
+      this->material_id(phase) == material->id()) {
     // Clone state variables
-    auto mat_state_vars = (this->material())->initialise_state_variables();
+    auto mat_state_vars = (this->material(phase))->initialise_state_variables();
     if (state_variables_[phase].size() == state_vars.size() &&
         mat_state_vars.size() == state_vars.size()) {
       this->state_variables_[phase] = state_vars;


### PR DESCRIPTION
**Describe the PR**
A fast PR to fix a possible bug with `material` and `material_id` phase in function `assign_material_state_vars`.

**Related Issues/PRs**
It was missing from my previous PR #675. Sorry!

**Additional context**
Actually the function `assign_material_state_vars` is never been called in the solver, but maybe needed for cloning particle process.