### PR TITLE
[Solver] Explicit Modified Update Stress Last solver

### DIFF
--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -140,6 +140,9 @@ class Particle : public ParticleBase<Tdim> {
   //! Map particle mass and momentum to nodes
   void map_mass_momentum_to_nodes() noexcept override;
 
+  //! Map particle momentum to nodes
+  void map_momentum_to_nodes() noexcept override;
+
   //! Map multimaterial properties to nodes
   void map_multimaterial_mass_momentum_to_nodes() noexcept override;
 

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -523,6 +523,19 @@ void mpm::Particle<Tdim>::map_mass_momentum_to_nodes() noexcept {
   }
 }
 
+//! Map particle momentum to nodes
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::map_momentum_to_nodes() noexcept {
+  // Check if particle mass is set
+  assert(mass_ != std::numeric_limits<double>::max());
+
+  // Map momentum to nodes
+  for (unsigned i = 0; i < nodes_.size(); ++i) {
+    nodes_[i]->update_momentum(true, mpm::ParticlePhase::Solid,
+                               mass_ * shapefn_[i] * velocity_);
+  }
+}
+
 //! Map multimaterial properties to nodes
 template <unsigned Tdim>
 void mpm::Particle<Tdim>::map_multimaterial_mass_momentum_to_nodes() noexcept {

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -141,6 +141,9 @@ class ParticleBase {
   //! Map particle mass and momentum to nodes
   virtual void map_mass_momentum_to_nodes() noexcept = 0;
 
+  //! Map particle momentum to nodes
+  virtual void map_momentum_to_nodes() noexcept = 0;
+
   //! Map multimaterial properties to nodes
   virtual void map_multimaterial_mass_momentum_to_nodes() noexcept = 0;
 

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -291,6 +291,49 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Update Stress Last
     if (this->stress_update_ == mpm::StressUpdate::USL)
       this->compute_stress_strain(phase);
+    // Modified Update Stress Last
+    else if (this->stress_update_ == mpm::StressUpdate::MUSL) {
+
+#pragma omp parallel sections
+      {
+        // Spawn a task for initialising nodes and cells
+#pragma omp section
+        {
+          // Reinitialise nodal momentum
+          mesh_->iterate_over_nodes(std::bind(
+              &mpm::NodeBase<Tdim>::update_momentum, std::placeholders::_1,
+              false, phase, Eigen::Matrix<double, Tdim, 1>::Zero()));
+        }
+      }  // Wait to complete
+
+      // Assign momentum to nodes
+      mesh_->iterate_over_particles(
+          std::bind(&mpm::ParticleBase<Tdim>::map_momentum_to_nodes,
+                    std::placeholders::_1));
+
+#ifdef USE_MPI
+      // Run if there is more than a single MPI task
+      if (mpi_size > 1) {
+        // MPI all reduce nodal momentum
+        mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>,
+                                            Tdim>(
+            std::bind(&mpm::NodeBase<Tdim>::momentum, std::placeholders::_1,
+                      phase),
+            std::bind(&mpm::NodeBase<Tdim>::update_momentum,
+                      std::placeholders::_1, false, phase,
+                      std::placeholders::_2));
+      }
+#endif
+
+      // Compute nodal velocity
+      mesh_->iterate_over_nodes_predicate(
+          std::bind(&mpm::NodeBase<Tdim>::compute_velocity,
+                    std::placeholders::_1),
+          std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
+
+      // Compute stress and strain
+      this->compute_stress_strain(phase);
+    }
 
     // Locate particles
     auto unlocatable_particles = mesh_->locate_particles_mesh();

--- a/tests/mpm_explicit_musl_test.cc
+++ b/tests/mpm_explicit_musl_test.cc
@@ -7,17 +7,17 @@ using Json = nlohmann::json;
 #include "mpm_explicit.h"
 #include "write_mesh_particles.h"
 
-// Check MPM Explicit USF
-TEST_CASE("MPM 2D Explicit USF implementation is checked",
-          "[MPM][2D][Explicit][USF][1Phase]") {
+// Check MPM Explicit MUSL
+TEST_CASE("MPM 2D Explicit MUSL implementation is checked",
+          "[MPM][2D][Explicit][MUSL][1Phase]") {
   // Dimension
   const unsigned Dim = 2;
 
   // Write JSON file
-  const std::string fname = "mpm-explicit-usf";
+  const std::string fname = "mpm-explicit-musl";
   const std::string analysis = "MPMExplicit2D";
-  const std::string stress_update = "usf";
-  bool resume = false;
+  const std::string stress_update = "musl";
+  const bool resume = false;
   REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
           true);
 
@@ -35,7 +35,7 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked",
   // clang-format off
   char* argv[] = {(char*)"./mpm",
                   (char*)"-f",  (char*)"./",
-                  (char*)"-i",  (char*)"mpm-explicit-usf-2d.json"};
+                  (char*)"-i",  (char*)"mpm-explicit-musl-2d.json"};
   // clang-format on
 
   SECTION("Check initialisation") {
@@ -71,9 +71,9 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked",
 
   SECTION("Check resume") {
     // Write JSON file
-    const std::string fname = "mpm-explicit-usf";
+    const std::string fname = "mpm-explicit-musl";
     const std::string analysis = "MPMExplicit2D";
-    const std::string stress_update = "usf";
+    const std::string stress_update = "musl";
     bool resume = true;
     REQUIRE(mpm_test::write_json(2, resume, analysis, stress_update, fname) ==
             true);
@@ -99,16 +99,16 @@ TEST_CASE("MPM 2D Explicit USF implementation is checked",
   }
 }
 
-// Check MPM Explicit USF
-TEST_CASE("MPM 3D Explicit USF implementation is checked",
-          "[MPM][3D][Explicit][USF][1Phase]") {
+// Check MPM Explicit MUSL
+TEST_CASE("MPM 3D Explicit MUSL implementation is checked",
+          "[MPM][3D][Explicit][MUSL][1Phase]") {
   // Dimension
   const unsigned Dim = 3;
 
   // Write JSON file
-  const std::string fname = "mpm-explicit-usf";
+  const std::string fname = "mpm-explicit-musl";
   const std::string analysis = "MPMExplicit3D";
-  const std::string stress_update = "usf";
+  const std::string stress_update = "musl";
   const bool resume = false;
   REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
           true);
@@ -127,7 +127,7 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked",
   // clang-format off
   char* argv[] = {(char*)"./mpm",
                   (char*)"-f",  (char*)"./",
-                  (char*)"-i",  (char*)"mpm-explicit-usf-3d.json"};
+                  (char*)"-i",  (char*)"mpm-explicit-musl-3d.json"};
   // clang-format on
 
   SECTION("Check initialisation") {
@@ -160,9 +160,9 @@ TEST_CASE("MPM 3D Explicit USF implementation is checked",
 
   SECTION("Check resume") {
     // Write JSON file
-    const std::string fname = "mpm-explicit-usf";
+    const std::string fname = "mpm-explicit-musl";
     const std::string analysis = "MPMExplicit3D";
-    const std::string stress_update = "usf";
+    const std::string stress_update = "musl";
     bool resume = true;
     REQUIRE(mpm_test::write_json(3, resume, analysis, stress_update, fname) ==
             true);

--- a/tests/mpm_explicit_musl_unitcell_test.cc
+++ b/tests/mpm_explicit_musl_unitcell_test.cc
@@ -1,0 +1,119 @@
+#include "catch.hpp"
+
+//! Alias for JSON
+#include "json.hpp"
+using Json = nlohmann::json;
+
+#include "mpm_explicit.h"
+#include "write_mesh_particles_unitcell.h"
+
+// Check MPM Explicit MUSL
+TEST_CASE("MPM 2D Explicit MUSL implementation is checked in unitcells",
+          "[MPM][2D][MUSL][Explicit][1Phase][unitcell]") {
+  // Dimension
+  const unsigned Dim = 2;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit2D";
+  const std::string stress_update = "musl";
+  REQUIRE(mpm_test::write_json_unitcell(2, analysis, stress_update, fname) ==
+          true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_2d_unitcell() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_2d_unitcell() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-2d-unitcell.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE(mpm->initialise_materials() == true);
+
+    // Initialise mesh and particles
+    REQUIRE(mpm->initialise_mesh() == true);
+    REQUIRE(mpm->initialise_particles() == true);
+
+    // Initialise external loading
+    REQUIRE(mpm->initialise_loads() == true);
+
+    // Renitialise materials
+    REQUIRE(mpm->initialise_materials() == false);
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+  }
+}
+
+// Check MPM Explicit
+TEST_CASE("MPM 3D Explicit MUSL implementation is checked in unitcells",
+          "[MPM][3D][Explicit][MUSL][1Phase][unitcell]") {
+  // Dimension
+  const unsigned Dim = 3;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit3D";
+  const std::string stress_update = "musl";
+  REQUIRE(mpm_test::write_json_unitcell(3, analysis, stress_update, fname) ==
+          true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_3d_unitcell() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_3d_unitcell() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-3d-unitcell.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE(mpm->initialise_materials() == true);
+
+    // Initialise mesh and particles
+    REQUIRE(mpm->initialise_mesh() == true);
+    REQUIRE(mpm->initialise_particles() == true);
+
+    // Renitialise materials
+    REQUIRE(mpm->initialise_materials() == false);
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+  }
+}

--- a/tests/mpm_explicit_usl_test.cc
+++ b/tests/mpm_explicit_usl_test.cc
@@ -88,6 +88,15 @@ TEST_CASE("MPM 2D Explicit USL implementation is checked",
     // Solve
     REQUIRE(mpm->solve() == true);
   }
+
+  SECTION("Check pressure smoothing") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Pressure smoothing
+    REQUIRE_NOTHROW(mpm->pressure_smoothing(0));
+  }
 }
 
 // Check MPM Explicit USL
@@ -167,5 +176,14 @@ TEST_CASE("MPM 3D Explicit USL implementation is checked",
     REQUIRE(mpm->checkpoint_resume() == true);
     // Solve
     REQUIRE(mpm->solve() == true);
+  }
+
+  SECTION("Check pressure smoothing") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Pressure smoothing
+    REQUIRE_NOTHROW(mpm->pressure_smoothing(0));
   }
 }

--- a/tests/particle_test.cc
+++ b/tests/particle_test.cc
@@ -804,6 +804,14 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
         REQUIRE(nodes.at(i)->velocity(phase)(j) ==
                 Approx(nodal_velocity(i, j)).epsilon(Tolerance));
 
+    REQUIRE_NOTHROW(particle->map_momentum_to_nodes());
+    // clang-format on
+    // Check nodal momentum
+    for (unsigned i = 0; i < nodal_momentum.rows(); ++i)
+      for (unsigned j = 0; j < nodal_momentum.cols(); ++j)
+        REQUIRE(nodes.at(i)->momentum(phase)(j) ==
+                Approx(2. * nodal_momentum(i, j)).epsilon(Tolerance));
+
     // Set momentum to get non-zero strain
     // clang-format off
     nodal_momentum << 0., 562.5 * 1.,
@@ -2071,6 +2079,14 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
       for (unsigned j = 0; j < nodal_velocity.cols(); ++j)
         REQUIRE(nodes.at(i)->velocity(phase)(j) ==
                 Approx(nodal_velocity(i, j)).epsilon(Tolerance));
+
+    REQUIRE_NOTHROW(particle->map_momentum_to_nodes());
+    // clang-format on
+    // Check nodal momentum
+    for (unsigned i = 0; i < nodal_momentum.rows(); ++i)
+      for (unsigned j = 0; j < nodal_momentum.cols(); ++j)
+        REQUIRE(nodes.at(i)->momentum(phase)(j) ==
+                Approx(2. * nodal_momentum(i, j)).epsilon(Tolerance));
 
     // Set momentum to get non-zero strain
     // clang-format off


### PR DESCRIPTION
**Describe the PR**
This PR quickly adds the explicit MUSL solver capability in our `mpm_explicit` solver. I thought it will be useful as the `mpm::StressUpdate::MUSL` is available, though never be used. Due to its considerably slower performance, if you think the MUSL option is not necessary, let's remove the MUSL option.

**Additional context**
The MUSL option is basically similar to USL stress update, though require one more time momentum update right before recomputing strain_rate and strain for stress update. I ran the benchmark tests in both serial and parallel and both are ok! The necessity to do `map_momentum_to_nodes` and the `compute_velocity` one more time add a bit more computation time, so I am not sure if it is so useful. Here is the time comparison for the 3D hydrostatic column test in our benchmark test run in my local machine.

| Stress Update                   | Runtime (s) |
|--------------------------|-------------------|
| USF                  | 512.5            |
| USL | 505.4             |
| MUSL       | 560.2             |

