### PR TITLE
[Feature] State variable vtk output for different phases

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -266,6 +266,7 @@ class Mesh {
 
   //! Return particles state variable data
   //! \param[in] attribute Name of the state variable attribute
+  //! \param[in] phase Index corresponding to the phase
   std::vector<double> particles_statevars_data(
       const std::string& attribute, unsigned phase = mpm::ParticlePhase::Solid);
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -264,8 +264,8 @@ class Mesh {
   std::vector<Eigen::Matrix<double, Tsize, 1>> particles_tensor_data(
       const std::string& attribute);
 
-  //! Return particles scalar data
-  //! \param[in] attribute Name of the scalar data attribute
+  //! Return particles state variable data
+  //! \param[in] attribute Name of the state variable attribute
   std::vector<double> particles_statevars_data(
       const std::string& attribute, unsigned phase = mpm::ParticlePhase::Solid);
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -266,7 +266,8 @@ class Mesh {
 
   //! Return particles scalar data
   //! \param[in] attribute Name of the scalar data attribute
-  std::vector<double> particles_statevars_data(const std::string& attribute);
+  std::vector<double> particles_statevars_data(
+      const std::string& attribute, unsigned phase = mpm::ParticlePhase::Solid);
 
   //! Compute and assign rotation matrix to nodes
   //! \param[in] euler_angles Map of node number and respective euler_angles

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1105,12 +1105,12 @@ std::vector<Eigen::Matrix<double, Tsize, 1>>
 template <unsigned Tdim>
 std::vector<double> mpm::Mesh<Tdim>::particles_statevars_data(
     const std::string& attribute, unsigned phase) {
-  std::vector<double> scalar_data;
-  scalar_data.reserve(particles_.size());
+  std::vector<double> statevars_data;
+  statevars_data.reserve(particles_.size());
   // Iterate over particles and add scalar value to data
   for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr)
-    scalar_data.emplace_back((*pitr)->state_variable(attribute, phase));
-  return scalar_data;
+    statevars_data.emplace_back((*pitr)->state_variable(attribute, phase));
+  return statevars_data;
 }
 
 //! Assign particles volumes

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1101,7 +1101,7 @@ std::vector<Eigen::Matrix<double, Tsize, 1>>
   return tensor_data;
 }
 
-//! Return particle scalar data
+//! Return particle state variable data
 template <unsigned Tdim>
 std::vector<double> mpm::Mesh<Tdim>::particles_statevars_data(
     const std::string& attribute, unsigned phase) {

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -1104,12 +1104,12 @@ std::vector<Eigen::Matrix<double, Tsize, 1>>
 //! Return particle scalar data
 template <unsigned Tdim>
 std::vector<double> mpm::Mesh<Tdim>::particles_statevars_data(
-    const std::string& attribute) {
+    const std::string& attribute, unsigned phase) {
   std::vector<double> scalar_data;
   scalar_data.reserve(particles_.size());
   // Iterate over particles and add scalar value to data
   for (auto pitr = particles_.cbegin(); pitr != particles_.cend(); ++pitr)
-    scalar_data.emplace_back((*pitr)->state_variable(attribute));
+    scalar_data.emplace_back((*pitr)->state_variable(attribute, phase));
   return scalar_data;
 }
 

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -193,7 +193,7 @@ class MPMBase : public MPM {
   //! Mathematical functions
   std::map<unsigned, std::shared_ptr<mpm::FunctionBase>> math_functions_;
   //! VTK state variables
-  std::vector<std::string> vtk_statevars_;
+  std::map<unsigned, std::vector<std::string>> vtk_statevars_;
   //! Set node concentrated force
   bool set_node_concentrated_force_{false};
   //! Damping type

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -193,7 +193,7 @@ class MPMBase : public MPM {
   //! Mathematical functions
   std::map<unsigned, std::shared_ptr<mpm::FunctionBase>> math_functions_;
   //! VTK state variables
-  std::map<unsigned, std::vector<std::string>> vtk_statevars_;
+  tsl::robin_map<unsigned, std::vector<std::string>> vtk_statevars_;
   //! Set node concentrated force
   bool set_node_concentrated_force_{false};
   //! Damping type

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -98,42 +98,27 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
         post_process_.at("vtk_statevars").size() > 0) {
       // Iterate over state_vars
       for (const auto& svars : post_process_["vtk_statevars"]) {
-        // Initial phase id and state vars
+        // Phase id
         unsigned phase_id = 0;
+        if (svars.contains("phase_id"))
+          phase_id = svars.at("phase_id").template get<unsigned>();
+
+        // State variables
         std::vector<std::string> state_var;
-
-        // If state variables are arranged as string
-        if (svars.is_string()) {
-          std::string attribute = svars.template get<std::string>();
-          state_var.emplace_back(attribute);
-        }
-        // If state variables are arranged as json object
-        else if (svars.is_object()) {
-          // Phase id
-          if (svars.contains("phase_id"))
-            phase_id = svars.at("phase_id").template get<unsigned>();
-
-          // State variables
-          if (svars.at("statevars").is_array() &&
-              svars.at("statevars").size() > 0) {
-            for (unsigned i = 0; i < svars.at("statevars").size(); ++i) {
-              std::string attribute =
-                  svars["statevars"][i].template get<std::string>();
-              state_var.emplace_back(attribute);
-            }
-          } else {
-            throw std::runtime_error(
-                "No VTK statevariable were specified, none will be generated");
+        if (svars.at("statevars").is_array() &&
+            svars.at("statevars").size() > 0) {
+          for (unsigned i = 0; i < svars.at("statevars").size(); ++i) {
+            std::string attribute =
+                svars["statevars"][i].template get<std::string>();
+            state_var.emplace_back(attribute);
           }
+        } else {
+          throw std::runtime_error(
+              "No VTK statevariable were specified, none will be generated");
         }
 
-        // Check if vtk_statevars_ has the designated phase_id
-        if (vtk_statevars_.find(phase_id) != vtk_statevars_.end())
-          vtk_statevars_.at(phase_id).insert(vtk_statevars_.at(phase_id).end(),
-                                             state_var.begin(),
-                                             state_var.end());
-        else
-          vtk_statevars_.insert(std::make_pair(phase_id, state_var));
+        // Insert vtk_statevars_
+        vtk_statevars_.insert(std::make_pair(phase_id, state_var));
       }
     } else {
       throw std::runtime_error(
@@ -591,7 +576,8 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
   for (auto const& vtk_statevar : vtk_statevars_) {
     unsigned phase_id = vtk_statevar.first;
     for (const auto& attribute : vtk_statevar.second) {
-      std::string phase_attribute = "P" + std::to_string(phase_id) + attribute;
+      std::string phase_attribute =
+          "phase" + std::to_string(phase_id) + attribute;
       // Write state variables
       auto file =
           io_->output_file(phase_attribute, extension, uuid_, step, max_steps)

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -93,40 +93,31 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
   }
 
   // VTK state variables
-  try {
-    if (post_process_.at("vtk_statevars").is_array() &&
-        post_process_.at("vtk_statevars").size() > 0) {
-      // Iterate over state_vars
-      for (const auto& svars : post_process_["vtk_statevars"]) {
-        // Phase id
-        unsigned phase_id = 0;
-        if (svars.contains("phase_id"))
-          phase_id = svars.at("phase_id").template get<unsigned>();
+  if (post_process_.at("vtk_statevars").is_array() &&
+      post_process_.at("vtk_statevars").size() > 0) {
+    // Iterate over state_vars
+    for (const auto& svars : post_process_["vtk_statevars"]) {
+      // Phase id
+      unsigned phase_id = 0;
+      if (svars.contains("phase_id"))
+        phase_id = svars.at("phase_id").template get<unsigned>();
 
-        // State variables
-        std::vector<std::string> state_var;
-        if (svars.at("statevars").is_array() &&
-            svars.at("statevars").size() > 0) {
-          for (unsigned i = 0; i < svars.at("statevars").size(); ++i) {
-            std::string attribute =
-                svars["statevars"][i].template get<std::string>();
-            state_var.emplace_back(attribute);
-          }
-        } else {
-          throw std::runtime_error(
-              "No VTK statevariable were specified, none will be generated");
-        }
-
+      // State variables
+      if (svars.at("statevars").is_array() &&
+          svars.at("statevars").size() > 0) {
         // Insert vtk_statevars_
+        const std::vector<std::string> state_var = svars["statevars"];
         vtk_statevars_.insert(std::make_pair(phase_id, state_var));
-      }
-    } else {
-      throw std::runtime_error(
-          "No VTK statevariable were specified, none will be generated");
+      } else
+        console_->warn(
+            "{} #{}: No VTK statevariable were specified, none will be "
+            "generated",
+            __FILE__, __LINE__);
     }
-  } catch (std::exception& exception) {
-    console_->warn("{} {}: {}", __FILE__, __LINE__, exception.what());
-  }
+  } else
+    console_->warn(
+        "{} #{}: No VTK statevariable were specified, none will be generated",
+        __FILE__, __LINE__);
 }
 
 // Initialise mesh

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -96,10 +96,44 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
   try {
     if (post_process_.at("vtk_statevars").is_array() &&
         post_process_.at("vtk_statevars").size() > 0) {
-      for (unsigned i = 0; i < post_process_.at("vtk_statevars").size(); ++i) {
-        std::string attribute =
-            post_process_["vtk_statevars"][i].template get<std::string>();
-        vtk_statevars_.emplace_back(attribute);
+      // Iterate over state_vars
+      for (const auto& svars : post_process_["vtk_statevars"]) {
+        // Initial phase id and state vars
+        unsigned phase_id = 0;
+        std::vector<std::string> state_var;
+
+        // If state variables are arranged as string
+        if (svars.is_string()) {
+          std::string attribute = svars.template get<std::string>();
+          state_var.emplace_back(attribute);
+        }
+        // If state variables are arranged as json object
+        else if (svars.is_object()) {
+          // Phase id
+          if (svars.contains("phase_id"))
+            phase_id = svars.at("phase_id").template get<unsigned>();
+
+          // State variables
+          if (svars.at("statevars").is_array() &&
+              svars.at("statevars").size() > 0) {
+            for (unsigned i = 0; i < svars.at("statevars").size(); ++i) {
+              std::string attribute =
+                  svars["statevars"][i].template get<std::string>();
+              state_var.emplace_back(attribute);
+            }
+          } else {
+            throw std::runtime_error(
+                "No VTK statevariable were specified, none will be generated");
+          }
+        }
+
+        // Check if vtk_statevars_ has the designated phase_id
+        if (vtk_statevars_.find(phase_id) != vtk_statevars_.end())
+          vtk_statevars_.at(phase_id).insert(vtk_statevars_.at(phase_id).end(),
+                                             state_var.begin(),
+                                             state_var.end());
+        else
+          vtk_statevars_.insert(std::make_pair(phase_id, state_var));
       }
     } else {
       throw std::runtime_error(
@@ -554,23 +588,29 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
   }
 
   // VTK state variables
-  for (const auto& attribute : vtk_statevars_) {
-    // Write state variables
-    auto file =
-        io_->output_file(attribute, extension, uuid_, step, max_steps).string();
-    vtk_writer->write_scalar_point_data(
-        file, mesh_->particles_statevars_data(attribute), attribute);
-    // Write a parallel MPI VTK container file
+  for (auto const& vtk_statevar : vtk_statevars_) {
+    unsigned phase_id = vtk_statevar.first;
+    for (const auto& attribute : vtk_statevar.second) {
+      std::string phase_attribute = "P" + std::to_string(phase_id) + attribute;
+      // Write state variables
+      auto file =
+          io_->output_file(phase_attribute, extension, uuid_, step, max_steps)
+              .string();
+      vtk_writer->write_scalar_point_data(
+          file, mesh_->particles_statevars_data(attribute, phase_id),
+          phase_attribute);
+      // Write a parallel MPI VTK container file
 #ifdef USE_MPI
-    if (mpi_rank == 0 && mpi_size > 1) {
-      auto parallel_file = io_->output_file(attribute, ".pvtp", uuid_, step,
-                                            max_steps, write_mpi_rank)
-                               .string();
-      unsigned ncomponents = 1;
-      vtk_writer->write_parallel_vtk(parallel_file, attribute, mpi_size, step,
-                                     max_steps, ncomponents);
-    }
+      if (mpi_rank == 0 && mpi_size > 1) {
+        auto parallel_file = io_->output_file(phase_attribute, ".pvtp", uuid_,
+                                              step, max_steps, write_mpi_rank)
+                                 .string();
+        unsigned ncomponents = 1;
+        vtk_writer->write_parallel_vtk(parallel_file, phase_attribute, mpi_size,
+                                       step, max_steps, ncomponents);
+      }
 #endif
+    }
   }
 }
 #endif

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -101,7 +101,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
       {"post_processing",
        {{"path", "results/"},
         {"vtk", {{"stresses", "strains", "velocity"}}},
-        {"vtk_statevars", {{"pdstrain"}}},
+        {"vtk_statevars", {{{"phase_id", 0}, {"statevars", "pdstrain"}}}},
         {"output_steps", 5}}}};
 
   // Dump JSON as an input file to be read

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -101,7 +101,7 @@ bool write_json(unsigned dim, bool resume, const std::string& analysis,
       {"post_processing",
        {{"path", "results/"},
         {"vtk", {{"stresses", "strains", "velocity"}}},
-        {"vtk_statevars", {{{"phase_id", 0}, {"statevars", "pdstrain"}}}},
+        {"vtk_statevars", {{{"phase_id", 0}, {"statevars", {"pdstrain"}}}}},
         {"output_steps", 5}}}};
 
   // Dump JSON as an input file to be read

--- a/tests/io/write_mesh_particles_unitcell.cc
+++ b/tests/io/write_mesh_particles_unitcell.cc
@@ -96,7 +96,7 @@ bool write_json_unitcell(unsigned dim, const std::string& analysis,
         {"newmark", {{"newmark", true}, {"gamma", 0.5}, {"beta", 0.25}}}}},
       {"post_processing",
        {{"path", "results/"},
-        {"vtk_statevars", {{"pdstrain"}}},
+        {"vtk_statevars", {{{"phase_id", 0}, {"statevars", "pdstrain"}}}},
         {"output_steps", 10}}}};
 
   // Dump JSON as an input file to be read


### PR DESCRIPTION
**Describe the PR**
This PR enhances the capability to output vtk files for two-phase particles following the material container refactoring done in PR #675 and #678.

**Related Issues/PRs**
PR #675 and #678 as well as PR #680 and Issue #633.

**Additional context**
This will break the existing input configuration. User should change the current `vtk_statevars` arrangement:
```
"vtk_statevars": ["pressure", "pdstrain"]
```
to the new one with `phase_id`:
```
"vtk_statevars": [
	{
		"phase_id" : 0,
		"statevars": ["pressure", "pdstrain"]
	},
	{
		"phase_id" : 1,
		"statevars": ["pressure"]
	}
]
```
If the user doesn't specify the `phase_id`, it is assumed that the `phase_id` is 0 by default.
```
"vtk_statevars": [
	{
		"statevars": ["pressure", "pdstrain"]
	}
]
```
There is a slight change also in the outputted file name. Instead of producing `pressureXYZ.vtp` or `pressureXYZ.pvtp` as output, the modified code will produce `P0pressureXYZ.vtp` and `P0pressureXYZ.pvtp` or `P1pressureXYZ.vtp` and `P1pressureXYZ.pvtp` for the solid and liquid phase, respectively. I am okay with any other idea of naming the output file, though we need to make it different, as otherwise, the second phase will overwrite the first one.