### PR TITLE
:hammer: Fix instructions for running openmp schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ The CB-Geo MPM code uses a `JSON` file for input configuration. To run the mpm c
 For example:
 
 ```
-export OMP_SCHEDULE="static, 4"
-./mpm -f /path/to/input-dir/ -i mpm-usf-3d.json -p 8
+export OMP_SCHEDULE="static,4"
+./mpm -f /path/to/input-dir/ -i mpm-usf-3d.json
 ```
 
 Where:


### PR DESCRIPTION
**Describe the PR**
The instructions in the README has an additional space which is incorrect and causes problem:

```
OMP: Warning #52: OMP_SCHEDULE value " 4" is invalid chunk size.
OMP: Info #104: OMP_SCHEDULE value "0" will be used.
OMP: Warning #52: OMP_SCHEDULE value " 4" is invalid chunk size.
OMP: Info #104: OMP_SCHEDULE value "0" will be used.
```

This is due to `export OMP_SCHEDULE="static, 4"` and should be `export OMP_SCHEDULE="static,4"`, without the space between `static` and `4`

**Related Issues/PRs**
https://cb-geo.discourse.group/t/openmp-issue-on-tacc/196