### PR TITLE
Increase MPI buffer to avoid errors in sending

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ workflows:
             - clang
             - cppcheck
             - codecov
+            - benchmarks
     nightly:
         jobs:
             - benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ workflows:
             - clang
             - cppcheck
             - codecov
-            - benchmarks
     nightly:
         jobs:
             - benchmarks

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -848,15 +848,15 @@ void mpm::Mesh<Tdim>::transfer_nonrank_particles(
 
         // Send number of particles to receiver rank
         unsigned nparticles = cell->nparticles();
-        MPI_Isend(&nparticles, 1, MPI_UNSIGNED, cell->rank(), 0, MPI_COMM_WORLD,
-                  &send_requests[nsend_requests]);
+        MPI_Ibsend(&nparticles, 1, MPI_UNSIGNED, cell->rank(), 0,
+                   MPI_COMM_WORLD, &send_requests[nsend_requests]);
 
         auto particle_ids = cell->particles();
         for (auto& id : particle_ids) {
           // Create a vector of serialized particle
           std::vector<uint8_t> buffer = map_particles_[id]->serialize();
-          MPI_Isend(buffer.data(), buffer.size(), MPI_UINT8_T, cell->rank(), 0,
-                    MPI_COMM_WORLD, &send_particle_requests[np]);
+          MPI_Ibsend(buffer.data(), buffer.size(), MPI_UINT8_T, cell->rank(), 0,
+                     MPI_COMM_WORLD, &send_particle_requests[np]);
           ++np;
 
           // Particles to be removed from the current rank

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -977,8 +977,8 @@ std::vector<uint8_t> mpm::Particle<Tdim>::serialize() {
   unsigned nmaterials = material_id_.size();
   MPI_Pack(&nmaterials, 1, MPI_UNSIGNED, data_ptr, data.size(), &position,
            MPI_COMM_WORLD);
-  MPI_Pack(&material_id_[mpm::ParticlePhase::Solid], 1, MPI_UNSIGNED, data_ptr, data.size(), &position,
-           MPI_COMM_WORLD);
+  MPI_Pack(&material_id_[mpm::ParticlePhase::Solid], 1, MPI_UNSIGNED, data_ptr,
+           data.size(), &position, MPI_COMM_WORLD);
 
   // ID
   MPI_Pack(&id_, 1, MPI_UNSIGNED_LONG_LONG, data_ptr, data.size(), &position,


### PR DESCRIPTION
**Describe the PR**

On domain decomposition, `transfer_nonrank_particles` gave an error when running on multiple MPI tasks. It resulted in corrupted particle data.

![image](https://user-images.githubusercontent.com/3963513/94037520-f8e63b00-fdb4-11ea-904c-5ea13235f7ee.png)

The buffer point in `MPI_Isend` ran out of scope/space. When using a thread-safe `MPI_Ibsend` instead of `MPI_Isend` the following error happened. 
```
Abort(67117313) on node 0 (rank 0 in comm 0): Fatal error in PMPI_Ibsend: Invalid buffer pointer, error stack:
```
Which clearly shows the error is because of running out of buffer space.

The MPI buffer space is increased in the main function to avoid this error.

**Related Issues/PRs**
#696 