### PR TITLE
[Hotfix] Deserialize particle bug

### DIFF
--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -1082,6 +1082,9 @@ void mpm::Particle<Tdim>::deserialize(
   // volume
   MPI_Unpack(data_ptr, data.size(), &position, &volume_, 1, MPI_DOUBLE,
              MPI_COMM_WORLD);
+  // mass density
+  this->mass_density_ = mass_ / volume_;
+
   // pressure
   double pressure;
   MPI_Unpack(data_ptr, data.size(), &position, &pressure, 1, MPI_DOUBLE,
@@ -1133,7 +1136,7 @@ void mpm::Particle<Tdim>::deserialize(
   if (nstate_vars > 0) {
     std::vector<double> svars;
     svars.reserve(nstate_vars);
-    MPI_Unpack(data_ptr, data.size(), &position, &svars, nstate_vars,
+    MPI_Unpack(data_ptr, data.size(), &position, &svars[0], nstate_vars,
                MPI_DOUBLE, MPI_COMM_WORLD);
 
     // Reinitialize state variables

--- a/tests/particle_serialize_deserialize_test.cc
+++ b/tests/particle_serialize_deserialize_test.cc
@@ -38,6 +38,19 @@ TEST_CASE("Particle is checked for serialization and deserialization",
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
         std::make_shared<mpm::Particle<Dim>>(id, pcoords);
 
+    // Initialise material
+    Json jmaterial;
+    jmaterial["density"] = 1000.;
+    jmaterial["bulk_modulus"] = 2.E9;
+    jmaterial["dynamic_viscosity"] = 8.9E-4;
+    unsigned mid = 1;
+
+    auto material =
+        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
+            "Newtonian3D", std::move(mid), jmaterial);
+    std::vector<std::shared_ptr<mpm::Material<Dim>>> materials;
+    materials.emplace_back(material);
+
     mpm::HDF5Particle h5_particle;
     h5_particle.id = 13;
     h5_particle.mass = 501.5;
@@ -94,21 +107,12 @@ TEST_CASE("Particle is checked for serialization and deserialization",
 
     h5_particle.material_id = 1;
 
+    h5_particle.nstate_vars = 1;
+
+    h5_particle.svars[0] = 1000.0;
+
     // Reinitialise particle from HDF5 data
-    REQUIRE(particle->initialise_particle(h5_particle) == true);
-
-    // Initialise material
-    Json jmaterial;
-    jmaterial["density"] = 1000.;
-    jmaterial["youngs_modulus"] = 1.0E+7;
-    jmaterial["poisson_ratio"] = 0.3;
-    unsigned mid = 1;
-
-    auto material =
-        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
-            "LinearElastic3D", std::move(mid), jmaterial);
-    std::vector<std::shared_ptr<mpm::Material<Dim>>> materials;
-    materials.emplace_back(material);
+    REQUIRE(particle->initialise_particle(h5_particle, material) == true);
 
     // Serialize particle
     auto buffer = particle->serialize();
@@ -128,6 +132,8 @@ TEST_CASE("Particle is checked for serialization and deserialization",
     REQUIRE(particle->volume() == rparticle->volume());
     // Check particle mass density
     REQUIRE(particle->mass_density() == rparticle->mass_density());
+    // Check particle pressure
+    REQUIRE(particle->pressure() == rparticle->pressure());
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
 
@@ -176,6 +182,17 @@ TEST_CASE("Particle is checked for serialization and deserialization",
 
     // Check material id
     REQUIRE(particle->material_id() == rparticle->material_id());
+
+    // Check state variable size
+    REQUIRE(particle->state_variables().size() ==
+            rparticle->state_variables().size());
+
+    // Check state variables
+    auto state_variables = material->state_variables();
+    for (const auto& state_var : state_variables) {
+      REQUIRE(particle->state_variable(state_var) ==
+              rparticle->state_variable(state_var));
+    }
 
     SECTION("Performance benchmarks") {
       // Number of iterations

--- a/tests/particle_serialize_deserialize_test.cc
+++ b/tests/particle_serialize_deserialize_test.cc
@@ -126,6 +126,8 @@ TEST_CASE("Particle is checked for serialization and deserialization",
     REQUIRE(particle->mass() == rparticle->mass());
     // Check particle volume
     REQUIRE(particle->volume() == rparticle->volume());
+    // Check particle mass density
+    REQUIRE(particle->mass_density() == rparticle->mass_density());
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
 


### PR DESCRIPTION
**Describe the PR**
I found two major bugs in the new particle deserialization function. The first one is that `mass_density_` is not computed from mass and volume as in hdf5 initialization, and therefore equals `0`. The navier stokes and two phase solvers will have an error, while since it is not used in the explicit solver, we didn't realize this bug. The second one is, if material with state variables is used, the current version of deserialization cannot initialize the `svars` properly in the new particle. We need to add the [0] while unpacking the svars vector. The current test and benchmarks are using linear elastic, and therefore, this error was not detected, however, mohr-coulomb problems show a segmentation fault as attached below.

**Related Issues/PRs**
PR #689 

**Additional context**
See the screenshot before and after the modification of the `svars` below (at step 8975). This is a Mohr-Coulomb dam break problem.
Before:
![image](https://user-images.githubusercontent.com/37140224/94428875-ab563d80-01bb-11eb-8988-7eb48553c214.png)
After:
![image](https://user-images.githubusercontent.com/37140224/94428895-b14c1e80-01bb-11eb-8431-8275e60a967a.png)

I added tests for both the mass density and the state variables, i.e. changing from LinearElastic3D to Newtonian3D that has pressure as the state variables.