### PR TITLE
:hammer: Fix libkahip location in cmake

### DIFF
--- a/cmake/FindKaHIP.cmake
+++ b/cmake/FindKaHIP.cmake
@@ -46,12 +46,12 @@ if (MPI_CXX_FOUND)
     DOC "Directory where the KaHIP header files are located"
     )
 
-  find_library(KAHIP_LIBRARY kahip
+  find_library(KAHIP_LIBRARY libkahip.a
     HINTS ${KAHIP_ROOT}/deploy $ENV{KAHIP_ROOT}/deploy /usr/local/KaHIP/deploy
     NO_DEFAULT_PATH
     DOC "Directory where the KaHIP library is located"
-  )
-
+    )
+  
   find_library(KAHIP_LIBRARY kahip
     DOC "Directory where the KaHIP library is located"
   )


### PR DESCRIPTION
**Describe the PR**
Fix issue of unable to find KaHIP library using `FindKaHIP.cmake`

**Related Issues/PRs**
https://github.com/cb-geo/mpm/issues/695
https://github.com/KaHIP/KaHIP/issues/59

**Additional context**
`5594f1d` (copies `libinterface.so` to `deploy/libkahip.so`), causing find_library in your FindKaHIP.cmake to find the shared library rather than the static one, hence the test case cannot be run because the deploy/ directory is probably not in your `LD_LIBRARY_PATH`.