### PR TITLE
Feature/norsand updates

### DIFF
--- a/include/materials/material_utility.h
+++ b/include/materials/material_utility.h
@@ -43,10 +43,8 @@ inline double lode_angle(
     double tolerance = std::numeric_limits<double>::epsilon());
 
 //! Compute derivative of p in terms of stress sigma
-//! \param[in] stress Stress in Voigt notation where positive is tension
 //! \retval dp_dsigma Derivative of p in terms of stress sigma
-inline const Eigen::Matrix<double, 6, 1> dp_dsigma(
-    const Eigen::Matrix<double, 6, 1>& stress);
+inline const Eigen::Matrix<double, 6, 1> dp_dsigma();
 
 //! Compute derivative of q in terms of stress sigma
 //! \param[in] stress Stress in Voigt notation where positive is tension

--- a/include/materials/material_utility.tcc
+++ b/include/materials/material_utility.tcc
@@ -81,8 +81,7 @@ inline double mpm::materials::lode_angle(
 }
 
 //! Compute derivative of p in terms of stress sigma
-inline const Eigen::Matrix<double, 6, 1> mpm::materials::dp_dsigma(
-    const Eigen::Matrix<double, 6, 1>& stress) {
+inline const Eigen::Matrix<double, 6, 1> mpm::materials::dp_dsigma() {
 
   Eigen::Matrix<double, 6, 1> dp_dsigma = Eigen::Matrix<double, 6, 1>::Zero();
   dp_dsigma(0) = 1. / 3.;

--- a/include/materials/modified_cam_clay.tcc
+++ b/include/materials/modified_cam_clay.tcc
@@ -495,7 +495,7 @@ void mpm::ModifiedCamClay<Tdim>::compute_df_dsigma(
   // Compute dF / dpc
   double df_dpc = -(p + pcc);
   // Compute dp / dSigma
-  Vector6d dp_dsigma = -mpm::materials::dp_dsigma(stress);
+  Vector6d dp_dsigma = -mpm::materials::dp_dsigma();
   // Compute dq / dSigma
   Vector6d dq_dsigma = mpm::materials::dq_dsigma(stress);
   // Compute dF/dSigma

--- a/include/materials/mohr_coulomb.tcc
+++ b/include/materials/mohr_coulomb.tcc
@@ -205,7 +205,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
                  (sin(theta + M_PI / 3.) * tan(phi) / 3.));
   }
   // Compute dEpsilon / dSigma
-  Vector6d depsilon_dsigma = mpm::materials::dp_dsigma(stress) * std::sqrt(3.);
+  Vector6d depsilon_dsigma = mpm::materials::dp_dsigma() * std::sqrt(3.);
   // Initialise dRho / dSigma
   Vector6d drho_dsigma = mpm::materials::dq_dsigma(stress) * std::sqrt(2. / 3.);
   // Compute dtheta / dsigma

--- a/include/materials/norsand.h
+++ b/include/materials/norsand.h
@@ -81,6 +81,11 @@ class NorSand : public Material<Tdim> {
   void compute_stress_invariants(const Vector6d& stress, double* p, double* q,
                                  double* lode_angle, double* M_theta);
 
+  //! Compute image parameters (psi_image, chi_image, M_image, M_image_tc)
+  //! \param[in] state_vars History-dependent state variables
+  //! \retval computation of image parameters
+  void compute_image_parameters(mpm::dense_map* state_vars);
+
   //! Compute state variables (void ratio, p_image, e_image, etc)
   //! \param[in] stress Stress
   //! \param[in] state_vars History-dependent state variables
@@ -149,6 +154,8 @@ class NorSand : public Material<Tdim> {
   double gamma_{std::numeric_limits<double>::max()};
   //! Dilatancy coefficient
   double chi_{std::numeric_limits<double>::max()};
+  //! Dilatancy coefficient image
+  double chi_image_{std::numeric_limits<double>::max()};
   //! Hardening modulus
   double hardening_modulus_{std::numeric_limits<double>::max()};
   //! Initial void ratio

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -81,7 +81,7 @@ mpm::dense_map mpm::NorSand<Tdim>::initialise_state_variables() {
       // M_image
       {"M_image", 0.},
       // M_image_tc
-      {"M_image_tc", 0},
+      {"M_image_tc", 0.},
       // Current void ratio
       {"void_ratio", void_ratio_initial_},
       // Void ratio image

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -169,12 +169,12 @@ void mpm::NorSand<Tdim>::compute_stress_invariants(const Vector6d& stress,
 //! Compute image parameters
 template <unsigned Tdim>
 void mpm::NorSand<Tdim>::compute_image_parameters(mpm::dense_map* state_vars) {
-  
+
   // Collect necessary state variables
   const double void_ratio = (*state_vars).at("void_ratio");
   const double e_image = (*state_vars).at("e_image");
   const double M_theta = (*state_vars).at("M_theta");
-  
+
   // Compute state parameter image
   const double psi_image_ = void_ratio - e_image;
   (*state_vars).at("psi_image") = psi_image_;
@@ -331,7 +331,7 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
   this->compute_stress_invariants(stress, &mean_p, &dev_q, &lode_angle,
                                   &mtheta);
 
-  // Get state variables and image parameters 
+  // Get state variables and image parameters
   // note: M_image is at current stress
   const double M_image = (*state_vars).at("M_image");
   const double M_image_tc = (*state_vars).at("M_image_tc");

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -314,7 +314,7 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
                     (N_ / (1 - N_))));
 
   // Compute dp / dsigma
-  const Vector6d dp_dsigma = mpm::materials::dp_dsigma(-stress);
+  const Vector6d dp_dsigma = mpm::materials::dp_dsigma();
 
   // Compute dF / dq
   const double dF_dq = 1.;

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -62,6 +62,8 @@ mpm::NorSand<Tdim>::NorSand(unsigned id, const Json& material_properties)
     Mtc_ = (6 * sin_friction_cs) / (3 - sin_friction_cs);
     Mte_ = (6 * sin_friction_cs) / (3 + sin_friction_cs);
 
+    chi_image_ = chi_ / (1. - ((chi_ * lambda_) / Mtc_));
+
     // Properties
     properties_ = material_properties;
 
@@ -76,11 +78,19 @@ mpm::dense_map mpm::NorSand<Tdim>::initialise_state_variables() {
   mpm::dense_map state_vars = {
       // M_theta
       {"M_theta", Mtc_},
+      // M_image
+      {"M_image", 0.},
+      // M_image_tc
+      {"M_image_tc", 0},
       // Current void ratio
       {"void_ratio", void_ratio_initial_},
       // Void ratio image
       {"e_image",
        gamma_ - lambda_ * log(p_image_initial_ / reference_pressure_)},
+      // State parameter image
+      {"psi_image",
+       void_ratio_initial_ -
+           (gamma_ - lambda_ * log(p_image_initial_ / reference_pressure_))},
       // Image pressure
       {"p_image", p_image_initial_},
       // p_cohesion
@@ -104,7 +114,8 @@ mpm::dense_map mpm::NorSand<Tdim>::initialise_state_variables() {
 template <unsigned Tdim>
 std::vector<std::string> mpm::NorSand<Tdim>::state_variables() const {
   const std::vector<std::string> state_vars = {
-      "M_theta",         "void_ratio",      "e_image",
+      "M_theta",         "M_image",         "M_image_tc",
+      "void_ratio",      "e_image",         "psi_image",
       "p_image",         "p_cohesion",      "p_dilation",
       "pdstrain",        "plastic_strain0", "plastic_strain1",
       "plastic_strain2", "plastic_strain3", "plastic_strain4",
@@ -138,20 +149,43 @@ void mpm::NorSand<Tdim>::compute_stress_invariants(const Vector6d& stress,
                                                    double* p, double* q,
                                                    double* lode_angle,
                                                    double* M_theta) {
-  // Note that in this subroutine, stress is compression positive
 
   // Compute mean stress p
-  *p = check_low(-1. * mpm::materials::p(-stress));
+  *p = check_low(mpm::materials::p(stress));
 
   // Compute q
-  *q = check_low(mpm::materials::q(-stress));
+  *q = check_low(mpm::materials::q(stress));
 
   // Compute Lode angle (cos convetion)
+  // Note: stress tensor passed in as compression positive, but lode_angle()
+  //       expects tenstion positive thus (-stress) passed to function
   *lode_angle = mpm::materials::lode_angle(-stress, tolerance_);
 
   // Compute M_theta (Jefferies and Shuttle, 2011)
   *M_theta =
       Mtc_ - std::pow(Mtc_, 2) / (3. + Mtc_) * cos(3. / 2. * *lode_angle);
+}
+
+//! Compute image parameters
+template <unsigned Tdim>
+void mpm::NorSand<Tdim>::compute_image_parameters(mpm::dense_map* state_vars) {
+  
+  // Collect necessary state variables
+  const double void_ratio = (*state_vars).at("void_ratio");
+  const double e_image = (*state_vars).at("e_image");
+  const double M_theta = (*state_vars).at("M_theta");
+  
+  // Compute state parameter image
+  const double psi_image_ = void_ratio - e_image;
+  (*state_vars).at("psi_image") = psi_image_;
+
+  // Compute critical state coefficient image
+  (*state_vars).at("M_image") =
+      M_theta * (1. - ((chi_image_ * N_ * std::fabs(psi_image_)) / Mtc_));
+
+  // Compute critical state coefficient image triaxial compression
+  (*state_vars).at("M_image_tc") =
+      Mtc_ * (1. - ((chi_image_ * N_ * std::fabs(psi_image_)) / Mtc_));
 }
 
 //! Compute state parameters
@@ -162,20 +196,21 @@ void mpm::NorSand<Tdim>::compute_state_variables(
 
   // Initialize invariants
   double mean_p = 0.;
-  double deviatoric_q = 0.;
+  double dev_q = 0.;
   double lode_angle = 0.;
   double mtheta = 0.;
 
   // Get invariants
-  this->compute_stress_invariants(stress, &mean_p, &deviatoric_q, &lode_angle,
+  this->compute_stress_invariants(stress, &mean_p, &dev_q, &lode_angle,
                                   &mtheta);
 
-  // Get state variables (note that M_theta used is at current stress)
-  const double M_theta = (*state_vars).at("M_theta");
+  // Get state variables and image parameters
+  // note : M_image is at current stress
+  const double M_image = (*state_vars).at("M_image");
   const double p_cohesion = (*state_vars).at("p_cohesion");
   const double p_dilation = (*state_vars).at("p_dilation");
-  double p_image;
   double e_image;
+  double p_image;
 
   if (yield_type == mpm::norsand::FailureState::Elastic) {
     // Keep the same pressure image and void ratio image at critical state
@@ -184,12 +219,10 @@ void mpm::NorSand<Tdim>::compute_state_variables(
   } else {
     // Compute and update pressure image
     p_image =
-        (mean_p + p_cohesion) *
-            std::pow(
-                ((1 - N_ / M_theta * deviatoric_q / (mean_p + p_cohesion)) /
-                 (1 - N_)),
-                ((N_ - 1) / N_)) -
-        p_cohesion - p_dilation;
+        std::pow(std::exp(1 - (dev_q / ((mean_p + p_cohesion) * M_image))),
+                 -1) *
+            (mean_p + p_cohesion) -
+        (p_cohesion + p_dilation);
     (*state_vars).at("p_image") = p_image;
 
     // Compute and update void ratio image
@@ -205,9 +238,9 @@ void mpm::NorSand<Tdim>::compute_state_variables(
   // Update void ratio
   // Note that dstrain is in tension positive - depsv = de / (1 + e_initial)
   double dvolumetric_strain = dstrain(0) + dstrain(1) + dstrain(2);
-  (*state_vars).at("void_ratio") =
-      check_low((*state_vars).at("void_ratio") -
-                (1 + void_ratio_initial_) * dvolumetric_strain);
+  double void_ratio = check_low((*state_vars).at("void_ratio") -
+                                (1 + void_ratio_initial_) * dvolumetric_strain);
+  (*state_vars).at("void_ratio") = void_ratio;
 }
 
 //! Compute elastic tensor
@@ -241,30 +274,38 @@ typename mpm::norsand::FailureState mpm::NorSand<Tdim>::compute_yield_state(
 
   // Initialize invariants
   double mean_p = 0.;
-  double deviatoric_q = 0.;
+  double dev_q = 0.;
   double lode_angle = 0.;
   double mtheta = 0.;
 
   // Get invariants
-  this->compute_stress_invariants(stress, &mean_p, &deviatoric_q, &lode_angle,
+  this->compute_stress_invariants(stress, &mean_p, &dev_q, &lode_angle,
                                   &mtheta);
 
-  // Get state variables
+  // Get state variables and image parameters
+  // note : M_image is at current stress
+  const double M_image = (*state_vars).at("M_image");
+  const double M_image_tc = (*state_vars).at("M_image_tc");
+  const double psi_image = (*state_vars).at("psi_image");
   const double p_image = (*state_vars).at("p_image");
-  const double M_theta = (*state_vars).at("M_theta");
   const double p_cohesion = (*state_vars).at("p_cohesion");
   const double p_dilation = (*state_vars).at("p_dilation");
 
   // Initialise yield status (Elastic, Yield)
   auto yield_type = mpm::norsand::FailureState::Elastic;
 
-  // Compute yield functions
-  (*yield_function) =
-      deviatoric_q / (mean_p + p_cohesion) -
-      M_theta / N_ *
-          (1 + (N_ - 1) * std::pow(((mean_p + p_cohesion) /
-                                    (p_image + p_cohesion + p_dilation)),
-                                   (N_ / (1 - N_))));
+  // Compute yield function with internal cap
+  const double ratio =
+      (p_image + p_cohesion + p_dilation) / (mean_p + p_cohesion);
+  const double cap = std::exp(-chi_image_ * psi_image / M_image_tc);
+  if (ratio > cap) {
+    (*yield_function) =
+        dev_q / (mean_p + p_cohesion) - M_image + M_image * std::log(1 / cap);
+  } else {
+    (*yield_function) = dev_q / (mean_p + p_cohesion) - M_image +
+                        M_image * std::log((mean_p + p_cohesion) /
+                                           (p_image + p_cohesion + p_dilation));
+  }
 
   // Yield criterion
   if ((*yield_function) > tolerance_)
@@ -282,36 +323,27 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
 
   // Initialize invariants
   double mean_p = 0.;
-  double deviatoric_q = 0.;
+  double dev_q = 0.;
   double lode_angle = 0.;
   double mtheta = 0.;
 
   // Get invariants
-  this->compute_stress_invariants(stress, &mean_p, &deviatoric_q, &lode_angle,
+  this->compute_stress_invariants(stress, &mean_p, &dev_q, &lode_angle,
                                   &mtheta);
 
-  // Get state variables
-  const double M_theta = (*state_vars).at("M_theta");
+  // Get state variables and image parameters 
+  // note: M_image is at current stress
+  const double M_image = (*state_vars).at("M_image");
+  const double M_image_tc = (*state_vars).at("M_image_tc");
+  const double psi_image = (*state_vars).at("psi_image");
   const double p_image = (*state_vars).at("p_image");
-  const double e_image = (*state_vars).at("e_image");
-  const double void_ratio = (*state_vars).at("void_ratio");
   const double p_cohesion = (*state_vars).at("p_cohesion");
   const double p_dilation = (*state_vars).at("p_dilation");
 
-  // Estimate dilatancy at peak
-  const double D_min = chi_ * (void_ratio - e_image);
-
-  // Estimate maximum image pressure
-  const double p_image_max =
-      (mean_p + p_cohesion) *
-      std::pow((1 + D_min * N_ / M_theta), ((N_ - 1) / N_));
-
   // Compute derivatives
   // Compute dF / dp
-  const double dF_dp =
-      -1. * M_theta / N_ *
-      (1 - std::pow(((mean_p + p_cohesion) / (p_image + p_cohesion)),
-                    (N_ / (1 - N_))));
+  const double dF_dp = M_image * (std::log(mean_p + p_cohesion) -
+                                  std::log(p_image + p_cohesion + p_dilation));
 
   // Compute dp / dsigma
   const Vector6d dp_dsigma = mpm::materials::dp_dsigma();
@@ -320,36 +352,38 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
   const double dF_dq = 1.;
 
   // Compute dq / dsigma
-  const Vector6d dq_dsigma = mpm::materials::dq_dsigma(-stress);
+  const Vector6d dq_dsigma = mpm::materials::dq_dsigma(stress);
 
-  // Compute dF / dM
-  const double dF_dM =
-      -1.0 / N_ * (mean_p + p_cohesion) *
-      (1 + (N_ - 1) * std::pow(((mean_p + p_cohesion) /
-                                (p_image + p_cohesion + p_dilation)),
-                               (N_ / (1 - N_))));
+  // Compute dF / dMi
+  const double dF_dMi =
+      (mean_p + p_cohesion) * (-1 + std::log(mean_p + p_cohesion) -
+                               std::log(p_image + p_cohesion + p_dilation));
 
-  // Use current lode angle to compute dtheta
-  const double sin_lode_angle = sin(3. / 2. * lode_angle);
+  // Compute dMi / dMtheta
+  const double dMi_dMtheta =
+      1 - (chi_image_ * N_ * std::fabs(psi_image) / Mtc_);
 
-  // Compute dM / dtehta
-  const double dM_dtheta =
-      3. / 2. * std::pow(Mtc_, 2) / (3. + Mtc_) * sin_lode_angle;
+  // Compute dMtheta / dtheta
+  const double dMtheta_dtheta =
+      (3 * std::pow(Mtc_, 2) * sin(3. / 2. * lode_angle)) / (2 * (3 + Mtc_));
 
   // Compute dtheta / dsigma
-  const Vector6d dtheta_dsigma = mpm::materials::dtheta_dsigma(-stress);
+  const Vector6d dtheta_dsigma = mpm::materials::dtheta_dsigma(stress);
 
   // dF_dsigma is in compression negative
-  const Vector6d dF_dsigma = (dF_dp * dp_dsigma) + (-1. * dF_dq * dq_dsigma) +
-                             (-1. * dF_dM * dM_dtheta * dtheta_dsigma);
+  const Vector6d dF_dsigma =
+      (dF_dp * dp_dsigma) + (dF_dq * dq_dsigma) +
+      (dF_dMi * dMi_dMtheta * dMtheta_dtheta * dtheta_dsigma);
 
   // Derivatives in respect to p_image
-  const double dF_dpi =
-      -1. * M_theta *
-      std::pow(((mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)),
-               (1 / (1 - N_)));
+  const double dF_dpi = (-1. * M_image * (mean_p + p_cohesion)) /
+                        (p_image + p_cohesion + p_dilation);
 
-  const double dpi_depsd = hardening_modulus_ * (p_image_max - p_image);
+  const double dpi_depsd =
+      hardening_modulus_ * (M_image / M_image_tc) *
+      std::pow((mean_p / p_image), 2) *
+      (std::exp(-1. * chi_image_ * psi_image / Mtc_) - (p_image / mean_p)) *
+      p_image;
 
   const double dF_dsigma_v = (dF_dsigma(0) + dF_dsigma(1) + dF_dsigma(2)) / 3;
   const double dF_dsigma_deviatoric =
@@ -365,26 +399,18 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
   if (bond_model_) {
     // Derivatives in respect to p_cohesion
     const double dF_dpcohesion =
-        M_theta / N_ *
-        (1 +
-         (N_ - 1) * std::pow(((mean_p + p_cohesion) /
-                              (p_image + p_cohesion + p_dilation)),
-                             (N_ / (1 - N_))) -
-         N_ * (p_image + p_dilation - mean_p) /
-             (p_image + p_cohesion + p_dilation) *
-             std::pow(
-                 ((mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)),
-                 (N_ / (1 - N_))));
+        M_image *
+        ((-(mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)) +
+         std::log(mean_p + p_cohesion) -
+         std::log(p_image + p_cohesion + p_dilation));
 
     const double dpcohesion_depsd =
         -p_cohesion_initial_ * m_cohesion_ *
         exp(-m_cohesion_ * (*state_vars).at("pdstrain"));
 
     // Derivatives in respect to p_dilation
-    const double dF_dpdilation =
-        -1. * M_theta *
-        std::pow(((mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)),
-                 (1 / (1 - N_)));
+    const double dF_dpdilation = (-1. * M_image * (mean_p + p_cohesion)) /
+                                 (p_image + p_cohesion + p_dilation);
 
     const double dpdilation_depsd =
         -p_dilation_initial_ * m_dilation_ *
@@ -413,7 +439,7 @@ Eigen::Matrix<double, 6, 1> mpm::NorSand<Tdim>::compute_stress(
   Vector6d dstrain_neg = -1 * dstrain;
 
   // Get stress invariants
-  const double mean_p = check_low(-1. * mpm::materials::p(stress));
+  const double mean_p = check_low(mpm::materials::p(stress_neg));
 
   // Elastic step
   // Bulk modulus computation
@@ -429,6 +455,9 @@ Eigen::Matrix<double, 6, 1> mpm::NorSand<Tdim>::compute_stress(
 
   // Trial stress - elastic
   Vector6d trial_stress = stress_neg + (this->de_ * dstrain_neg);
+
+  // Compute image parameters at current stress
+  this->compute_image_parameters(state_vars);
 
   // Initialise value for yield function
   double yield_function;

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -219,7 +219,7 @@ void mpm::NorSand<Tdim>::compute_state_variables(
   } else {
     // Compute and update pressure image
     p_image =
-        std::pow(std::exp(1 - (dev_q / ((mean_p + p_cohesion) * M_image))),
+        std::pow(std::exp(1. - (dev_q / ((mean_p + p_cohesion) * M_image))),
                  -1) *
             (mean_p + p_cohesion) -
         (p_cohesion + p_dilation);
@@ -238,8 +238,9 @@ void mpm::NorSand<Tdim>::compute_state_variables(
   // Update void ratio
   // Note that dstrain is in tension positive - depsv = de / (1 + e_initial)
   double dvolumetric_strain = dstrain(0) + dstrain(1) + dstrain(2);
-  double void_ratio = check_low((*state_vars).at("void_ratio") -
-                                (1 + void_ratio_initial_) * dvolumetric_strain);
+  double void_ratio =
+      check_low((*state_vars).at("void_ratio") -
+                (1. + void_ratio_initial_) * dvolumetric_strain);
   (*state_vars).at("void_ratio") = void_ratio;
 }
 
@@ -300,7 +301,7 @@ typename mpm::norsand::FailureState mpm::NorSand<Tdim>::compute_yield_state(
   const double cap = std::exp(-chi_image_ * psi_image / M_image_tc);
   if (ratio > cap) {
     (*yield_function) =
-        dev_q / (mean_p + p_cohesion) - M_image + M_image * std::log(1 / cap);
+        dev_q / (mean_p + p_cohesion) - M_image + M_image * std::log(1. / cap);
   } else {
     (*yield_function) = dev_q / (mean_p + p_cohesion) - M_image +
                         M_image * std::log((mean_p + p_cohesion) /
@@ -356,16 +357,16 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
 
   // Compute dF / dMi
   const double dF_dMi =
-      (mean_p + p_cohesion) * (-1 + std::log(mean_p + p_cohesion) -
+      (mean_p + p_cohesion) * (-1. + std::log(mean_p + p_cohesion) -
                                std::log(p_image + p_cohesion + p_dilation));
 
   // Compute dMi / dMtheta
   const double dMi_dMtheta =
-      1 - (chi_image_ * N_ * std::fabs(psi_image) / Mtc_);
+      1. - (chi_image_ * N_ * std::fabs(psi_image) / Mtc_);
 
   // Compute dMtheta / dtheta
   const double dMtheta_dtheta =
-      (3 * std::pow(Mtc_, 2) * sin(3. / 2. * lode_angle)) / (2 * (3 + Mtc_));
+      (3. * std::pow(Mtc_, 2) * sin(3. / 2. * lode_angle)) / (2. * (3. + Mtc_));
 
   // Compute dtheta / dsigma
   const Vector6d dtheta_dsigma = mpm::materials::dtheta_dsigma(stress);
@@ -385,7 +386,7 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
       (std::exp(-1. * chi_image_ * psi_image / Mtc_) - (p_image / mean_p)) *
       p_image;
 
-  const double dF_dsigma_v = (dF_dsigma(0) + dF_dsigma(1) + dF_dsigma(2)) / 3;
+  const double dF_dsigma_v = (dF_dsigma(0) + dF_dsigma(1) + dF_dsigma(2)) / 3.;
   const double dF_dsigma_deviatoric =
       std::sqrt(2. / 3.) * std::sqrt(std::pow(dF_dsigma(0) - dF_dsigma_v, 2) +
                                      std::pow(dF_dsigma(1) - dF_dsigma_v, 2) +
@@ -400,7 +401,7 @@ void mpm::NorSand<Tdim>::compute_plastic_tensor(const Vector6d& stress,
     // Derivatives in respect to p_cohesion
     const double dF_dpcohesion =
         M_image *
-        ((-(mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)) +
+        ((-1. * (mean_p + p_cohesion) / (p_image + p_cohesion + p_dilation)) +
          std::log(mean_p + p_cohesion) -
          std::log(p_image + p_cohesion + p_dilation));
 

--- a/tests/materials/material_utility_test.cc
+++ b/tests/materials/material_utility_test.cc
@@ -61,7 +61,7 @@ TEST_CASE("materials utility is checked", "[materials]") {
     REQUIRE(lode_angle_tolerance == Approx(M_PI / 6.).epsilon(Tolerance));
 
     // Compute dp_dsigma
-    Eigen::Matrix<double, 6, 1> dp_dsigma = mpm::materials::dp_dsigma(stress);
+    Eigen::Matrix<double, 6, 1> dp_dsigma = mpm::materials::dp_dsigma();
     REQUIRE(dp_dsigma(0) == Approx(1. / 3.).epsilon(Tolerance));
     REQUIRE(dp_dsigma(1) == Approx(1. / 3.).epsilon(Tolerance));
     REQUIRE(dp_dsigma(2) == Approx(1. / 3.).epsilon(Tolerance));
@@ -188,7 +188,7 @@ TEST_CASE("materials utility is checked", "[materials]") {
             Approx(0.563342522771415).epsilon(Tolerance));
 
     // Compute dp_dsigma
-    Eigen::Matrix<double, 6, 1> dp_dsigma = mpm::materials::dp_dsigma(stress);
+    Eigen::Matrix<double, 6, 1> dp_dsigma = mpm::materials::dp_dsigma();
     REQUIRE(dp_dsigma(0) == Approx(1. / 3.).epsilon(Tolerance));
     REQUIRE(dp_dsigma(1) == Approx(1. / 3.).epsilon(Tolerance));
     REQUIRE(dp_dsigma(2) == Approx(1. / 3.).epsilon(Tolerance));

--- a/tests/materials/norsand_test.cc
+++ b/tests/materials/norsand_test.cc
@@ -1,7 +1,6 @@
 #include <limits>
 
 #include <cmath>
-#include <iostream>
 
 #include "Eigen/Dense"
 #include "catch.hpp"


### PR DESCRIPTION
## Describe the PR
NorSand formulation is updated to be aligned with Jefferies and Been (2019) as described previously here -> https://github.com/cb-geo/mpm/issues/714 . Internal formulation changes include updates to the yield function. There are no proposed changes for user-facing components of the NorSand model. 

Test cases are updated for the new formulation. 

In addition to the NorSand updates, this PR contains a small refactoring of the material utility function `dp_dsigma(...)`. As mentioned in the above issue, passing a vector of the current stress state should not be required. Thus, passing this vector is removed. 

## Validation
A simple FEM code is availabe from the publishers ([found here](https://www.routledge.com/Soil-Liquefaction-A-Critical-State-Approach-Second-Edition/Jefferies-Been/p/book/9781482213683)). Updates to the CB-Geo implementation of NorSand are compared to the FEM code for a suite of triaxial compression tests. These tests include:
```
* Undrained TX,  psi_0 = -0.05
* Undrained TX,  psi_0 = +0.05
* Undrained TX,  psi_0 =  0.00
* Drained TX,    psi_0 = -0.05
* Drained TX,    psi_0 = +0.05
* Drained TX,    psi_0 =  0.00
```
Below is an example of the validation for the undrained, dense sample.
```
* solid black == FEM code
* dashed red == updated CB-Geo MPM code
* dashed purple == previous CB-Geo MPM code
```

![image](https://user-images.githubusercontent.com/62029065/125531944-e1e93e9b-2f9b-4f6d-b474-ba8bf7b51063.png)

The other 5 validation plots are are posted [here]().


## Remaining work
Documentation will be updated prior to merging in `develop`. 

Following this NorSand improvement, anisotropic elastic stiffness will be considered. 

### Edit:
Here is the mpm-doc PR -> https://github.com/cb-geo/mpm-doc/pull/62