### PR TITLE
:computer: Add a repartition flag  to resume using manual h4 files

### DIFF
--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -954,8 +954,10 @@ template <unsigned Tdim>
 void mpm::Mesh<Tdim>::resume_domain_cell_ranks() {
   // Get MPI rank
   int mpi_rank = 0;
+  int mpi_size = 0;
 #ifdef USE_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
   const unsigned rank_max = std::numeric_limits<unsigned>::max();
   const unsigned ncells = this->ncells();
   // Vector of cell ranks

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -982,6 +982,13 @@ void mpm::Mesh<Tdim>::resume_domain_cell_ranks() {
   unsigned j = 0;
   for (auto citr = cells_.cbegin(); citr != cells_.cend(); ++citr) {
     int recv_rank = recv_ranks.at(j);
+    if (recv_rank >= mpi_size) {
+      console_->error(
+          "Resuming analysis: Cell id {} has invalid MPI rank: {} larger than "
+          "MPI size: {}",
+          (*citr)->id(), recv_rank, mpi_size);
+      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
     (*citr)->rank(recv_rank);
     ++j;
   }

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -62,6 +62,13 @@ bool mpm::MPMExplicit<Tdim>::solve() {
   if (analysis_.find("resume") != analysis_.end())
     resume = analysis_["resume"]["resume"].template get<bool>();
 
+  // Enable repartitioning if resume is done with particles generated outside
+  // the MPM code.
+  bool repartition = false;
+  if (analysis_.find("resume") != analysis_.end() &&
+      analysis_["resume"].find("repartition") != analysis_["resume"].end())
+    repartition = analysis_["resume"]["repartition"].template get<bool>();
+
   // Pressure smoothing
   pressure_smoothing_ = io_->analysis_bool("pressure_smoothing");
 
@@ -85,18 +92,22 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     mesh_->iterate_over_particles(std::bind(
         &mpm::ParticleBase<Tdim>::compute_mass, std::placeholders::_1));
 
+  bool initial_step = (resume == true) ? false : true;
   // Check point resume
   if (resume) {
     this->checkpoint_resume();
-    mesh_->resume_domain_cell_ranks();
+    if (repartition) {
+      this->mpi_domain_decompose(initial_step);
+    } else {
+      mesh_->resume_domain_cell_ranks();
 #ifdef USE_MPI
 #ifdef USE_GRAPH_PARTITIONING
-    MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(MPI_COMM_WORLD);
 #endif
 #endif
+    }
   } else {
     // Domain decompose
-    bool initial_step = (resume == true) ? false : true;
     this->mpi_domain_decompose(initial_step);
   }
 


### PR DESCRIPTION
**Describe the PR**
When using a manually written particles HDF5 files and resuming from step 0, it will typically call `mesh_->resume_domain_cell_ranks()` which then assigns the current MPI_RANK to the cell if the cell has particles in it. This works on the assumption that the current cell has particles only on the current rank - which is true when generated using our MPM code, but not for particles generated manually and written to HDF5 file. When particles are distributed across different MPI ranks for the same cell, MPI_Reduce will result in MPI_RANK larger than the MPI_SIZE (bad!) - assigning to a different MPI rank as long as it's within MPI_SIZE is bad for efficiency, which will be resolved in the subsequent step.

This PR adds a boolean flag called `repartition: true` to `resume` JSON to enable repartitioning when resuming from a HDF5 file. This is an optional flag which is set to false. 

**Additional context**
Input file change:

```json
"analysis": {
		"resume": {
			"resume": true,
			"repartition": true,
			"uuid": "slope",
			"step": 0
		}
}
```