### PR TITLE
Adding Physical Time to VTK Outputs for #727

### DIFF
--- a/include/io/vtk_writer.h
+++ b/include/io/vtk_writer.h
@@ -74,10 +74,11 @@ class VtkWriter {
   //! \param[in] mpi_size Number of MPI tasks
   //! \param[in] step Current time step
   //! \param[in] max_steps Maximum number of steps in the simulation
+  //! \param[in] step_size Physical time step size
   //! \param[in] ncomponents Number of components to write
   void write_parallel_vtk(const std::string& filename,
                           const std::string& attribute, int mpi_size,
-                          unsigned step, unsigned max_steps,
+                          unsigned step, unsigned max_steps, double step_size,
                           unsigned ncomponents = 3);
 
  private:

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -541,7 +541,7 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
                                .string();
 
       vtk_writer->write_parallel_vtk(parallel_file, attribute, mpi_size, step,
-                                     max_steps);
+                                     max_steps, dt_);
     }
 #endif
   }
@@ -562,7 +562,7 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
                                .string();
 
       vtk_writer->write_parallel_vtk(parallel_file, attribute, mpi_size, step,
-                                     max_steps);
+                                     max_steps, dt_);
     }
 #endif
   }
@@ -583,7 +583,7 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
                                .string();
 
       vtk_writer->write_parallel_vtk(parallel_file, attribute, mpi_size, step,
-                                     max_steps, 9);
+                                     max_steps, dt_, 9);
     }
 #endif
   }
@@ -609,7 +609,7 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
                                  .string();
         unsigned ncomponents = 1;
         vtk_writer->write_parallel_vtk(parallel_file, phase_attribute, mpi_size,
-                                       step, max_steps, ncomponents);
+                                       step, max_steps, dt_, ncomponents);
       }
 #endif
     }

--- a/src/io/vtk_writer.cc
+++ b/src/io/vtk_writer.cc
@@ -279,7 +279,7 @@ void VtkWriter::write_parallel_vtk(const std::string& filename,
   pvtk.open(filename);
   pvtk << ppolydata;
   pvtk.close();
-  
+
   // Write parallel grouping VTK file
 
   std::string output_path = filename.substr(0, filename.find_last_of("\\/"));
@@ -297,11 +297,11 @@ void VtkWriter::write_parallel_vtk(const std::string& filename,
   group_parts_file << ".pvtp";
 
   boost::filesystem::path file_check(group_filename);
-  
+
   if (boost::filesystem::exists(file_check)) {
     group_vtk.open(group_filename, std::fstream::app);
     group_data = "\t<DataSet timestep=\"" + std::to_string(step * step_size) +
-      "\" file=\"./" + group_parts_file.str() + "\"/>\n";
+                 "\" file=\"./" + group_parts_file.str() + "\"/>\n";
     group_vtk << group_data;
   } else {
     group_vtk.open(group_filename);
@@ -317,7 +317,7 @@ void VtkWriter::write_parallel_vtk(const std::string& filename,
     std::string closing = "</Collection>\n</VTKFile>";
     group_vtk << closing;
   }
-  
+
   group_vtk.close();
 }
 

--- a/tests/io/vtk_writer_test.cc
+++ b/tests/io/vtk_writer_test.cc
@@ -51,8 +51,9 @@ TEST_CASE("VTK Writer is checked", "[vtk][writer]") {
     int mpi_size = 2;
     unsigned step = 1000;
     unsigned max_steps = 10000;
+    double step_size = 0.5;
     vtk_writer->write_parallel_vtk(parallel_vtk_file, attribute, mpi_size, step,
-                                   max_steps);
+                                   max_steps, step_size);
 
     // Check file data
     std::string ppolydata =
@@ -98,8 +99,9 @@ TEST_CASE("VTK Writer is checked", "[vtk][writer]") {
     int mpi_size = 2;
     unsigned step = 1000;
     unsigned max_steps = 10000;
+    double step_size = 0.5;
     vtk_writer->write_parallel_vtk(parallel_vtk_file, attribute, mpi_size, step,
-                                   max_steps, 1);
+                                   max_steps, step_size, 1);
 
     // Check file data
     std::string ppolydata =


### PR DESCRIPTION
Describe the PR
Added physical time to MPI-parallel VTK outputs so that physical simulation time can be seen in ParaView visualization, .pvd files are created for each attribute with time step included.

Related Issues/PRs
Related to issue #727 

![image](https://user-images.githubusercontent.com/84877960/163645589-ee69e0b9-33db-42ae-86d7-829b0c0d1274.png)


