### PR TITLE
Extending Mohr Coulomb state variables

### DIFF
--- a/include/materials/mohr_coulomb.tcc
+++ b/include/materials/mohr_coulomb.tcc
@@ -71,10 +71,10 @@ mpm::dense_map mpm::MohrCoulomb<Tdim>::initialise_state_variables() {
                                {"theta", 0.},
                                // Plastic deviatoric strain
                                {"pdstrain", 0.},
-                               // Elastic energy
-                               {"E_el", 0.},
-                               // Plastic work
-                               {"W_pl", 0.},
+                               // Elastic energy (volume-specific)
+                               {"e_el", 0.},
+                               // Plastic work (volume-specific)
+                               {"w_pl", 0.},
                                // Flag for current failure because of tensile stress
                                {"tensile_fail_curr", 0},
                                // Flag for current failure because of shear stress
@@ -90,7 +90,7 @@ mpm::dense_map mpm::MohrCoulomb<Tdim>::initialise_state_variables() {
 template <unsigned Tdim>
 std::vector<std::string> mpm::MohrCoulomb<Tdim>::state_variables() const {
   const std::vector<std::string> state_vars = {
-      "phi", "psi", "cohesion", "epsilon", "rho", "theta", "pdstrain", "E_el", "W_pl", "tensile_fail_curr", "shear_fail_curr", "tensile_fail", "shear_fail"};
+      "phi", "psi", "cohesion", "epsilon", "rho", "theta", "pdstrain", "e_el", "w_pl", "tensile_fail_curr", "shear_fail_curr", "tensile_fail", "shear_fail"};
   return state_vars;
 }
 
@@ -492,11 +492,11 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   Vector6d deps_el = ((1+poisson_ratio_)*dstress - poisson_ratio_*tr_dsig*Id) / youngs_modulus_; // Elastic deformation increment (only true strain coefficients)
   Vector6d strain_coefs; // coefficients necessary below
   strain_coefs << 1, 1, 1, 2, 2, 2;
-  (*state_vars).at("E_el") += updated_stress.cwiseProduct(deps_el.cwiseProduct(strain_coefs)).sum()*ptr->volume(); // with 2*sigma_xy*eps_xy + .. on the out-of-diagonal terms, this is the correct expression sigma_ij:depsilon^el_ij (times volume)
+  (*state_vars).at("e_el") += updated_stress.cwiseProduct(deps_el.cwiseProduct(strain_coefs)).sum(); // with 2*sigma_xy*eps_xy + .. on the out-of-diagonal terms, this is the correct expression sigma_ij:depsilon^el_ij
 
   // Update plastic work
   Vector6d deps_pl = dstrain - deps_el.cwiseProduct(strain_coefs); // Plastic deformation increment in Voigt notation (with engineering strain coefficents)
-  (*state_vars).at("W_pl") += updated_stress.cwiseProduct(deps_pl).sum()*ptr->volume();
+  (*state_vars).at("w_pl") += updated_stress.cwiseProduct(deps_pl).sum();
 
   return updated_stress;
 }

--- a/include/materials/mohr_coulomb.tcc
+++ b/include/materials/mohr_coulomb.tcc
@@ -485,11 +485,13 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   (*state_vars).at("pdstrain") += dpdstrain;
 
   // Update elastic energy
-  Vector6d Id({1, 1, 1, 0, 0, 0}); // Identity in Voigt notation
+  Vector6d Id; // Identity in Voigt notation
+  Id << 1, 1, 1, 0, 0, 0; // the direct brace initialization would require a recent (e.g., Ubuntu 22.04) environment
   Vector6d dstress = updated_stress - stress; // Stress increment
   double tr_dsig = dstress(0) + dstress(1) + dstress(2); // Trace of the stress increment tensor
   Vector6d deps_el = ((1+poisson_ratio_)*dstress - poisson_ratio_*tr_dsig*Id) / youngs_modulus_; // Elastic deformation increment (only true strain coefficients)
-  Vector6d strain_coefs({1, 1, 1, 2, 2, 2}); // coefficients necessary below
+  Vector6d strain_coefs; // coefficients necessary below
+  strain_coefs << 1, 1, 1, 2, 2, 2;
   (*state_vars).at("E_el") += updated_stress.cwiseProduct(deps_el.cwiseProduct(strain_coefs)).sum()*ptr->volume(); // with 2*sigma_xy*eps_xy + .. on the out-of-diagonal terms, this is the correct expression sigma_ij:depsilon^el_ij (times volume)
 
   // Update plastic work

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -117,9 +117,19 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
 
-      const std::vector<std::string> state_vars = {
-          "phi", "psi", "cohesion", "epsilon", "rho", "theta", "pdstrain", "E_el",
-          "W_pl", "tensile_fail_curr", "shear_fail_curr", "tensile_fail", "shear_fail"};
+      const std::vector<std::string> state_vars = {"phi",
+                                                   "psi",
+                                                   "cohesion",
+                                                   "epsilon",
+                                                   "rho",
+                                                   "theta",
+                                                   "pdstrain",
+                                                   "E_el",
+                                                   "W_pl",
+                                                   "tensile_fail_curr",
+                                                   "shear_fail_curr",
+                                                   "tensile_fail",
+                                                   "shear_fail"};
       auto state_vars_test = material->state_variables();
       REQUIRE(state_vars == state_vars_test);
     }

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -116,6 +116,12 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("e_el") == 0.);
+      REQUIRE(state_variables.at("w_pl") == 0.);
+      REQUIRE(state_variables.at("tensile_fail_curr") == 0);
+      REQUIRE(state_variables.at("tensile_fail") == 0);
+      REQUIRE(state_variables.at("shear_fail_curr") == 0);
+      REQUIRE(state_variables.at("shear_fail") == 0);
 
       const std::vector<std::string> state_vars = {"phi",
                                                    "psi",
@@ -124,8 +130,8 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
                                                    "rho",
                                                    "theta",
                                                    "pdstrain",
-                                                   "E_el",
-                                                   "W_pl",
+                                                   "e_el",
+                                                   "w_pl",
                                                    "tensile_fail_curr",
                                                    "shear_fail_curr",
                                                    "tensile_fail",
@@ -566,6 +572,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       REQUIRE(updated_stress(3) == Approx(0.).epsilon(Tolerance));
       REQUIRE(updated_stress(4) == Approx(0.).epsilon(Tolerance));
       REQUIRE(updated_stress(5) == Approx(0.).epsilon(Tolerance));
+      // Check whether failure flag state variables (after being computed in compute_stress) are correct
+      REQUIRE(state_variables.at("shear_fail") == 1);
+      REQUIRE(state_variables.at("shear_fail_curr") == 1);
+      REQUIRE(state_variables.at("tensile_fail") == 0);
+      REQUIRE(state_variables.at("tensile_fail_curr") == 0);
     }
   }
 }
@@ -2866,6 +2877,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       // Check plastic strain
       REQUIRE(state_variables.at("pdstrain") ==
               Approx(0.0007751567).epsilon(Tolerance));
+      // In the present workflow, all failure flags remain at 0 ?...
+      // Check plastic work and elastic energy
+      REQUIRE(state_variables.at("e_el") == Approx(15.33614017380).epsilon(Tolerance));
+      REQUIRE(state_variables.at("w_pl") == Approx(4.5135130001).epsilon(Tolerance));
     }
 
     //! Check for shear failure (pdstrain >  pdstrain_residual)
@@ -3373,6 +3388,14 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       // Check plastic strain
       REQUIRE(state_variables.at("pdstrain") ==
               Approx(0.0002112522).epsilon(Tolerance));
+      // Check failure flags
+      REQUIRE(state_variables.at("shear_fail") == 1);
+      REQUIRE(state_variables.at("shear_fail_curr") == 1);
+      REQUIRE(state_variables.at("tensile_fail") == 0);
+      REQUIRE(state_variables.at("tensile_fail_curr") == 0);
+      // Check plastic work and elastic energy
+      REQUIRE(state_variables.at("e_el") == Approx(1.153960429).epsilon(Tolerance));
+      REQUIRE(state_variables.at("w_pl") == Approx(1.0964114497).epsilon(Tolerance));
     }
 
     //! Check for shear failure (pdstrain >  pdstrain_residual)

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -118,7 +118,8 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
 
       const std::vector<std::string> state_vars = {
-          "phi", "psi", "cohesion", "epsilon", "rho", "theta", "pdstrain"};
+          "phi", "psi", "cohesion", "epsilon", "rho", "theta", "pdstrain", "E_el",
+          "W_pl", "tensile_fail_curr", "shear_fail_curr", "tensile_fail", "shear_fail"};
       auto state_vars_test = material->state_variables();
       REQUIRE(state_vars == state_vars_test);
     }

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -572,7 +572,8 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       REQUIRE(updated_stress(3) == Approx(0.).epsilon(Tolerance));
       REQUIRE(updated_stress(4) == Approx(0.).epsilon(Tolerance));
       REQUIRE(updated_stress(5) == Approx(0.).epsilon(Tolerance));
-      // Check whether failure flag state variables (after being computed in compute_stress) are correct
+      // Check whether failure flag state variables (after being computed in
+      // compute_stress) are correct
       REQUIRE(state_variables.at("shear_fail") == 1);
       REQUIRE(state_variables.at("shear_fail_curr") == 1);
       REQUIRE(state_variables.at("tensile_fail") == 0);
@@ -2879,8 +2880,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.0007751567).epsilon(Tolerance));
       // In the present workflow, all failure flags remain at 0 ?...
       // Check plastic work and elastic energy
-      REQUIRE(state_variables.at("e_el") == Approx(15.33614017380).epsilon(Tolerance));
-      REQUIRE(state_variables.at("w_pl") == Approx(4.5135130001).epsilon(Tolerance));
+      REQUIRE(state_variables.at("e_el") ==
+              Approx(15.33614017380).epsilon(Tolerance));
+      REQUIRE(state_variables.at("w_pl") ==
+              Approx(4.5135130001).epsilon(Tolerance));
     }
 
     //! Check for shear failure (pdstrain >  pdstrain_residual)
@@ -3394,8 +3397,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       REQUIRE(state_variables.at("tensile_fail") == 0);
       REQUIRE(state_variables.at("tensile_fail_curr") == 0);
       // Check plastic work and elastic energy
-      REQUIRE(state_variables.at("e_el") == Approx(1.153960429).epsilon(Tolerance));
-      REQUIRE(state_variables.at("w_pl") == Approx(1.0964114497).epsilon(Tolerance));
+      REQUIRE(state_variables.at("e_el") ==
+              Approx(1.153960429).epsilon(Tolerance));
+      REQUIRE(state_variables.at("w_pl") ==
+              Approx(1.0964114497).epsilon(Tolerance));
     }
 
     //! Check for shear failure (pdstrain >  pdstrain_residual)


### PR DESCRIPTION
**Description**
This PR includes new state variables for the Mohr-Coulomb material:

- 4 (binary) flags specifying the type of failure (if any). It can now be distinguished whether the material is currently (or has ever) failed in shear and/or tension

- stored elastic energy. Note that it is denoted `E_el`, should it be rather `eEl` ?

- cumulated plastic work, i.e. dissipation, given as a positive number. (well, let's not argue here whether this really is a state variable from a theoretical perspective ;-) ). Which is currently `W_pl` (should it be rather `wPl` ?)

**Additional context**
- I was about to modify mpm-doc as well to document this change, but have not yet fully decided about the most appropriate place to do so. Probably in source corresponding to https://mpm.cb-geo.com/#/theory/material/mohr-coulomb, in a new (final) section "Output state variables" ?

- This code comes from @SchDvr work during [his PhD thesis](https://theses.hal.science/tel-04101270). There is quite a number of other updates that could be proposed to be applied following his work, but this should probably be further discussed elsewhere.
